### PR TITLE
Adding in missing scroll-snap properties

### DIFF
--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -175,6 +175,8 @@ contexts:
           | blend-mode|azimuth|pause-after|pause-before|pause|pitch-range|pitch
           | text-height|system|negative|prefix|suffix|range|pad|fallback
           | additive-symbols|symbols|speak-as|speak|grid-gap
+          | scroll-snap-type|scroll-snap-stop|scroll-padding|scroll-padding-top|scroll-padding-right|scroll-padding-bottom|scroll-padding-left|scroll-padding-inline|scroll-padding-inline-start|scroll-padding-inline-end|scroll-padding-block|scroll-padding-block-start|scroll-padding-block-end
+          | scroll-snap-align|scroll-margin|scroll-margin-top|scroll-margin-right|scroll-margin-bottom|scroll-margin-left|scroll-margin-inline|scroll-margin-inline-start|scroll-margin-inline-end|scroll-margin-block|scroll-margin-block-start|scroll-margin-block-end
         )\b(?=\s*:)
       scope: meta.property-name.css support.type.property-name.css
       push:

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -155,6 +155,8 @@ variables:
       | blend-mode|azimuth|pause-after|pause-before|pause|pitch-range|pitch
       | text-height|system|negative|prefix|suffix|range|pad|fallback
       | additive-symbols|symbols|speak-as|speak|grid-gap
+      | scroll-snap-type|scroll-snap-stop|scroll-padding|scroll-padding-top|scroll-padding-right|scroll-padding-bottom|scroll-padding-left|scroll-padding-inline|scroll-padding-inline-start|scroll-padding-inline-end|scroll-padding-block|scroll-padding-block-start|scroll-padding-block-end
+      | scroll-snap-align|scroll-margin|scroll-margin-top|scroll-margin-right|scroll-margin-bottom|scroll-margin-left|scroll-margin-inline|scroll-margin-inline-start|scroll-margin-inline-end|scroll-margin-block|scroll-margin-block-start|scroll-margin-block-end
     )\b
 
 


### PR DESCRIPTION
Properties list taken from:
https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Scroll_Snap

Fixes issues with scroll-snap properties not having the correct scope applied to them.