### PR TITLE
Add support for debugger scope

### DIFF
--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -285,7 +285,7 @@ contexts:
           pop: true
         - include: Sass.sublime-syntax#sass-script-expression
     - match: '(@)(debug|warn|error)\b'
-      scope: keyword.control.at-rule.sass
+      scope: keyword.control.at-rule.debugger.sass
       captures:
         1: punctuation.definition.keyword.sass
       push:

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -284,7 +284,17 @@ contexts:
         - match: '(?={)'
           pop: true
         - include: Sass.sublime-syntax#sass-script-expression
-    - match: '(@)(debug|warn|error)\b'
+    - match: '(@)(warn|error)\b'
+      scope: keyword.control.at-rule.warn.sass
+      captures:
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - match: '(;)'
+          scope: punctuation.terminator.rule.sass
+          pop: true
+        - include: Sass.sublime-syntax#sass-script-expression
+    - match: '(@)(debug)\b'
       scope: keyword.control.at-rule.debugger.sass
       captures:
         1: punctuation.definition.keyword.sass

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -699,7 +699,7 @@ contexts:
           pop: true
         - include: sass-script-expression
     - match: '(@)(debug|warn|error)\b'
-      scope: keyword.control.at-rule.sass
+      scope: keyword.control.at-rule.debugger.sass
       captures:
         1: punctuation.definition.keyword.sass
       push:

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -698,7 +698,16 @@ contexts:
         - match: '(?=$)'
           pop: true
         - include: sass-script-expression
-    - match: '(@)(debug|warn|error)\b'
+    - match: '(@)(warn|error)\b'
+      scope: keyword.control.at-rule.warn.sass
+      captures:
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - match: '(?=$)'
+          pop: true
+        - include: sass-script-expression
+    - match: '(@)(debug)\b'
       scope: keyword.control.at-rule.debugger.sass
       captures:
         1: punctuation.definition.keyword.sass


### PR DESCRIPTION
This will make it possible to style `@warn`, `@debug` and `@error` differently (similar to `debugger` in JavaScript).