### PR TITLE
Match css rewrite

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,9 +11,9 @@ jobs:
       - name: Install OpenGL
         run: sudo apt-get -y install libgl1-mesa-glx libglu1-mesa
       - name: Download syntax_tests
-        run: wget --content-disposition https://download.sublimetext.com/st_syntax_tests_build_4073_x64.tar.bz2
+        run: wget --content-disposition https://download.sublimetext.com/st_syntax_tests_build_4121_x64.tar.xz
       - name: Extract syntax_tests
-        run: tar xf "$(ls st_syntax_tests_build_*_x64.tar.bz2)"
+        run: tar xf "$(ls st_syntax_tests_build_*_x64.tar.xz)"
       - name: Move syntax_tests
         run: mv st_syntax_tests/syntax_tests ./
       - name: Cleanup syntax_tests dir

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install OpenGL
         run: sudo apt-get -y install libgl1-mesa-glx libglu1-mesa
       - name: Download syntax_tests
-        run: wget --content-disposition https://download.sublimetext.com/st_syntax_tests_build_4073_x64.tar.bz2
+        run: wget --content-disposition https://download.sublimetext.com/st_syntax_tests_build_4094_x64.tar.bz2
       - name: Extract syntax_tests
         run: tar xf "$(ls st_syntax_tests_build_*_x64.tar.bz2)"
       - name: Move syntax_tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Move root dirs into "Data/Packages/" subdir'
         run: |
           mkdir -p Data/Packages/Sass/
-          find . -maxdepth 1 -mindepth 1 -type d -not -name 'Data' -exec mv '{}' Data/Packages/Sass/ ';'
+          find . -maxdepth 1 -mindepth 1 -type d -not -name 'Data' -not -name 'syntax_tests' -exec mv '{}' Data/Packages/Sass/ ';'
 
       - name: Run syntax tests
         run: ./syntax_tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,38 +3,32 @@ name: continuous-integration
 on: [push]
 
 jobs:
-  run_syntax_tests:
-    name: Test on Build ${{ matrix.sublime-build }} (${{ matrix.sublime-channel }})
+  build:
+    name: Run syntax_tests
     runs-on: ubuntu-latest
-    timeout-minutes: 15 # default is 6 hours!
-    continue-on-error: ${{ matrix.optional }}
-    strategy:
-      max-parallel: 2
-      fail-fast: false
-      matrix:
-        include:
-          - sublime-channel: stable
-            sublime-build: 4121
-            optional: true
-          - sublime-channel: dev
-            sublime-build: 4122
-            optional: false
     steps:
-
-      - name: Git checkout
-        uses: actions/checkout@master
-
-      - name: Get binary for Build ${{ matrix.sublime-build }} (${{ matrix.sublime-channel }})
-        run: |
-          wget -O st_syntax_tests.tar.xz https://download.sublimetext.com/st_syntax_tests_build_${{ matrix.sublime-build }}_x64.tar.xz
-          tar xf st_syntax_tests.tar.xz
-          mv st_syntax_tests/* ./
-          rm -R st_syntax_tests st_syntax_tests.tar.xz
-
-      - name: 'Move root dirs into "Data/Packages/" subdir'
-        run: |
-          mkdir -p Data/Packages/Sass/
-          find . -maxdepth 1 -mindepth 1 -type d -not -name 'Data' -not -name 'syntax_tests' -exec mv '{}' Data/Packages/Sass/ ';'
-
+      - uses: actions/checkout@master
+      - name: Install OpenGL
+        run: sudo apt-get -y install libgl1-mesa-glx libglu1-mesa
+      - name: Download syntax_tests
+        run: wget --content-disposition https://download.sublimetext.com/st_syntax_tests_build_4073_x64.tar.bz2
+      - name: Extract syntax_tests
+        run: tar xf "$(ls st_syntax_tests_build_*_x64.tar.bz2)"
+      - name: Move syntax_tests
+        run: mv st_syntax_tests/syntax_tests ./
+      - name: Cleanup syntax_tests dir
+        run: rm -R st_syntax_tests*
+      - name: Cleanup git dir
+        run: rm -R .git*
+      - name: Setup 'Data/Packages/Sass'
+        run: mkdir -p 'Data/Packages/Sass'
+      - name: Move package into its own subdir within Data dir
+        run: >-
+          find .
+          -maxdepth 1
+          -mindepth 1
+          -not -name 'Data'
+          -not -name 'syntax_tests'
+          -exec mv -v '{}' 'Data/Packages/Sass/' \;
       - name: Run syntax tests
         run: ./syntax_tests

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,32 +3,38 @@ name: continuous-integration
 on: [push]
 
 jobs:
-  build:
-    name: Run syntax_tests
+  run_syntax_tests:
+    name: Test on Build ${{ matrix.sublime-build }} (${{ matrix.sublime-channel }})
     runs-on: ubuntu-latest
+    timeout-minutes: 15 # default is 6 hours!
+    continue-on-error: ${{ matrix.optional }}
+    strategy:
+      max-parallel: 2
+      fail-fast: false
+      matrix:
+        include:
+          - sublime-channel: stable
+            sublime-build: 4121
+            optional: true
+          - sublime-channel: dev
+            sublime-build: 4122
+            optional: false
     steps:
-      - uses: actions/checkout@master
-      - name: Install OpenGL
-        run: sudo apt-get -y install libgl1-mesa-glx libglu1-mesa
-      - name: Download syntax_tests
-        run: wget --content-disposition https://download.sublimetext.com/st_syntax_tests_build_4094_x64.tar.bz2
-      - name: Extract syntax_tests
-        run: tar xf "$(ls st_syntax_tests_build_*_x64.tar.bz2)"
-      - name: Move syntax_tests
-        run: mv st_syntax_tests/syntax_tests ./
-      - name: Cleanup syntax_tests dir
-        run: rm -R st_syntax_tests*
-      - name: Cleanup git dir
-        run: rm -R .git*
-      - name: Setup 'Data/Packages/Sass'
-        run: mkdir -p 'Data/Packages/Sass'
-      - name: Move package into its own subdir within Data dir
-        run: >-
-          find .
-          -maxdepth 1
-          -mindepth 1
-          -not -name 'Data'
-          -not -name 'syntax_tests'
-          -exec mv -v '{}' 'Data/Packages/Sass/' \;
+
+      - name: Git checkout
+        uses: actions/checkout@master
+
+      - name: Get binary for Build ${{ matrix.sublime-build }} (${{ matrix.sublime-channel }})
+        run: |
+          wget -O st_syntax_tests.tar.xz https://download.sublimetext.com/st_syntax_tests_build_${{ matrix.sublime-build }}_x64.tar.xz
+          tar xf st_syntax_tests.tar.xz
+          mv st_syntax_tests/* ./
+          rm -R st_syntax_tests st_syntax_tests.tar.xz
+
+      - name: 'Move root dirs into "Data/Packages/" subdir'
+        run: |
+          mkdir -p Data/Packages/Sass/
+          find . -maxdepth 1 -mindepth 1 -type d -not -name 'Data' -exec mv '{}' Data/Packages/Sass/ ';'
+
       - name: Run syntax tests
         run: ./syntax_tests

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1084,8 +1084,6 @@ contexts:
     - include: at-page-property-names
     - include: property-values
     - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
 
   at-page-property-names:
     - match: '{{page_property_names}}'

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1642,18 +1642,19 @@ contexts:
     # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
     - match: '[a-zA-Z0-9_-]*(?=#{)'
       captures:
-        0: support.type.property-name
+        0: meta.property-name.css support.type.property-name.css
       push:
         - meta_scope: meta.property-name.css
         - include: sass-interpolation
         - match: '[a-zA-Z0-9_-]*'
           captures:
-            0: support.type.property-name
+            0: meta.property-name.css support.type.property-name.css
         - include: push-to-value
         - include: terminator-pop
         - match: '\s*(?=$)'
           pop: 1
     - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
+      scope: meta.property-name.css
       push: property-identifier-content
     - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
       scope: meta.property-name.css support.type.property-name.css
@@ -1664,6 +1665,7 @@ contexts:
           pop: 1
 
   property-identifier-content:
+    - meta_scope: meta.property-name.css
     - include: comments
     - include: vendor-prefixes
     # specific properties with special treatment

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1582,7 +1582,17 @@ contexts:
 
   # Highly modified from CSS because there is no strict separation
   # between selectors and properties in Sass,
-  # ie. there is no 'property list'
+  property-lists:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: property-list-content
+
+  property-list-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - match: \}
+      scope: punctuation.section.block.end.css
+      pop: 1
+    - include: rule-list-body
 
   rule-list-body:
     # Note: This context is used by HTML.sublime-syntax
@@ -3243,7 +3253,5 @@ contexts:
       pop: 1
 
   terminator-pop:
-    - match: '\s*(?=$)'
-      pop: 1
-    - match: (?=[;){}]|$)
+    - match: (?=[;){}])
       pop: 1

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -2783,6 +2783,7 @@ contexts:
       push: maybe-illegal-operator
     - match: '[-+*/]'
       scope: keyword.operator.arithmetic.css
+    - include: sass-value-expression
 
   toggle-functions:
     # toggle()

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -669,9 +669,10 @@ contexts:
         0: variable.declaration.sass
         1: punctuation.definition.variable.sass
       push:
+        - include: comments
         - include: push-to-value
-        - match: '\s*(?=$)'
-          pop: 1
+        - include: terminator-pop
+        - include: immediately-pop
 
     # Sass content at-rule
     - match: '((@)content){{break}}'
@@ -680,16 +681,14 @@ contexts:
         2: punctuation.definition.keyword.sass
       push:
         - include: terminator-pop
-        - match: '\s*(?=$)'
-          pop: 1
+        - include: immediately-pop
 
     # CSS modules
     - match: '\b(composes)\b'
       scope: meta.property-name.css-modules.css support.type.property-name
       push:
         - include: push-to-value
-        - match: '\s*(?=$)'
-          pop: 1
+        - include: terminator-pop
     - match: '\s*(:)(import|export)'
       scope: meta.selector.css entity.other.pseudo-class.css-modules.css
       captures:
@@ -712,29 +711,26 @@ contexts:
             - match: '\}'
               scope: punctuation.section.block.end.css
               pop: 1
-            - include: Sass.sublime-syntax#comments
+            - include: comments
             - match: '([a-zA-Z0-9_-]+)\s*(:)'
               captures:
                 1: meta.property-name.css-modules.css support.type.property-name.css-modules.css
                 2: punctuation.separator.key-value.css
                 3: variable.other.css-modules.css
               push:
-                - match: '(;|\s*(?=$))'
-                  captures:
-                    1: punctuation.terminator.rule.css
-                  pop: 1
-                - include: Sass.sublime-syntax#quoted-strings
+                - include: terminator-pop
+                - include: quoted-strings
                 - match: '\b[^\s''"]+\b'
                   scope: string.unquoted.css
         - match: ''
           pop: 1
 
     - include: comments
-    - include: Sass.sublime-syntax#sass-mixins
+    - include: sass-mixins
     - include: selectors
     - include: at-rules
     - include: rule-list-body
-    - include: Sass.sublime-syntax#sass-interpolated-selectors
+    - include: sass-interpolated-selectors
     - match: \{
       scope: punctuation.section.block.begin.css
     - match: \}
@@ -778,7 +774,7 @@ contexts:
 ###[ AT RULES ]################################################################
 
   at-rules:
-    - include: Sass.sublime-syntax#sass-at-rules
+    - include: sass-at-rules
     - include: at-charset
     - include: at-counter-style
     - include: at-custom-media
@@ -949,7 +945,7 @@ contexts:
     - include: at-rule-end
 
   at-keyframe-names:
-    - include: Sass.sublime-syntax#sass-interpolation
+    - include: sass-interpolation
     - match: '{{illegal_custom_ident}}'
       scope: invalid.illegal.identifier.css
     - match: '{{ident}}'
@@ -1184,7 +1180,7 @@ contexts:
     - include: media-query-conditions
     - include: media-query-property-names
     - include: media-query-property-values
-    - include: Sass.sublime-syntax#sass-value-expression
+    - include: sass-value-expression
     - include: var-functions
     - include: calc-functions
     - include: scalar-rational-constants
@@ -1268,7 +1264,7 @@ contexts:
   # or a property
 
   selectors:
-    - include: Sass.sublime-syntax#sass-interpolated-selectors
+    - include: sass-interpolated-selectors
     - match: (?=\s*{{svg_tags}})
       push:
         - meta_scope: meta.selector.css
@@ -1311,7 +1307,7 @@ contexts:
       scope: punctuation.definition.entity.css
       push:
         - meta_scope: entity.other.attribute-name.class.css
-        - include: Sass.sublime-syntax#sass-interpolation
+        - include: sass-interpolation
         - match: '{{generic_ident}}'
           pop: 1
         - include: immediately-pop
@@ -1320,7 +1316,7 @@ contexts:
       scope: punctuation.definition.entity.css
       push:
         - meta_scope: entity.other.attribute-name.id.css
-        - include: Sass.sublime-syntax#sass-interpolation
+        - include: sass-interpolation
         - match: '{{generic_ident}}'
           pop: 1
         - include: immediately-pop
@@ -1329,7 +1325,7 @@ contexts:
       scope: punctuation.definition.entity.sass
       push:
         - meta_scope: entity.other.attribute-name.placeholder.sass
-        - include: Sass.sublime-syntax#sass-interpolation
+        - include: sass-interpolation
         - match: '{{generic_ident}}'
           pop: 1
         - include: immediately-pop
@@ -1371,8 +1367,8 @@ contexts:
     - meta_scope: meta.selector.css
     - include: selector-end
     - include: comma-delimiters
-    - include: Sass.sublime-syntax#sass-ampersand
-    - include: Sass.sublime-syntax#sass-interpolated-selectors
+    - include: sass-ampersand
+    - include: sass-interpolated-selectors
 
     # Html Tags
     - match: '{{html_tags}}'
@@ -1644,11 +1640,12 @@ contexts:
         0: support.type.property-name
       push:
         - meta_scope: meta.property-name.css
-        - include: Sass.sublime-syntax#sass-interpolation
+        - include: sass-interpolation
         - match: '[a-zA-Z0-9_-]*'
           captures:
             0: support.type.property-name
         - include: push-to-value
+        - include: terminator-pop
         - match: '\s*(?=$)'
           pop: 1
     - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
@@ -1657,6 +1654,7 @@ contexts:
       scope: meta.property-name.css support.type.property-name.css
       push:
         - include: push-to-value
+        - include: terminator-pop
         - match: '\s*(?=$)'
           pop: 1
 
@@ -1672,8 +1670,7 @@ contexts:
     - include: custom-property
 
     - include: push-to-value
-    - match: '\s*(?=$|;)'
-      pop: 1
+    - include: immediately-pop
 
   builtin-property:
     - match: '{{property_names}}'
@@ -1706,7 +1703,7 @@ contexts:
     - include: builtin-values
     - include: other-functions
     - include: other-constants
-    - include: Sass.sublime-syntax#sass-value-expression
+    - include: sass-value-expression
 
   builtin-values:
     - include: quoted-strings
@@ -1718,7 +1715,7 @@ contexts:
     - include: common-constants
     - include: generic-font-names
     - include: vendor-prefixes
-    - include: Sass.sublime-syntax#sass-value-expression
+    - include: sass-value-expression
 
   # When including `color-values` and `color-adjuster-functions`, make sure it is
   # included after the color adjustors to prevent `color-values` from consuming
@@ -1908,7 +1905,7 @@ contexts:
     - include: terminator-pop
     - include: comments
     - include: var-functions
-    - include: Sass.sublime-syntax#sass-value-expression
+    - include: sass-value-expression
 
 ###[ BUILTIN AT RULE FUNCTIONS ]###############################################
 
@@ -3150,7 +3147,7 @@ contexts:
       scope: constant.character.escape.newline.css
     - match: \\(?:\h{1,6}|.)
       scope: constant.character.escape.css
-    - include: Sass.sublime-syntax#sass-interpolation
+    - include: sass-interpolation
 
 ###[ URL STRING CONSTANTS ]####################################################
 
@@ -3280,3 +3277,419 @@ contexts:
   terminator-pop:
     - match: (?=[;){}])
       pop: 1
+
+###############################################################################
+###[ Sass ]####################################################################
+###############################################################################
+
+  sass-script-expression:
+    - include: sass-value-expression
+    - include: builtin-values
+    - match: '{{ident}}'
+      scope: constant.other.sass
+
+  sass-value-expression:
+    - include: comments
+    - include: comma-delimiters
+    - include: sass-maps
+    - include: sass-variables
+    - include: sass-functions
+    - include: sass-custom-functions
+    - include: sass-operators
+    - include: sass-interpolation
+    - match: \b(true|false|null)\b
+      scope: constant.language.sass
+
+  sass-maps:
+    - match: '\('
+      captures:
+        0: punctuation.section.group.begin.sass
+      push:
+        - meta_scope: meta.group.css meta.map.arguments.sass
+        - match: '\)'
+          captures:
+            0: punctuation.section.group.end.sass
+          pop: 1
+        - match: '(\$)([a-zA-Z0-9_-][\w-]*)\s*(:)'
+          captures:
+            0: variable.other.sass
+            1: punctuation.definition.variable.sass
+            3: punctuation.separator.key-value.css
+        - match: '({{ident}})\s*(:)'
+          captures:
+            1: variable.parameter.sass
+            2: punctuation.separator.key-value.css
+        - include: property-value-content
+
+  sass-variables:
+    - match: '(({{ident}})(\.))?(\$)([a-zA-Z0-9_-][\w-]*)'
+      scope: variable.other.sass
+      captures:
+        2: entity.name.namespace.sass
+        3: punctuation.separator.namespace.sass
+        4: punctuation.definition.variable.sass
+    - include: sass-interpolation
+
+  sass-functions:
+    - match: '\b(zip|variable-exists|unquote|unitless|unit|unique-id|type-of|transparentize|to-upper-case|to-lower-case|tan|str-slice|str-length|str-insert|str-index|sqrt|spin|softlight|sin|simple-selectors|set-nth|selector-unify|selector-replace|selector-parse|selector-nest|selector-extend|selector-append|screen|scale-color|saturation|saturate|round|rgba|rgb|replace|red|random|quote|pow|pi|percentage|overlay|opacify|nth|negation|multiply|mod|mixin-exists|mix|min|max|map-values|map-remove|map-merge|map-keys|map-has-key|map-get|luma|list-separator|lightness|lighten|length|keywords|join|isnumber|is-superselector|is-bracketed|invert|inspect|index|if|ie-hex-str|hue|hsvvalue|hsvsaturation|hsvhue|hsva|hsv|hsla|hsl|hardlight|greyscale|green|grayscale|global-variable-exists|get-function|function-exists|format|floor|feature-exists|fadeout|fadein|fade|extract|exclusion|escape|e|difference|desaturate|data-uri|darken|cos|convert|contrast|content-exists|complement|comparable|color|change-color|ceil|call|calc|blue|average|atan|asin|argb|append|alpha|adjust-hue|adjust-color|acos|abs)(?=\()'
+      captures:
+        1: support.function.sass
+      push:
+        - meta_scope: meta.function-call.sass
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.sass meta.function-call.arguments.css meta.group.css
+            - match: (\$)([a-zA-Z0-9_-][\w-]*)(?=:)
+              scope: variable.other.sass
+              captures:
+                1: punctuation.definition.variable.sass
+              push:
+                - match: ':'
+                  scope: punctuation.separator.key-value.css
+                - include: property-value-content
+                - match: (?=\()
+                  pop: 1
+            - include: function-arguments-common
+            - include: color-values
+            - include: percentage-constants
+            - include: scalar-constants
+            - include: angle-constants
+            - include: length-constants
+            - include: scalar-integer-constants
+            - include: generic-font-names
+            - include: numeric-constants
+            - match: '{{ident}}'
+              scope: constant.other.sass
+
+  sass-custom-functions:
+    - match: '\b(?!var)(({{ident}})(\.))?([a-z_-]+)(?=\()'
+      scope: support.function.custom.sass
+      captures:
+        2: entity.name.namespace.sass
+        3: punctuation.separator.namespace.sass
+      push:
+        - meta_scope: meta.function-call.sass
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.sass meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: color-values
+            - include: percentage-constants
+            - include: scalar-constants
+            - include: angle-constants
+            - include: length-constants
+            - include: scalar-integer-constants
+            - include: generic-font-names
+            - include: numeric-constants
+            - match: '{{ident}}'
+              scope: constant.other.sass
+
+  sass-interpolation:
+    - match: '(#)({)'
+      captures:
+        1: punctuation.definition.variable.sass
+        2: punctuation.section.group.begin.sass
+      push:
+        - meta_scope: meta.group.interpolation.sass
+        - match: '(})'
+          scope: punctuation.section.group.end.sass
+          pop: 1
+        - include: sass-script-expression
+
+  sass-operators:
+    - match: /|\*|\-\-|\-|\+\+|\+|~
+      scope: keyword.operator.arithmetic.sass
+    - match: $|%|~|===|==|=|!=|!==|<=|>=|<<=|>>=|>>>=|<>|<|>|!|&&|\|\||\?\:|%=|\+=|\-=|&=|\bnot\b|\bor\b|\band\b|\bwhen\b
+      scope: keyword.operator.sass
+    - match: (?:\s*)\b(not|or|and|when|from|to|through|in)(?=\s)
+      captures:
+        1: keyword.operator.sass
+
+  sass-mixins:
+    - match: '\s*((\=)([\w-]+))'
+      captures:
+        2: keyword.control.directive.sass
+        3: entity.name.function.sass
+      push:
+        - meta_scope: meta.function.declaration.sass
+        - include: terminator-pop
+        - match: '\('
+          scope: punctuation.section.group.begin.sass
+          push:
+            - meta_scope: meta.function.parameters.sass
+            - match: '\)'
+              scope: punctuation.section.group.end.sass
+              pop: 1
+            - include: comma-delimiters
+            - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
+              scope: variable.parameter.sass
+              captures:
+                1: punctuation.definition.variable.sass
+              push:
+                - match: '(?=[,\)])'
+                  pop: 1
+                - match: ':'
+                  scope: punctuation.separator.key-value.css
+                - include: property-value-content
+    - match: '\s*((\+)([\w-]+))'
+      captures:
+        2: keyword.control.directive.sass
+        3: variable.function.sass
+      push:
+        - meta_scope: meta.function-call.sass
+        - include: terminator-pop
+        - match: '\('
+          scope: punctuation.section.group.begin.sass
+          push:
+            - meta_scope: meta.function-call.arguments.sass
+            - match: '\)'
+              scope: punctuation.section.group.end.sass
+              pop: 1
+            - include: sass-value-expression
+            - include: comma-delimiters
+            - include: property-value-content
+            - include: quoted-strings
+            - include: sass-ampersand
+            - include: prefixed-selectors
+            - match: '{{ident}}'
+              scope: constant.other.sass
+
+###[ SASS AMPERSAND ]#########################################
+
+  sass-ampersand:
+    - match: '\s*(&)'
+      captures:
+        1: keyword.operator.ampersand.sass
+      push:
+        # - meta_scope: meta.selector.css
+        - match: '[-_]+'
+          scope: entity.other.attribute-name.css
+
+          push:
+            - match: '{{ident}}'
+              scope: entity.other.attribute-name.css
+            - include: sass-interpolation
+            - include: selectors
+            - include: comments
+            - match: '(?={)'
+              pop: 2
+        - include: selector-content
+
+###[ SASS AT-RULE FUNCTIONS ]#########################################
+
+  sass-at-rules:
+    - match: '(@)(each){{break}}'
+      captures:
+        0: keyword.control.flow.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.each.sass
+        - include: sass-variables
+        - include: comma-delimiters
+        - include: terminator-pop
+        - match: \b(in){{break}}
+          scope: keyword.operator.sass
+          push:
+            - include: terminator-pop
+            - include: comments
+            - include: comma-delimiters
+            - include: var-function
+            - include: sass-value-expression
+    - match: '(@)(for|while){{break}}'
+      captures:
+        0: keyword.control.flow.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - include: terminator-pop
+        - include: sass-script-expression
+    - match: '(@)(if|else if|else){{break}}'
+      captures:
+        0: keyword.control.flow.conditional.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - include: terminator-pop
+        - include: sass-script-expression
+    - match: '(@)(warn|error){{break}}'
+      captures:
+        0: keyword.control.at-rule.warn.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - include: terminator-pop
+        - include: sass-script-expression
+    - match: '(@)(debug){{break}}'
+      captures:
+        0: keyword.control.at-rule.debugger.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - include: terminator-pop
+        - include: sass-script-expression
+    - match: '(@)(at-root){{break}}'
+      captures:
+        0: keyword.control.directive.at-root.sass
+        1: punctuation.definition.keyword.sass
+    - match: '(@)(extend){{break}}'
+      captures:
+        0: keyword.control.directive.extend.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.extend.sass
+        - include: terminator-pop
+        - match: \!\s*(default|global|optional){{break}}
+          scope: keyword.other.sass
+        - include: selectors
+    - match: '((@)(mixin|function))\s+([\w-]+)'
+      captures:
+        1: keyword.control.directive.sass
+        2: punctuation.definition.keyword.sass
+        4: entity.name.function.sass
+      push:
+        - meta_scope: meta.function.declaration.sass
+        - include: terminator-pop
+        - match: '\('
+          scope: punctuation.section.group.begin.sass
+          push:
+            - meta_scope: meta.function.parameters.sass
+            - match: '\)'
+              scope: punctuation.section.group.end.sass
+              pop: 1
+            - include: comma-delimiters
+            - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
+              scope: variable.parameter.sass
+              captures:
+                1: punctuation.definition.variable.sass
+              push:
+                - match: '(?=[,\)])'
+                  pop: 1
+                - match: ':'
+                  scope: punctuation.separator.key-value.css
+                - match: '\b(false|true|null)\b'
+                  scope: constant.language.sass
+                - include: property-value-content
+    - match: '((@)(include))\s+(([a-z]+)(\.))?([\w-]+)'
+      captures:
+        1: keyword.control.directive.sass
+        2: punctuation.definition.keyword.sass
+        5: entity.name.namespace.sass
+        6: punctuation.separator.namespace.sass
+        7: variable.function.sass
+      push:
+        - meta_scope: meta.function-call.sass
+        - include: terminator-pop
+        - match: '\('
+          scope: punctuation.section.group.begin.sass
+          push:
+            - meta_scope: meta.function-call.arguments.sass
+            - match: '\)'
+              scope: punctuation.section.group.end.sass
+              pop: 1
+            - include: comments
+            - include: sass-variables
+            - include: sass-functions
+            - include: sass-operators
+            - include: comma-delimiters
+            - include: property-value-content
+            - include: quoted-strings
+            - include: sass-ampersand
+            - include: prefixed-selectors
+            - match: '{{ident}}'
+              scope: constant.other.sass
+    - match: '(@)(return){{break}}'
+      captures:
+        0: keyword.control.directive.return.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - include: terminator-pop
+        - include: property-value-content
+    - match: '\s*((@)(use|forward){{break}})\s*'
+      captures:
+        1: keyword.control.directive.module.sass
+        2: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.module.sass
+        - include: terminator-pop
+        - match: '\b(as)\b\s+([a-zA-Z0-9_-]*(\*)?)'
+          captures:
+            1: keyword.control.as.sass
+            2: meta.generic-name.sass
+            3: constant.language.import-all.sass
+        - match: '\b(show|hide)\b'
+          scope: keyword.control.show-hide.sass
+          push:
+            - include: terminator-pop
+            - include: comments
+            - include: sass-variables
+            - include: sass-functions
+            - include: sass-operators
+            - include: comma-delimiters
+            - match: '{{ident}}'
+              scope: meta.generic-name.sass
+        - match: '(with)\s+(\()'
+          captures:
+            1: keyword.control.with.sass
+            2: punctuation.section.group.begin.sass
+          push:
+            - match: '\)'
+              scope: punctuation.section.group.end.sass
+              pop: 1
+            - match: ':'
+              scope: punctuation.separator.key-value.css
+            - include: comments
+            - include: sass-variables
+            - include: sass-functions
+            - include: sass-operators
+            - include: comma-delimiters
+            - include: property-value-content
+        - include: comments
+        - include: quoted-strings
+
+###[ SASS INTERPOLATED SELECTORS ]#########################################
+
+  sass-interpolated-selector-body:
+    - match: '({)'
+      scope: punctuation.section.group.begin.sass
+      push:
+        - match: '(})'
+          scope: punctuation.section.group.end.sass
+          pop: 2
+        - include: sass-script-expression
+
+  sass-interpolated-selectors:
+    - match: '\s*(#)(?={.*}{{pseudo_elements}})'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: sass-interpolated-selector-body
+    - match: '\s*(#)(?={.*}:{{regular_pseudo_classes}})'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: sass-interpolated-selector-body
+    - match: '\s*(#)(?={.*}:({{functional_pseudo_classes}})\()'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: sass-interpolated-selector-body
+    - match: '\s*(#)(?={.*}:(-(moz|ms|webkit)-){{ident}})'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: sass-interpolated-selector-body
+    - match: '\s*(#)(?={.*}(?![-:]))'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: sass-interpolated-selector-body

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1665,7 +1665,6 @@ contexts:
           pop: 1
 
   property-identifier-content:
-    - meta_scope: meta.property-name.css
     - include: comments
     - include: vendor-prefixes
     # specific properties with special treatment

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1368,7 +1368,6 @@ contexts:
       scope: keyword.operator.combinator.css
 
   selector-content:
-    - meta_scope: meta.selector.css
     - include: selector-end
     - include: comma-delimiters
     - include: sass-ampersand

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1328,6 +1328,8 @@ contexts:
       push:
         - meta_scope: entity.other.attribute-name.placeholder.sass
         - include: sass-interpolation
+        - match: '[a-z_-]+'
+          scope: entity.name.tag.custom.sass
         - match: '{{generic_ident}}'
           pop: 1
         - include: immediately-pop

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1265,7 +1265,7 @@ contexts:
 
   selectors:
     - include: sass-interpolated-selectors
-    - match: (?=\s*{{svg_tags}})
+    - match: (?=\s*{{svg_tags}}(?!-|\s*:))
       push:
         - meta_scope: meta.selector.css
         - include: selector-content

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -689,6 +689,7 @@ contexts:
       push:
         - include: push-to-value
         - include: terminator-pop
+        - include: immediately-pop
     - match: '\s*(:)(import|export)'
       scope: meta.selector.css entity.other.pseudo-class.css-modules.css
       captures:
@@ -710,8 +711,9 @@ contexts:
             - meta_scope: meta.group.css-modules.css
             - match: '\}'
               scope: punctuation.section.block.end.css
-              pop: 1
+              pop: 2
             - include: comments
+            - include: rule-terminators
             - match: '([a-zA-Z0-9_-]+)\s*(:)'
               captures:
                 1: meta.property-name.css-modules.css support.type.property-name.css-modules.css

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -72,7 +72,8 @@ variables:
 
   # Custom Element Names
   # https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts
-  custom_element_tags: \b[a-z]{{custom_element_chars}}*-{{custom_element_chars}}*{{break}}
+  # adjusted from CSS so it doesn't match on interpolation (#{)
+  custom_element_tags: \b[a-z]{{custom_element_chars}}*-{{custom_element_chars}}*(?!#{){{break}}
   # Note: Excludes `.` as it is used to identify attribute access
   custom_element_chars: |-
     (?x:
@@ -709,9 +710,9 @@ contexts:
     - include: comments
     - include: Sass.sublime-syntax#sass-mixins
     - include: selectors
-    - include: Sass.sublime-syntax#sass-interpolated-selectors
     - include: at-rules
     - include: rule-list-body
+    - include: Sass.sublime-syntax#sass-interpolated-selectors
 
 ###[ COMMENTS ]################################################################
 
@@ -1282,7 +1283,7 @@ contexts:
       scope: variable.language.wildcard.asterisk.css
     # Class and Id Selectors
     # https://drafts.csswg.org/selectors-4/#class-html
-    - match: \.
+    - match: \.(?={{nmchar}})
       scope: punctuation.definition.entity.css
       push:
         - meta_scope: entity.other.attribute-name.class.css
@@ -1291,7 +1292,7 @@ contexts:
           pop: 1
         - include: immediately-pop
     # https://drafts.csswg.org/selectors-4/#id-selectors
-    - match: \#
+    - match: \#(?={{nmchar}})
       scope: punctuation.definition.entity.css
       push:
         - meta_scope: entity.other.attribute-name.id.css
@@ -1300,7 +1301,7 @@ contexts:
           pop: 1
         - include: immediately-pop
     # sass extend-only selectors
-    - match: \%
+    - match: \%(?={{nmchar}})
       scope: punctuation.definition.entity.sass
       push:
         - meta_scope: entity.other.attribute-name.placeholder.sass
@@ -1539,8 +1540,8 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - include: selectors
+            - include: function-arguments-common
 
   # Functional Pseudo Classes with generic arguments
   pseudo-class-function-with-generic-args:
@@ -1600,8 +1601,29 @@ contexts:
 ###[ PROPERTY IDENTIFIERS ]####################################################
 
   property-identifiers:
+    # Sass nested property names
+    # Partial property names, split at "-"
+    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
+    - match: '[a-zA-Z0-9_-]*(?=#{)'
+      captures:
+        0: support.type.property-name
+      push:
+        - meta_scope: meta.property-name.css
+        - include: sass-interpolation
+        - match: '[a-zA-Z0-9_-]*'
+          captures:
+            0: support.type.property-name
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
     - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
       push: property-identifier-content
+    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
+      scope: meta.property-name.css support.type.property-name.css
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
 
   property-identifier-content:
     - meta_scope: meta.property-name.css
@@ -1613,7 +1635,7 @@ contexts:
     # common properties
     - include: builtin-property
     - include: custom-property
-    
+
     - include: push-to-value
     - match: '\s*(?=$|;)'
       pop: true
@@ -1637,28 +1659,6 @@ contexts:
     - match: ':'
       scope: punctuation.separator.key-value.css
       push: property-value-content
-    # Sass nested property names
-    # Partial property names, split at "-"
-    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
-    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - include: push-to-value
-        - match: '\s*(?=$)'
-          pop: true
-    - match: '[a-zA-Z0-9_-]*((#)({)((\$)([a-zA-Z0-9_-][\w-]*))(}))[a-zA-Z0-9_-]*'
-      captures:
-        0: meta.property-name.css support.type.property-name
-        1: meta.group.interpolation.sass
-        2: punctuation.definition.variable.sass
-        3: punctuation.section.group.begin.sass
-        4: variable.other.sass
-        5: punctuation.definition.variable.sass
-        7: punctuation.section.group.end.sass
-      push:
-        - include: push-to-value
-        - match: '\s*(?=$)'
-          pop: true
 
   property-value-content:
     - meta_content_scope: meta.property-value.css
@@ -2263,10 +2263,10 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:auto-fill|auto-fit){{break}}
               scope: keyword.other.grid.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: calc-functions
             - include: minmax-functions
             - include: grid-constants
@@ -2351,12 +2351,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:at|from){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|center|left|right|top){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: angle-constants
             - include: length-constants
@@ -2374,12 +2374,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:to){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|left|right|top){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: angle-constants
             - include: length-constants
@@ -2397,12 +2397,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:at|circle|ellipse){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|center|left|right|top|(closest|farthest)-(corner|side)){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: length-constants
             - include: percentage-constants
@@ -2422,9 +2422,9 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - match: \b(?i:auto){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
             - include: calc-functions
             - include: length-constants
 
@@ -2438,9 +2438,9 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - match: \b(?i:round){{break}}
               scope: keyword.other.shape.css
+            - include: function-arguments-common
             - include: calc-functions
             - include: length-constants
             - include: percentage-constants
@@ -2457,11 +2457,11 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - match: \b(?i:at){{break}}
               scope: keyword.other.shape.css
             - match: \b(?i:top|right|bottom|left|center|closest-side|farthest-side){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
             - include: calc-functions
             - include: length-constants
             - include: percentage-constants
@@ -2476,10 +2476,10 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:nonzero|evenodd){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: calc-functions
             - include: length-constants
             - include: percentage-constants
@@ -2514,11 +2514,11 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
+            - match: \b(?i:end|middle|start){{break}}
+              scope: keyword.other.timing.css
             - include: function-arguments-common
             - include: comma-delimiters
             - include: calc-functions
-            - match: \b(?i:end|middle|start){{break}}
-              scope: keyword.other.timing.css
             - include: scalar-integer-constants
 
 ###[ BUILTIN TRANSFORM FUNCTIONS ]#############################################

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -3297,8 +3297,8 @@ contexts:
     - include: comma-delimiters
     - include: sass-maps
     - include: sass-variables
-    - include: sass-functions
-    - include: sass-custom-functions
+    - include: sass-builtin-functions
+    - include: sass-namespaced-functions
     - include: sass-operators
     - include: sass-interpolation
     - match: \b(true|false|null)\b
@@ -3334,10 +3334,10 @@ contexts:
         4: punctuation.definition.variable.sass
     - include: sass-interpolation
 
-  sass-functions:
+  sass-builtin-functions:
     - match: '\b(zip|variable-exists|unquote|unitless|unit|unique-id|type-of|transparentize|to-upper-case|to-lower-case|tan|str-slice|str-length|str-insert|str-index|sqrt|spin|softlight|sin|simple-selectors|set-nth|selector-unify|selector-replace|selector-parse|selector-nest|selector-extend|selector-append|screen|scale-color|saturation|saturate|round|rgba|rgb|replace|red|random|quote|pow|pi|percentage|overlay|opacify|nth|negation|multiply|mod|mixin-exists|mix|min|max|map-values|map-remove|map-merge|map-keys|map-has-key|map-get|luma|list-separator|lightness|lighten|length|keywords|join|isnumber|is-superselector|is-bracketed|invert|inspect|index|if|ie-hex-str|hue|hsvvalue|hsvsaturation|hsvhue|hsva|hsv|hsla|hsl|hardlight|greyscale|green|grayscale|global-variable-exists|get-function|function-exists|format|floor|feature-exists|fadeout|fadein|fade|extract|exclusion|escape|e|difference|desaturate|data-uri|darken|cos|convert|contrast|content-exists|complement|comparable|color|change-color|ceil|call|calc|blue|average|atan|asin|argb|append|alpha|adjust-hue|adjust-color|acos|abs)(?=\()'
       captures:
-        1: support.function.sass
+        1: support.function.builtin.sass
       push:
         - meta_scope: meta.function-call.sass
         - meta_include_prototype: false
@@ -3367,9 +3367,9 @@ contexts:
             - match: '{{ident}}'
               scope: constant.other.sass
 
-  sass-custom-functions:
+  sass-namespaced-functions:
     - match: '\b(?!var)(({{ident}})(\.))?([a-z_-]+)(?=\()'
-      scope: support.function.custom.sass
+      scope: support.function.sass
       captures:
         2: entity.name.namespace.sass
         3: punctuation.separator.namespace.sass
@@ -3575,13 +3575,13 @@ contexts:
                 - match: '\b(false|true|null)\b'
                   scope: constant.language.sass
                 - include: property-value-content
-    - match: '((@)(include))\s+(([a-z]+)(\.))?([\w-]+)'
+    - match: '((@)(include))\s+((([a-z]+)(\.))?([\w-]+))'
       captures:
         1: keyword.control.directive.sass
         2: punctuation.definition.keyword.sass
-        5: entity.name.namespace.sass
-        6: punctuation.separator.namespace.sass
-        7: variable.function.sass
+        4: variable.function.sass
+        6: entity.name.namespace.sass
+        7: punctuation.separator.namespace.sass
       push:
         - meta_scope: meta.function-call.sass
         - include: terminator-pop
@@ -3594,7 +3594,7 @@ contexts:
               pop: 1
             - include: comments
             - include: sass-variables
-            - include: sass-functions
+            - include: sass-builtin-functions
             - include: sass-operators
             - include: comma-delimiters
             - include: property-value-content
@@ -3629,7 +3629,7 @@ contexts:
             - include: terminator-pop
             - include: comments
             - include: sass-variables
-            - include: sass-functions
+            - include: sass-builtin-functions
             - include: sass-operators
             - include: comma-delimiters
             - match: '{{ident}}'
@@ -3646,7 +3646,7 @@ contexts:
               scope: punctuation.separator.key-value.css
             - include: comments
             - include: sass-variables
-            - include: sass-functions
+            - include: sass-builtin-functions
             - include: sass-operators
             - include: comma-delimiters
             - include: property-value-content

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -3289,7 +3289,6 @@ contexts:
 ###############################################################################
 
   sass-script-expression:
-    - include: sass-value-expression
     - include: builtin-values
     - match: '{{ident}}'
       scope: constant.other.sass
@@ -3303,6 +3302,11 @@ contexts:
     - include: sass-namespaced-functions
     - include: sass-operators
     - include: sass-interpolation
+    - include: color-values
+    - include: unicode-ranges
+    - include: numeric-constants
+    - include: common-constants
+    - include: generic-font-names
     - match: \b(true|false|null)\b
       scope: constant.language.sass
 
@@ -3504,7 +3508,7 @@ contexts:
             - include: comments
             - include: comma-delimiters
             - include: var-function
-            - include: sass-value-expression
+            - include: sass-script-expression
     - match: '(@)(for|while){{break}}'
       captures:
         0: keyword.control.flow.sass

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -671,7 +671,7 @@ contexts:
       push:
         - include: push-to-value
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
 
     # Sass content at-rule
     - match: '((@)content){{break}}'
@@ -680,7 +680,7 @@ contexts:
         2: punctuation.definition.keyword.sass
       push:
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
 
     # CSS modules
     - match: '\b(composes)\b'
@@ -688,7 +688,7 @@ contexts:
       push:
         - include: push-to-value
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
     - match: '\s*(:)(import|export)'
       scope: meta.selector.css entity.other.pseudo-class.css-modules.css
       captures:
@@ -701,11 +701,11 @@ contexts:
             - meta_scope: meta.group.css
             - match: '\)'
               scope: punctuation.section.group.end.css
-              pop: true
+              pop: 1
             - include: quoted-strings
         - match: '\s*(?=$)'
           scope: punctuation.terminator.rule.sass
-          pop: true
+          pop: 1
 
     - include: comments
     - include: Sass.sublime-syntax#sass-mixins
@@ -747,7 +747,7 @@ contexts:
       push:
         - meta_scope: comment.line.double-slash.sass
         - match: \n
-          pop: true
+          pop: 1
 
 ###[ AT RULES ]################################################################
 
@@ -1376,10 +1376,10 @@ contexts:
             - meta_scope: meta.group.css
             - match: '\)'
               scope: punctuation.section.group.end.css
-              pop: true
+              pop: 1
             - include: quoted-strings
         - match: ''
-          pop: true
+          pop: 1
     - match: '\s*(:)(local|global)'
       scope: meta.selector.css entity.other.pseudo-class.css-modules.css
       captures:
@@ -1615,7 +1615,7 @@ contexts:
             0: support.type.property-name
         - include: push-to-value
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
     - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
       push: property-identifier-content
     - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
@@ -1623,7 +1623,7 @@ contexts:
       push:
         - include: push-to-value
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
 
   property-identifier-content:
     - meta_scope: meta.property-name.css
@@ -1638,7 +1638,7 @@ contexts:
 
     - include: push-to-value
     - match: '\s*(?=$|;)'
-      pop: true
+      pop: 1
 
   builtin-property:
     - match: '{{property_names}}'

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1371,6 +1371,8 @@ contexts:
     - include: comma-delimiters
     - include: sass-ampersand
     - include: sass-interpolated-selectors
+    - match: '\!\s*(default|global|optional)\b'
+      scope: keyword.other.sass
 
     # Html Tags
     - match: '{{html_tags}}'
@@ -3544,8 +3546,6 @@ contexts:
       push:
         - meta_scope: meta.at-rule.extend.sass
         - include: terminator-pop
-        - match: \!\s*(default|global|optional){{break}}
-          scope: keyword.other.sass
         - include: selectors
     - match: '((@)(mixin|function))\s+([\w-]+)'
       captures:

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -7,652 +7,682 @@ file_extensions:
 scope: source.scss
 
 variables:
-  unicode: '\\\h{1,6}[ \t\n\f]?'
-  escape: '(?:{{unicode}}|\\[^\n\f\h])'
-  nonascii: '[\p{L}\p{M}\p{S}\p{N}&&[^[:ascii:]]]'
-  nmstart: '(?:[[_a-zA-Z]{{nonascii}}]|{{escape}})'
-  nmchar: '(?:[[-\w]{{nonascii}}]|{{escape}})'
-  ident: '(?:--{{nmchar}}+|-?{{nmstart}}{{nmchar}}*)'
+  # Basic tokens
+  # https://www.w3.org/TR/css3-selectors/#lex
+  unicode: \\\h{1,6}[ \t\n\f]?
+  escape: (?:{{unicode}}|\\[^\n\f\h])
+  nmstart: (?:[_[:alpha:][:^ascii:]]|{{escape}})
+  nmchar: (?:[-_[:alnum:][:^ascii:]]|{{escape}})
+
+  # Identifier Break
+  # The proper pattern would be (?!{{nmchar}}), but its impact on performance
+  # is just too high, thus several optimizations are applied.
+  # 1. Use positive lookahead with \Z to handle `eof`
+  # 2. Breaks are ascii characters other than denoted by {{nmchar}}.
+  # 3. Assume unicode or escape character if backslash is matched, instead of
+  #    matching (?!{{escape}}) which also effects performance negative.
+  break: (?=[[^-_[:alnum:]\\]&&[[:ascii:]]]|\Z)
+
+  # Identifiers
+  # https://www.w3.org/TR/css-syntax-3/#typedef-ident-token
+  # https://www.w3.org/TR/css3-selectors/#lex
+  ident: (?:{{custom_ident}}|{{generic_ident}})
+  custom_ident: (?:--{{nmchar}}*)
+  generic_ident: (?:-?{{nmstart}}{{nmchar}}*)
+
+  # Ilegal Custom Identifier Names
+  # https://www.w3.org/TR/css-values-4/#custom-idents
+  illegal_custom_ident: |-
+    \b{{illegal_custom_ident_tokens}}{{break}}
+  illegal_custom_ident_tokens: |-
+    (?xi: auto | default | inherit | initial | none | unset )
+
+  # Types
+  # https://www.w3.org/TR/css3-values/#numeric-types
+  # https://www.w3.org/TR/css-syntax-3/#number-token-diagram
+  integer: ([-+]?)(\d+)
+  float: ([-+]?)(\d*(\.)\d+(?:[eE][-+]?\d+)?|\d+[eE][-+]?\d+)
+
+  # Units
+  # https://www.w3.org/TR/css3-values/#lengths
+  units: |-
+    (?x:
+      %
+    | {{absolute_lengths}}
+    | {{angle_units}}
+    | {{duration_units}}
+    | {{font_relative_lengths}}
+    | {{frequency_units}}
+    | {{resolution_units}}
+    | {{viewport_percentage_lengths}}
+    )
+  font_relative_lengths: (?i:em|ex|ch|rem)\b
+  viewport_percentage_lengths: (?i:vw|vh|vmin|vmax)\b
+  absolute_lengths: (?i:cm|mm|q|in|pt|pc|px|fr)\b
+  angle_units: (?i:deg|grad|rad|turn)\b
+  duration_units: (?i:s|ms)\b
+  frequency_units: (?i:Hz|kHz)\b
+  resolution_units: (?i:dpi|dpcm|dppx)\b
+
+  # Combinators
+  # https://drafts.csswg.org/selectors-4/#combinators
+  combinators: (?:>{1,3}|[~+]|\|{2})
+
+  vendor_prefix: -(?:webkit|moz|ms|o)-
+
+  # Custom Element Names
+  # https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts
+  custom_element_tags: \b[a-z]{{custom_element_chars}}*-{{custom_element_chars}}*{{break}}
+  # Note: Excludes `.` as it is used to identify attribute access
+  custom_element_chars: |-
+    (?x:
+      [-_a-z0-9\x{00B7}]
+    | [\x{00C0}-\x{00D6}]
+    | [\x{00D8}-\x{00F6}]
+    | [\x{00F8}-\x{02FF}]
+    | [\x{0300}-\x{037D}]
+    | [\x{037F}-\x{1FFF}]
+    | [\x{200C}-\x{200D}]
+    | [\x{203F}-\x{2040}]
+    | [\x{2070}-\x{218F}]
+    | [\x{2C00}-\x{2FEF}]
+    | [\x{3001}-\x{D7FF}]
+    | [\x{F900}-\x{FDCF}]
+    | [\x{FDF0}-\x{FFFD}]
+    | [\x{10000}-\x{EFFFF}]
+    )
+
+  # HTML tags
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+  # Note: Sections are sorted by expected frequency.
+  html_tags:  |-
+    (?x:
+      {{html_inline_tags}}
+    | {{html_text_tags}}
+    | {{html_section_tags}}
+    | {{html_table_tags}}
+    | {{html_embedded_tags}}
+    | {{html_forms_tags}}
+    | {{html_media_tags}}
+    | {{html_interactive_tags}}
+    | {{html_script_tags}}
+    | {{html_web_tags}}
+    | {{html_markup_tags}}
+    | {{html_header_tags}}
+    | {{html_root_tags}}
+    | {{html_deprecated_tags}}
+    )
+
+  html_root_tags: |-
+    \b(?xi: html | body ){{break}}
+
+  html_header_tags: |-
+    \b(?xi: base | head | link | meta | script | style | title ){{break}}
+
+  html_section_tags: |-
+    \b(?xi:
+        address | article | aside | footer | header | h1 | h2 | h3 | h4 | h5 | h6
+      | hgroup | main | nav | section
+    ){{break}}
+
+  html_text_tags: |-
+    \b(?xi:
+        blockquote | cite | dd | dt | dl | div | figcaption | figure | hr | li
+      | ol | p | pre | ul
+    ){{break}}
+
+  html_inline_tags: |-
+    \b(?xi:
+        a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i | kbd
+      | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span | strong
+      | sub | sup | u | var | wbr
+    ){{break}}
+
+  html_media_tags: |-
+    \b(?xi: area | audio | source | img | map | track | video ){{break}}
+
+  html_embedded_tags: |-
+    \b(?xi: embed | iframe | object | param | picture | source ){{break}}
+
+  html_script_tags: |-
+    \b(?xi: canvas | noscript | script ){{break}}
+
+  html_markup_tags: |-
+    \b(?xi: del | ins ){{break}}
+
+  html_table_tags: |-
+    \b(?xi:
+        caption | col | colgroup | table | tbody | tr | td | tfoot | th | thead
+    ){{break}}
+
+  html_forms_tags: |-
+    \b(?xi:
+        button | datalist | option | fieldset | label | form | input | legend
+      | meter | optgroup | select | output | progress | textarea
+    ){{break}}
+
+  html_interactive_tags: |-
+    \b(?xi: details | dialog | menu | summary ){{break}}
+
+  html_web_tags: |-
+    \b(?xi: slot | template ){{break}}
+
+  # removed the content tag because it's also a property and that mucks up the logic
+  html_deprecated_tags: |-
+    \b(?xi:
+        acronym | applet | basefont | bgsound | big | blink | center | command
+      | dir | element | font | frame | frameset | image | isindex
+      | keygen | listing | marquee | menuitem | multicol | nextid | nobr
+      | noembed | noframes | plaintext | shadow | spacer | strike | tt | xmp
+    ){{break}}
+
+  # SVG tag names
+  # maintained from previous CSS.sublime-syntax
+  svg_tags: |-
+    \b(?xi:
+        circle | clipPath | defs | ellipse | eventsource | filter | foreignObject
+      | g | glyph | glyphRef | line | linearGradient | marker | mask | path
+      | pattern | polygon | polyline | radialGradient | rect | stop | svg
+      | switch | symbol | text | textPath | tref | tspan | use
+      # custom element like tags reserved for SVG/MathML
+      | annotation-xml | color-profile | missing-glyph
+      | font-face(?: -src | -uri | -format | -name )?
+    ){{break}}
+
+  # Predefined Color Values (Standard Set)
+  # https://www.w3.org/TR/CSS22/syndata.html#color-units
+  standard_colors: |-
+    \b(?xi:
+        aqua | black | blue | fuchsia | gray | green | lime | maroon | navy
+      | olive | orange | purple | red | silver | teal | white | yellow
+    ){{break}}
+
+  # Predefined Color Values (Extended Set)
+  # https://www.w3.org/TR/css3-color/#svg-color
+  extended_colors: |-
+    \b(?xi:
+        aliceblue | antiquewhite | aquamarine | azure | beige | bisque
+      | blanchedalmond | blueviolet | brown | burlywood | cadetblue | chartreuse
+      | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue
+      | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki
+      | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred
+      | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey
+      | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey
+      | dodgerblue | firebrick | floralwhite | forestgreen | gainsboro
+      | ghostwhite | gold | goldenrod | greenyellow | grey | honeydew | hotpink
+      | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen
+      | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow
+      | lightgray | lightgreen | lightgrey | lightpink | lightsalmon
+      | lightseagreen | lightskyblue | lightslategray | lightslategrey
+      | lightsteelblue | lightyellow | limegreen | linen | magenta
+      | mediumaquamarine | mediumblue | mediumorchid | mediumpurple
+      | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise
+      | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin
+      | navajowhite | oldlace | olivedrab | orangered | orchid | palegoldenrod
+      | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru
+      | pink | plum | powderblue | rebeccapurple | rosybrown | royalblue
+      | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna
+      | skyblue | slateblue | slategray | slategrey | snow | springgreen
+      | steelblue | tan | thistle | tomato | turquoise | violet | wheat
+      | whitesmoke | yellowgreen
+    ){{break}}
+
+
+  # Illegal Counter Style Definition Names
+  # https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style-name
+  counter_style_illegal_names: |-
+    \b(?xi: decimal | disc | {{illegal_custom_ident_tokens}} ){{break}}
+
+  # Predefined Counter Styles
+  # https://drafts.csswg.org/css-counter-styles-3/#predefined-counters
+  counter_style_names: |-
+    \b(?xi:
+        none | arabic-indic | armenian | bengali | cambodian | circle
+      | cjk-decimal | cjk-earthly-branch | cjk-heavenly-stem | decimal-leading-zero
+      | decimal | devanagari | disclosure-closed | disclosure-open | disc
+      | ethiopic-numeric | georgian | gujarati | gurmukhi | hebrew
+      | hiragana-iroha | hiragana | japanese-formal | japanese-informal
+      | kannada | katakana-iroha | katakana | khmer
+      | korean-hangul-formal | korean-hanja-formal | korean-hanja-informal | lao
+      | lower-alpha | lower-armenian | lower-greek | lower-latin | lower-roman
+      | malayalam | mongolian | myanmar | oriya | persian
+      | simp-chinese-formal | simp-chinese-informal
+      | square | tamil | telugu | thai | tibetan
+      | trad-chinese-formal | trad-chinese-informal
+      | upper-alpha | upper-armenian | upper-latin | upper-roman
+    ){{break}}
+
+  # @counter-style Property Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@counter-style
+  counter_style_property_names: |-
+    \b(?xi:
+      additive-symbols | negative | pad | prefix | range
+    | suffix | symbols (?# | fallback | speak-as | system )
+    ){{break}}
+
+  # Predefined Counter Speak As Property Constants
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-speak-as
+  counter_speak_as_constants: |-
+    \b(?xi: auto | bullets | numbers | words | spell-out ){{break}}
+
+  # Predefined Counter Style System Constants
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-system
+  counter_system_constants: |-
+    \b(?xi: cyclic | numeric | alphabetic | symbolic | additive | fixed ){{break}}
+
+  # @font-face Property Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face
+  font_face_property_names: |-
+    \b(?xi:
+      ascent-override | descent-override | font-display | (?# font-family | ) src
+    | font-feature-settings | font-variation-settings | font-stretch | font-style
+    | font-weight | font-variant | line-gap-override | size-adjust | unicode-range
+    ){{break}}
+
+  # Page Margin Property Names
+  # https://www.w3.org/TR/css-page-3/#margin-at-rule
+  page_margin_property_names: |-
+    \b(?xi:
+        (?: bottom | top ) - (?: left-corner | left | center | right | right-corner )
+      | (?: left | right ) - (?: top | middle | bottom )
+    ){{break}}
+
+  # Property names are sorted by popularity in descending order.
+  # Note:
+  # 1) Popularity data taken from https://www.chromestatus.com/metrics/css/popularity
+  # 2) Properties starting with `alias-` or `webkit-` are removed
+  property_names: |-
+    \b(?xi:
+      width | height | display | position | padding | border | margin | top
+    | left | margin-top | color | font-size | background-color | text-align
+    | opacity | font-weight | font-family | background | overflow | line-height
+    | float | box-sizing | text-decoration | z-index | cursor | margin-left
+    | border-radius | vertical-align | margin-bottom | margin-right | right
+    | padding-top | padding-left | max-width | box-shadow | bottom | content
+    | padding-right | transform | white-space | min-height | padding-bottom
+    | background-image | border-bottom | visibility | outline
+    | background-position | min-width | transition | border-top | border-color
+    | background-repeat | text-transform | background-size | max-height
+    | list-style | clear | font-style | justify-content | border-left
+    | align-items | border-right | border-width | font | text-overflow
+    | overflow-y | pointer-events | border-style | flex-direction | animation
+    | overflow-x | letter-spacing | flex | word-wrap | flex-wrap | fill
+    | transform-origin | list-style-type | border-collapse
+    | border-top-left-radius | border-bottom-left-radius | user-select | clip
+    | text-shadow | border-bottom-right-radius | word-break | flex-grow
+    | border-top-right-radius | border-bottom-color | border-top-color
+    | flex-shrink | align-self | text-rendering | animation-timing-function
+    | direction | background-clip | zoom | border-spacing | text-indent
+    | outline-offset | border-left-color | transition-property
+    | border-right-color | animation-name | stroke | touch-action
+    | animation-duration | transition-delay | filter | overflow-wrap
+    | animation-delay | border-bottom-width | variable | font-variant
+    | flex-basis | transition-duration | border-top-width | animation-fill-mode
+    | object-fit | transition-timing-function | will-change | outline-width
+    | order | outline-style | stroke-width | border-right-width | align-content
+    | resize | table-layout | appearance | animation-iteration-count
+    | border-left-width | flex-flow | stroke-dashoffset | stroke-dasharray
+    | backface-visibility | unicode-bidi | border-bottom-style
+    | text-size-adjust | border-top-style | animation-direction | word-spacing
+    | contain | speak | grid-template-columns | font-feature-settings
+    | perspective | list-style-position | clip-path | image-rendering
+    | font-display | transform-style | border-left-style | outline-color
+    | background-position-x | background-attachment | border-right-style
+    | margin-block-end | background-origin | animation-play-state | hyphens
+    | stroke-linecap | font-stretch | object-position | page-break-inside
+    | column-gap | counter-reset | counter-increment | background-position-y
+    | margin-block-start | size | grid-template-rows | column-count | quotes
+    | padding-inline-end | text-decoration-skip | border-image | all
+    | page-break-after | fill-opacity | font-variant-ligatures
+    | scroll-boundary-behavior | empty-cells | list-style-image | justify-self
+    | overflow-anchor | padding-inline-start | grid-gap | text-decoration-color
+    | margin-inline-start | caret-color | grid-column-gap | aspect-ratio
+    | stroke-opacity | margin-inline-end | grid-column | perspective-origin
+    | caption-side | columns | scroll-behavior | justify-items | line-break
+    | grid-row-gap | column-width | orphans | widows | backdrop-filter
+    | mix-blend-mode | tab-size | stop-color | column-rule | grid-area
+    | stroke-miterlimit | text-align-last | page-break-before
+    | grid-column-start | border-image-slice | border-image-repeat
+    | text-decoration-style | border-image-width | grid-column-end | grid-row
+    | scroll-snap-align | scroll-snap-type | border-image-outset
+    | text-decoration-line | column-fill | border-inline-end-width
+    | border-inline-start-width | grid-row-start | stroke-linejoin
+    | inset-inline-end | inset-inline-start | grid-auto-flow | grid-auto-rows
+    | grid-template-areas | border-image-source | fill-rule | font-kerning
+    | grid-row-end | font-variant-numeric | break-inside | shape-outside
+    | color-scheme | shape-image-threshold | scroll-boundary-behavior-y
+    | text-decoration-skip-ink | page | isolation | background-blend-mode
+    | page-orientation | inset | gap | scroll-snap-margin | column-rule-color
+    | place-items | column-rule-style | shape-rendering | content-visibility
+    | grid-auto-columns | scroll-boundary-behavior-x | writing-mode | clip-rule
+    | font-variant-caps | scroll-padding | text-anchor | mask | row-gap
+    | background-repeat-x | intrinsic-size | text-underline-position
+    | font-variant-east-asian | column-span | vector-effect | dominant-baseline
+    | stop-opacity | break-after | grid-template | break-before | mask-type
+    | scroll-snap-stop | border-inline-start-color | border-inline-end-color | r
+    | alignment-baseline | text-decoration-thickness | column-rule-width | d
+    | image-orientation | rx | text-orientation | cx | baseline-shift
+    | scroll-padding-top | padding-block-start | padding-block-end | cy
+    | min-inline-size | inline-size | background-repeat-y | shape-margin
+    | block-size | marker | min-block-size | paint-order | ry
+    | scroll-snap-margin-top | border-block-end-color | border-block-end-width
+    | border-inline-start-style | border-inline-end-style
+    | border-block-end-style | font-variation-settings
+    | border-block-start-width | border-block-start-color
+    | border-block-start-style | place-content | y | x | ruby-position
+    | text-combine-upright | color-interpolation-filters | color-interpolation
+    | color-rendering | transform-box | marker-end | flood-color | marker-start
+    | marker-mid | flood-opacity | lighting-color | forced-color-adjust
+    | buffered-rendering | place-self | offset-path | scroll-padding-left
+    | offset-distance | offset-rotate | text-underline-offset | max-inline-size
+    | max-block-size | border-inline-end | scroll-snap-margin-inline-start
+    | scroll-padding-inline-start | scroll-snap-margin-block-end
+    | scroll-snap-margin-block-start | scroll-padding-block-end
+    | scroll-snap-margin-inline-end | scroll-padding-block-start
+    | scroll-padding-inline-end | font-optical-sizing | grid
+    | scroll-padding-bottom | scroll-snap-margin-left | inset-block-end
+    | overscroll-behavior-block | overscroll-behavior-inline | inset-block-start
+    | scroll-snap-margin-right | scroll-padding-right
+    | scroll-snap-margin-bottom | border-inline-start | margin-inline
+    | border-end-start-radius | border-end-end-radius | margin-block
+    | border-start-start-radius | border-start-end-radius | padding-inline
+    | counter-set | padding-block | border-block-end | offset
+    | border-block-start | inset-inline | inset-block | scroll-snap-margin-block
+    | scroll-padding-inline | scroll-padding-block | scroll-snap-margin-inline
+    | border-block | offset-rotation | border-inline | border-block-color
+    | border-inline-width | border-inline-color | border-block-style
+    | border-block-width | border-inline-style | motion | motion-offset
+    | motion-path | font-size-adjust | text-justify | scale | scrollbar-gutter
+    | animation-timeline | rotate | translate | snap-height | math-style
+    | math-shift | math-depth | offset-anchor | offset-position
+    | glyph-orientation-vertical | internal-callback | text-line-through
+    | text-line-through-color | text-line-through-mode | text-line-through-style
+    | text-line-through-width | text-overline | text-overline-color
+    | text-overline-mode | text-overline-style | text-overline-width
+    | text-underline | text-underline-color | text-underline-mode
+    | text-underline-style | text-underline-width | shape-inside | shape-padding
+    | enable-background | color-profile | glyph-orientation-horizontal | kerning
+    | image-resolution | max-zoom | min-zoom | orientation | user-zoom
+    | mask-source-type | touch-action-delay | scroll-blocks-on | motion-rotation
+    | scroll-snap-points-x | scroll-snap-points-y | scroll-snap-coordinate
+    | scroll-snap-destination | apply-at-rule | viewport-fit | overflow-block
+    | syntax | content-size | intrinsic-block-size | intrinsic-height
+    | intrinsic-inline-size | intrinsic-width | render-subtree
+    | origin-trial-test-property | subtree-visibility
+    | math-superscript-shift-style | start
+    # END OF QUERY RESULTS
+    # BEGIN OF legacy properties which existed before the last query
+    | box-direction | line-box-contain | mask-image | mask-origin | flex-order
+    | font-synthesis | line-clamp | flex-negative | blend-mode
+    | font-variant-position | flex-align | column-break-before
+    | flex-item-align | azimuth | user-drag | mask-repeat | box-flex
+    | flex-preferred-size | font-language-override | box-align
+    | text-emphasis-color | box-ordinal-group | mask-composite
+    | transform-origin-y | pause | tap-highlight-color | text-fill-color
+    | text-emphasis-style | transform-origin-x | text-emphasis-position
+    | box-pack | box-decoration-break | box-orient
+    | text-emphasis | mask-clip | nbsp-mode | pause-after | pitch
+    | text-height | mask-position | flex-line-pack | perspective-origin-x
+    | mask-size | font-variant-alternates | perspective-origin-y
+    | font-smoothing | overflow-scrolling | flex-positive | pitch-range
+    ){{break}}
+
+  property_value_constants: |-
+    (?x:
+      {{font_display_constants}}
+    | {{font_property_constants}}
+    | {{font_size_constants}}
+    | {{font_style_constants}}
+    | {{unsorted_property_constants}}
+    )
+
+  unsorted_property_constants: |-
+    \b(?xi:
+      absolute|active|add
+    | all(-(petite|small)-caps|-scroll)?
+    | alpha(betic)?
+    | alternate(-reverse)?
+    | always|annotation|antialiased|at
+    | auto(hiding-scrollbar|-flow)?
+    | avoid(-column|-page|-region)?
+    | background(-color|-image|-position|-size)?
+    | backwards|balance|baseline|below|bevel|bicubic|bidi-override|blink
+    | block-line-height
+    | blur
+    | border(-bottom|-left|-right|-top)?-(color|radius|width|style)
+    | border-(bottom|top)-(left|right)-radius
+    | border-image(-outset|-repeat|-slice|-source|-width)?
+    | border(-bottom|-left|-right|-top|-collapse|-spacing|-box)?
+    | both|bottom
+    | box(-shadow)?
+    | break-(all|word)
+    | brightness
+    | butt(on)?
+    | capitalize
+    | cent(er|ral)
+    | char(acter-variant)?
+    | cjk-ideographic|clip|clone|close-quote
+    | closest-(corner|side)
+    | col-resize|collapse
+    | color(-stop|-burn|-dodge)?
+    | column((-count|-gap|-reverse|-rule(-color|-width)?|-width)|s)?
+    | common-ligatures|condensed|consider-shifts|contain
+    | content(-box|s)?
+    | contextual|contrast|cover
+    | crisp(-e|E)dges
+    | crop
+    | cross(hair)?
+    | da(rken|shed)
+    | default|dense|diagonal-fractions|difference|disabled
+    | discretionary-ligatures|disregard-shifts
+    | distribute(-all-lines|-letter|-space)?
+    | dotted|double|drop-shadow
+    | (nwse|nesw|ns|ew|sw|se|nw|ne|w|s|e|n)-resize
+    | ease(-in-out|-in|-out)?
+    | element|ellipsis|embed|end|EndColorStr|evenodd
+    | exclu(de(-ruby)?|sion)
+    | expanded
+    | (extra|semi|ultra)-(condensed|expanded)
+    | farthest-(corner|side)?
+    | fill(-box|-opacity)?
+    | filter|first|fixed|flat
+    | fit-content
+    | flex((-basis|-end|-grow|-shrink|-start)|box)?
+    | flip|flood-color
+    | font(-size(-adjust)?|-stretch|-weight)?
+    | forwards
+    | from(-image)?
+    | full-width|geometricPrecision|glyphs|gradient|grayscale
+    | grid(-height)?
+    | groove|hand|hanging|hard-light|height|help|hidden|hide
+    | historical-(forms|ligatures)
+    | horizontal(-tb)?
+    | hue
+    | ideograph(-alpha|-numeric|-parenthesis|-space|ic)
+    | inactive|include-ruby|infinite|inherit|initial
+    | inline(-block|-box|-flex(box)?|-line-height|-table)?
+    | inset|inside
+    | inter(-ideograph|-word|sect)
+    | invert|isolat(e|ion)
+    | jis(04|78|83|90)
+    | justify(-all)?
+    | keep-all
+    | landscape|ledger|legal|letter|A[3-5]|(JIS-)?B[4-5]|portrait
+    | last|left|letter-spacing|legacy
+    | light(e[nr]|ing-color)
+    | line(-edge|-height|-through)?
+    | linear(-gradient|RGB)?
+    | lining-nums|list-item|local|loose|lowercase|lr-tb|ltr
+    | lumin(osity|ance)|manual
+    | margin(-bottom|-box|-left|-right|-top)?
+    | marker(-offset|s)?
+    | mathematical
+    | max-(content|height|lines|size|width)
+    | medium|middle
+    | min-(content|height|width)
+    | miter|mixed|move|multiply|newspaper
+    | no-(change|clip|(close|open)-quote|(common|discretionary|historical)-ligatures|contextual|drop|repeat)
+    | none|nonzero|not-allowed|nowrap
+    | offset(-after|-before|-end|-start)?
+    | oldstyle-nums|opacity|open-quote
+    | optimize(Legibility|Precision|Quality|Speed)
+    | order|ordinal|ornaments
+    | outline(-color|-offset|-width)?
+    | outset|outside|over(line|-edge|lay)
+    | padding(-bottom|-box|-left|-right|-top)?
+    | page|painted|paused
+    | perspective-origin
+    | petite-caps|pixelated|pointer
+    | pre(-line|-wrap)?
+    | preserve-3d
+    | progid:DXImageTransform.Microsoft.(Alpha|Blur|dropshadow|gradient|Shadow)
+    | progress
+    | proportional-(nums|width)
+    | radial-gradient|recto|region|relative
+    | repeat(-[xy])?
+    | repeating-(linear|radial)-gradient
+    | replaced|reset-size|reverse|ridge|right
+    | round
+    | row(-resize|-reverse)?
+    | run-in
+    | ruby(-base|-text)?(-container)?
+    | rtl|running|saturat(e|ion)|screen
+    | safe
+    | scroll(-position|bar)?
+    | separate|sepia
+    | scale-down
+    | shape-(image-threshold|margin|outside)
+    | show
+    | sideways(-lr|-rl)?
+    | simplified
+    | slashed-zero|slice
+    | smooth|snap|solid|soft-light
+    | space(-around|-between|-evenly)?
+    | span|sRGB
+    | stack(ed-fractions)?
+    | start(ColorStr)?
+    | static
+    | step-(end|start)
+    | sticky
+    | stop-(color|opacity)
+    | stretch|strict
+    | stroke(-box|-dash(array|offset)|-miterlimit|-opacity|-width)?
+    | style(set)?
+    | stylistic
+    | sub(grid|pixel-antialiased|tract)?
+    | super|swash
+    | table(-caption|-cell|(-column|-footer|-header|-row)-group|-column|-row)?
+    | tabular-nums|tb-rl
+    | text((-bottom|-(decoration|emphasis)-color|-indent|-(over|under|after|before)-edge|-shadow|-size(-adjust)?|-top)|field)?
+    | thi(ck|n)
+    | titling-ca(ps|se)
+    | to[p]?
+    | touch|traditional
+    | transform(-origin)?
+    | under(-edge|line)?
+    | unicase|unsafe|unset|uppercase|upright
+    | use-(glyph-orientation|script)
+    | verso
+    | vertical(-align|-ideographic|-lr|-rl|-text)?
+    | view-box
+    | viewport-fill(-opacity)?
+    | visibility
+    | visible(Fill|Painted|Stroke)?
+    | wait|wavy|weight|whitespace|width|word-spacing
+    | wrap(-reverse)?
+    | z-index|zero
+    | zoom(-in|-out)?
+    ){{break}}
+
+  # https://www.w3.org/TR/css-fonts-4/#font-display-desc
+  font_display_constants: |-
+    \b(?xi:
+    block | swap | fallback | optional
+    ){{break}}
+
+  # Generic Font Families
+  font_family_constants: |-
+    \b(?xi:
+    # CSS 2 fonts
+    # https://www.w3.org/TR/CSS22/fonts.html#generic-font-families
+      sans-serif | serif | cursive | monospace | fantasy
+    # CSS 3 level 4 fonts
+    # https://www.w3.org/TR/2019/WD-css-fonts-4-20191113/#generic-family-value
+    | emoji | math | fangsong | system-ui
+    # https://www.w3.org/TR/2019/WD-css-fonts-4-20191113/#standard-font-families
+    | ui-sans-serif | ui-serif | ui-monospace | ui-rounded
+    ){{break}}
+
+  # https://www.w3.org/TR/CSS22/fonts.html#font-shorthand
+  font_property_constants: |-
+    \b(?xi:
+      caption | icon | menu | message-box | small-caption | status-bar
+    ){{break}}
+
+  # https://www.w3.org/TR/CSS22/fonts.html#font-size-props
+  font_size_constants: |-
+    \b(?xi:
+      larger | large | medium | small | smaller | x{1,2}-(?: large | small )
+    ){{break}}
+
+  # https://www.w3.org/TR/CSS22/fonts.html#font-boldness
+  # https://www.w3.org/TR/CSS22/fonts.html#font-styling
+  # https://www.w3.org/TR/CSS22/fonts.html#small-caps
+  font_style_constants: |-
+    \b(?xi:
+      normal | bold | bolder | lighter | italic | oblique | small-caps
+    ){{break}}
+
+###[ PSEUDO SELECTORS FOR SASS ]###############################################
+  pseudo_elements: |-
+    (?x:
+        (:{1,2})(?:before|after|first-line|first-letter) # CSS1 & CSS2 require : or ::
+      | (::)(-(?:moz|ms|webkit)-)?(?:{{ident}}) # CSS3 requires ::
+    ){{break}}
+
+  regular_pseudo_classes: '\b(active|any-link|blank|checked|current|default|defined|disabled|drop|empty|enabled|first|first-child|first-of-type|fullscreen|future|focus|focus-visible|focus-within|host|hover|indeterminate|in-range|invalid|last-child|last-of-type|left|link|local-link|only-child|only-of-type|optional|out-of-range|past|placeholder-shown|read-only|read-write|required|right|root|scope|target|target-within|user-invalid|valid|visited)\b(?![-])'
+  functional_pseudo_classes: '\b(dir|lang|matches|not|has|drop|nth-last-child|nth-child|nth-last-of-type|nth-of-type){{break}}'
+
+
+###############################################################################
 
 contexts:
   main:
-    - include: Sass.sublime-syntax#frontmatter
-    - include: Sass.sublime-syntax#comment-block
-    - include: Sass.sublime-syntax#comment-line
-    - include: Sass.sublime-syntax#selectors
-    - include: properties
-    - include: Sass.sublime-syntax#keyframe-operators
-    - include: Sass.sublime-syntax#interpolated-selectors
-    - include: Sass.sublime-syntax#custom-element-selectors
-    - include: at-rules
-    - include: curly-braces
-    - include: Sass.sublime-syntax#comma-delimiter
-    - include: css-modules
+    # Yekyll front matter
+    - match: '^---$'
+      scope: frontmatter.jekyll punctuation.section.frontmatter.begin.jekyll
+      embed: scope:source.yaml
+      embed_scope: frontmatter.jekyll
+      escape: '^---$'
+      escape_captures:
+        0: frontmatter.jekyll punctuation.section.frontmatter.end.jekyll
 
-  properties:
-    - include: Sass.sublime-syntax#comment-line
-    - include: Sass.sublime-syntax#comment-block
-    - match: '\b(font-family|font|family)\b(?=\s*:)'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - match: '(\s*)(;)'
-          pop: true
-          captures:
-            1: meta.property-value.css
-            2: punctuation.terminator.rule.css
-        - match: '(?=\s*[;})])'
-          pop: true
-        - match: ':'
-          scope: punctuation.separator.key-value.css
-          push:
-            - meta_content_scope: meta.property-value.css
-            - match: '(?=\s*([;})]))'
-              pop: true
-            - include: Sass.sublime-syntax#comment-line
-            - include: Sass.sublime-syntax#comment-block
-            - include: Sass.sublime-syntax#numeric-values
-            - include: Sass.sublime-syntax#property-value-constants
-            - include: Sass.sublime-syntax#var-function
-            - include: Sass.sublime-syntax#sass-maps
-            - include: Sass.sublime-syntax#sass-variables
-            - include: Sass.sublime-syntax#sass-functions
-            - include: Sass.sublime-syntax#sass-custom-functions
-            - match: '{{ident}}(\s+{{ident}})*\b(?!:)'
-              scope: string.unquoted.css
-            - include: Sass.sublime-syntax#literal-string
-            - include: Sass.sublime-syntax#unquoted-concatenated-string
-            - include: Sass.sublime-syntax#sass-operators
-            - include: Sass.sublime-syntax#comma-delimiter
-            - match: '(?={)'
-              pop: true
-        - match: ''
-          pop: true
-    - match: |-
-        \b(?x)(
-            display|width|background-color|height|position|font-family|font-weight
-          | top|opacity|cursor|background-image|right|visibility|box-sizing
-          | user-select|left|float|margin-left|margin-top|line-height
-          | padding-left|z-index|margin-bottom|margin-right|margin
-          | vertical-align|padding-top|white-space|border-radius|padding-bottom
-          | padding-right|padding|bottom|clear|max-width|box-shadow|content
-          | border-color|min-height|min-width|font-style|border-width
-          | border-collapse|background-size|text-overflow|max-height|text-transform
-          | text-shadow|text-indent|border-style|overflow-y|list-style-type
-          | word-wrap|border-spacing|appearance|zoom|overflow-x|border-top-left-radius
-          | border-bottom-left-radius|border-top-color|pointer-events
-          | border-bottom-color|align-items|justify-content|letter-spacing
-          | border-top-right-radius|border-bottom-right-radius|border-right-width
-          | font-smoothing|border-bottom-width|border-right-color|direction
-          | border-top-width|src|border-left-color|border-left-width
-          | tap-highlight-color|table-layout|background-clip|word-break
-          | transform-origin|resize|filter|backdrop-filter|backface-visibility|text-rendering
-          | box-orient|transition-property|transition-duration|word-spacing
-          | quotes|outline-offset|animation-timing-function|animation-duration
-          | animation-name|transition-timing-function|border-bottom-style
-          | border-bottom|transition-delay|transition|unicode-bidi|border-top-style
-          | border-top|unicode-range|list-style-position|orphans|outline-width
-          | line-clamp|order|flex-direction|box-pack|animation-fill-mode
-          | outline-color|list-style-image|list-style|touch-action|flex-grow
-          | border-left-style|border-left|animation-iteration-count
-          | page-break-inside|box-flex|box-align|page-break-after|animation-delay
-          | widows|border-right-style|border-right|flex-align|outline-style
-          | outline|background-origin|animation-direction|fill-opacity
-          | background-attachment|flex-wrap|transform-style|counter-increment
-          | overflow-wrap|counter-reset|animation-play-state|animation
-          | will-change|box-ordinal-group|image-rendering|mask-image|flex-flow
-          | background-position-y|stroke-width|background-position-x|background-position
-          | background-blend-mode|flex-shrink|flex-basis|flex-order|flex-item-align
-          | flex-line-pack|flex-negative|flex-pack|flex-positive|flex-preferred-size
-          | flex|user-drag|font-stretch|column-count|empty-cells|align-self
-          | caption-side|mask-size|column-gap|mask-repeat|box-direction
-          | font-feature-settings|mask-position|align-content|object-fit
-          | columns|text-fill-color|clip-path|stop-color|font-kerning
-          | page-break-before|stroke-dasharray|size|fill-rule|border-image-slice
-          | column-width|break-inside|column-break-before|border-image-width
-          | stroke-dashoffset|border-image-repeat|border-image-outset|line-break
-          | stroke-linejoin|stroke-linecap|stroke-miterlimit|stroke-opacity
-          | stroke|shape-rendering|border-image-source|border-image|border
-          | tab-size|writing-mode|perspective-origin-y|perspective-origin-x
-          | perspective-origin|perspective|text-align-last|text-align|clip-rule
-          | clip|text-anchor|column-rule-color|box-decoration-break|column-fill
-          | fill|column-rule-style|mix-blend-mode|text-emphasis-color
-          | baseline-shift|dominant-baseline|page|alignment-baseline
-          | column-rule-width|column-rule|break-after|font-variant-ligatures
-          | transform-origin-y|transform-origin-x|transform|object-position
-          | break-before|column-span|isolation|shape-outside|all
-          | color-interpolation-filters|marker|marker-end|marker-start
-          | marker-mid|color-rendering|color-interpolation|background-repeat-x
-          | background-repeat-y|background-repeat|background|mask-type
-          | flood-color|flood-opacity|text-orientation|mask-composite
-          | text-emphasis-style|paint-order|lighting-color|shape-margin
-          | text-emphasis-position|text-emphasis|shape-image-threshold
-          | mask-clip|mask-origin|mask|font-variant-caps|font-variant-alternates
-          | font-variant-east-asian|font-variant-numeric|font-variant-position
-          | font-variant|font-size-adjust|font-size|font-language-override
-          | font-display|font-synthesis|font|line-box-contain|text-justify
-          | text-decoration-color|text-decoration-style|text-decoration-line
-          | text-decoration|text-underline-position|grid-template-rows
-          | grid-template-columns|grid-template-areas|grid-template|rotate|scale
-          | translate|scroll-behavior|grid-column-start|grid-column-end
-          | grid-column-gap|grid-row-start|grid-row-end|grid-auto-rows
-          | grid-area|grid-auto-flow|grid-auto-columns|image-orientation
-          | hyphens|overflow-scrolling|overflow|color-profile|kerning
-          | nbsp-mode|color|image-resolution|grid-row-gap|grid-row|grid-column
-          | blend-mode|azimuth|pause-after|pause-before|pause|pitch-range|pitch
-          | text-height|system|negative|prefix|suffix|range|pad|fallback
-          | additive-symbols|symbols|speak-as|speak|grid-gap
-        )\b(?=\s*:)
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - include: property-value-wrapper
-    - match: '(-(?:webkit|moz|ms|o)-)({{ident}})(?=\s*:)'
-      captures:
-        0: meta.property-name.css
-        1: support.type.vendor-prefix.css
-        2: support.type.property-name.css
-      push:
-        - include: property-value-wrapper
+    # Sass variable declarations
     - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
       captures:
         0: variable.declaration.sass
         1: punctuation.definition.variable.sass
       push:
-        - include: property-value-wrapper
-    - match: '(--)({{nmchar}}+)'
-      captures:
-        0: meta.property-name.css support.type.custom-property.css
-        1: punctuation.definition.custom-property.css
-        2: support.type.custom-property.name.css
-      push:
-        - include: property-value-wrapper
-    # Partial property names, split at "-"
-    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
-    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - include: property-value-wrapper
-    - match: '[a-zA-Z0-9_-]*((#)({)((\$)([a-zA-Z0-9_-][\w-]*))(}))[a-zA-Z0-9_-]*'
-      captures:
-        0: meta.property-name.css support.type.property-name
-        1: meta.group.interpolation.sass
-        2: punctuation.definition.variable.sass
-        3: punctuation.definition.group.begin.sass
-        4: variable.other.sass
-        5: punctuation.definition.variable.sass
-        7: punctuation.definition.group.end.sass
-      push:
-        - include: property-value-wrapper
-    - match: '\b(composes)\b'
-      scope: meta.property-name.css-modules.css support.type.property-name
-      push:
-        - include: property-value-wrapper
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
 
-  property-value-wrapper:
-    - match: '(\s*)(;)'
-      pop: true
-      captures:
-        1: meta.property-value.css
-        2: punctuation.terminator.rule.css
-    - match: '(?=\s*[;})])'
-      pop: true
-    - match: '\s*(:)'
-      captures:
-        1: punctuation.separator.key-value.css
-      push:
-        - meta_content_scope: meta.property-value.css
-        - match: '(?=\s*[;})])'
-          pop: true
-        - include: Sass.sublime-syntax#property-values
-        - match: '(?={)'
-          pop: true
-    - match: ''
-      pop: true
-
-  at-rules:
-    - match: '(@)(each)\b'
-      scope: keyword.control.flow.sass
-      captures:
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.each.sass
-        - include: Sass.sublime-syntax#sass-variables
-        - include: Sass.sublime-syntax#comma-delimiter
-        - match: '(?={)'
-          pop: true
-        - match: '\b(in)\b'
-          scope: keyword.operator.sass
-          push:
-            - match: '(?={)'
-              pop: true
-            - include: Sass.sublime-syntax#comment-block
-            - include: Sass.sublime-syntax#comment-line
-            - include: Sass.sublime-syntax#comma-delimiter
-            - include: Sass.sublime-syntax#var-function
-            - include: Sass.sublime-syntax#sass-variables
-            - include: Sass.sublime-syntax#sass-functions
-            - include: Sass.sublime-syntax#sass-custom-functions
-            - include: Sass.sublime-syntax#sass-interpolation
-            - include: Sass.sublime-syntax#sass-maps
-            - include: Sass.sublime-syntax#unquoted-string
-            - include: Sass.sublime-syntax#sass-operators
-    - match: '(@)(for|while)\b'
-      scope: keyword.control.flow.sass
-      captures:
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '(?={)'
-          pop: true
-        - include: Sass.sublime-syntax#sass-script-expression
-    - match: '(@)(if|else if|else)\b'
-      scope: keyword.control.flow.conditional.sass
-      captures:
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '(?={)'
-          pop: true
-        - include: Sass.sublime-syntax#sass-script-expression
-    - match: '(@)(warn|error)\b'
-      scope: keyword.control.at-rule.warn.sass
-      captures:
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '(;)'
-          scope: punctuation.terminator.rule.sass
-          pop: true
-        - include: Sass.sublime-syntax#sass-script-expression
-    - match: '(@)(debug)\b'
-      scope: keyword.control.at-rule.debugger.sass
-      captures:
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '(;)'
-          scope: punctuation.terminator.rule.sass
-          pop: true
-        - include: Sass.sublime-syntax#sass-script-expression
-    - match: '(@)(at-root)\b'
-      scope: keyword.control.at-rule.at-root.sass
-      captures:
-        1: punctuation.definition.keyword.sass
-    - match: '(@)(extend)\b'
-      scope: keyword.control.at-rule.extend.sass
-      captures:
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.extend.sass
-        - match: '(;)'
-          scope: punctuation.terminator.rule.sass
-          pop: true
-        - match: \!\s*(default|global|optional)
-          scope: keyword.other.sass
-        - include: Sass.sublime-syntax#selectors
-        - include: Sass.sublime-syntax#custom-element-selectors
-    - match: '((@)(mixin|function))\s+([\w-]+)'
-      captures:
-        1: keyword.control.at-rule.sass
-        2: punctuation.definition.keyword.sass
-        4: entity.name.function.sass
-      push:
-        - meta_scope: meta.function.declaration.sass
-        - match: '\s*(?=[\{;])'
-          pop: true
-        - match: '\('
-          scope: punctuation.definition.group.begin.sass
-          push:
-            - meta_scope: meta.function.parameters.sass
-            - match: '\)'
-              scope: punctuation.definition.group.end.sass
-              pop: true
-            - include: Sass.sublime-syntax#comma-delimiter
-            - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
-              scope: variable.parameter.sass
-              captures:
-                1: punctuation.definition.variable.sass
-              push:
-                - match: '(?=[,\)])'
-                  pop: true
-                - match: ':'
-                  scope: punctuation.separator.key-value.css
-                - match: '\b(false|true|null)\b'
-                  scope: constant.language.sass
-                - include: Sass.sublime-syntax#property-values
-            - match: '\{'
-              scope: punctuation.section.property-list.begin.sass
-              push:
-              - match: '\}'
-                scope: punctuation.section.property-list.end.sass
-                pop: true
-              - include: main
-    - match: '((@)(include))\s+(([a-z]+)(\.))?([\w-]+)'
-      captures:
-        0: variable.function.sass
-        1: keyword.control.at-rule.sass
-        2: punctuation.definition.keyword.sass
-        5: entity.name.namespace.sass
-        6: punctuation.separator.namespace.sass
-      push:
-        - meta_scope: meta.function-call.sass
-        - match: '\s*(;)'
-          captures:
-            1: punctuation.terminator.rule.sass
-          pop: true
-        - match: '\s*(?=[\{;])'
-          pop: true
-        - match: '\('
-          scope: punctuation.definition.group.begin.sass
-          push:
-            - meta_scope: meta.function-call.arguments.sass
-            - include: Sass.sublime-syntax#comment-block
-            - include: Sass.sublime-syntax#comment-line
-            - include: Sass.sublime-syntax#sass-variables
-            - include: Sass.sublime-syntax#sass-functions
-            - include: Sass.sublime-syntax#sass-operators
-            - include: Sass.sublime-syntax#comma-delimiter
-            - include: Sass.sublime-syntax#property-values
-            - include: Sass.sublime-syntax#literal-string
-            - match: '{{ident}}'
-              scope: string.unquoted.sass
-            - include: Sass.sublime-syntax#selectors
-            - include: Sass.sublime-syntax#custom-element-selectors
-            - match: '\)'
-              scope: punctuation.definition.group.end.sass
-              pop: true
-    - match: '(@)(return)\b'
-      scope: keyword.control.at-rule.return.sass
-      captures:
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '\s*(;)'
-          captures:
-            1: punctuation.terminator.rule.css
-          pop: true
-        - include: Sass.sublime-syntax#property-values
-    - match: '\s*((@)(use|forward)\b)\s*'
-      captures:
-        1: keyword.control.at-rule.module.sass
-        2: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.module.sass
-        - match: '\s*(;)'
-          scope: punctuation.terminator.rule.sass
-          pop: true
-        - match: '\b(as)\b\s+([a-zA-Z0-9_-]*(\*)?)'
-          captures:
-            1: keyword.control.as.sass
-            2: meta.generic-name.sass
-            3: constant.language.import-all.sass
-        - match: '\b(show|hide)\b'
-          scope: keyword.control.show-hide.sass
-          push:
-            - match: '(?=;)'
-              pop: true
-            - include: Sass.sublime-syntax#comment-block
-            - include: Sass.sublime-syntax#comment-line
-            - include: Sass.sublime-syntax#sass-variables
-            - include: Sass.sublime-syntax#sass-functions
-            - include: Sass.sublime-syntax#sass-operators
-            - include: Sass.sublime-syntax#comma-delimiter
-            - match: '{{ident}}'
-              scope: meta.generic-name.sass
-        - match: '(with)\s+(\()'
-          captures:
-            1: keyword.control.with.sass
-            2: punctuation.definition.group.begin.sass
-          push:
-            - match: '\)'
-              scope: punctuation.definition.group.end.sass
-              pop: true
-            - match: ':'
-              scope: punctuation.separator.key-value.css
-            - include: Sass.sublime-syntax#comment-block
-            - include: Sass.sublime-syntax#comment-line
-            - include: Sass.sublime-syntax#sass-variables
-            - include: Sass.sublime-syntax#sass-functions
-            - include: Sass.sublime-syntax#sass-operators
-            - include: Sass.sublime-syntax#comma-delimiter
-            - include: Sass.sublime-syntax#property-values
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - include: Sass.sublime-syntax#literal-string
-    - match: '((@)(?:-(?:webkit|moz|o)-)?(charset|namespace|font-face)\b)'
-      captures:
-        1: keyword.control.at-rule.css
-        2: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.css
-        - match: '\s*(;)'
-          captures:
-            1: punctuation.terminator.rule.sass
-          pop: true
-        - match: '\s*(?=[\{;])'
-          pop: true
-        - match: (url)(\()
-          captures:
-            1: meta.function-call.css support.function.url.css
-            2: punctuation.definition.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '\)'
-              scope: punctuation.definition.group.end.css
-              pop: true
-            - include: Sass.sublime-syntax#literal-string
-            - include: Sass.sublime-syntax#unquoted-string
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - include: Sass.sublime-syntax#literal-string
-    - match: '\s*((@)counter-style\b)\s+(?:(?i:\b(decimal|none)\b)|({{ident}}))?\s*(?=\{|$)'
-      captures:
-        1: keyword.control.at-rule.counter-style.css
-        2: punctuation.definition.keyword.css
-        3: invalid.illegal.counter-style-name.css
-        4: entity.other.counter-style-name.css
-      push:
-        - meta_scope: meta.at-rule.counter-style.css
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - match: '(?=\{)'
-          pop: true
-    - match: '(?=\s*@custom-media\b)'
-      push:
-        - match: ;
-          scope: punctuation.terminator.css
-          pop: true
-        - match: \s*((@)custom-media)
-          captures:
-            1: keyword.control.at-rule.custom-media.css
-            2: punctuation.definition.keyword.css
-            3: support.constant.custom-media.css
-          push:
-            - meta_scope: meta.at-rule.custom-media.css
-            - match: \s*(?=;)
-              pop: true
-            - include: media-query
-    - match: '((@)document)'
-      captures:
-        1: keyword.control.at-rule.document.css
-        2: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.document.css
-        - match: '(?=[\{;])'
-          pop: true
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - include: Sass.sublime-syntax#url-function
-        - include: Sass.sublime-syntax#url-prefix-function
-        - include: Sass.sublime-syntax#domain-function
-        - include: Sass.sublime-syntax#regexp-function
-        - include: Sass.sublime-syntax#comma-delimiter
-    - match: '\s*((@)import\b)\s*'
-      captures:
-        1: keyword.control.at-rule.import.css
-        2: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.import.css
-        - match: ';'
-          scope: punctuation.terminator.rule.sass
-          pop: true
-        - match: '(\()(reference|inline|less|css|once|multiple|optional)(\))'
-          captures:
-            0: meta.at-rule.arguments.sass
-            1: punctuation.definition.group.begin.sass
-            2: constant.other.sass
-            3: punctuation.definition.group.end.sass
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - include: Sass.sublime-syntax#literal-string
-        - include: Sass.sublime-syntax#url-function
-        - include: media-query
-    - match: '\s*((@)(-webkit-|-moz-|-o-)?keyframes)'
-      captures:
-        1: keyword.control.at-rule.keyframe.css
-        2: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.keyframe.css
-        - match: '\s*(?=[\{;])'
-          pop: true
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - include: Sass.sublime-syntax#sass-interpolation
-        - match: '\s*({{ident}})?'
-          captures:
-            1: entity.other.animation-name.css
-        - match: '\s*(?:(,)|(?=[{;]))'
-          captures:
-            1: punctuation.definition.arbitrary-repetition.css
-    - match: '\s*((@)media)\b'
-      captures:
-        1: keyword.control.at-rule.media.css
-        2: punctuation.definition.keyword.css
-        3: support.constant.media.css
-      push:
-        - meta_scope: meta.at-rule.media.css
-        - include: media-query
-        - match: '(?=\{)'
-          pop: true
-    - match: '\s*((@)namespace)\s+({{ident}}(?!{{nmchar}}|\())?'
-      captures:
-        1: keyword.control.at-rule.namespace.css
-        2: punctuation.definition.keyword.css
-        3: entity.other.namespace-prefix.css
-      push:
-        - meta_scope: meta.at-rule.namespace.css
-        - include: at-rule-punctuation
-        - include: Sass.sublime-syntax#literal-string
-        - include: Sass.sublime-syntax#url-function
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-    - match: '\s*((@)page)\s*(?:(:)(first|left|right))?\s*'
-      captures:
-        1: keyword.control.at-rule.page.css
-        2: punctuation.definition.keyword.css
-        3: punctuation.definition.entity.css
-        4: entity.other.pseudo-class.css
-      push:
-        - meta_scope: meta.at-rule.page.css
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - match: '\s*(?=\{)'
-          pop: true
-    - match: '((@)supports)'
-      captures:
-        1: keyword.control.at-rule.supports.css
-        2: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.supports.css
-        - match: '(?=\{)'
-          pop: true
-        - include: Sass.sublime-syntax#at-supports-operators
-        - include: at-supports-parens
-    - match: '((@)content)'
+    # Sass content at-rule
+    - match: '((@)content){{break}}'
       captures:
         1: keyword.control.at-rule.content.sass
         2: punctuation.definition.keyword.sass
       push:
-        - match: ';'
-          scope: punctuation.terminator.rule.sass
-          pop: true
-        - match: '(?=$)'
+        - match: '\s*(?=$)'
           pop: true
 
-  at-supports-parens:
-    - match: '\('
-      scope: punctuation.definition.group.begin.css
+    # CSS modules
+    - match: '\b(composes)\b'
+      scope: meta.property-name.css-modules.css support.type.property-name
       push:
-        - meta_scope: meta.group.css
-        - match: '\)'
-          scope: punctuation.definition.group.end.css
+        - include: push-to-value
+        - match: '\s*(?=$)'
           pop: true
-        - include: Sass.sublime-syntax#at-supports-operators
-        - include: at-supports-parens
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - include: properties
-
-  at-rule-punctuation:
-    - match: ';'
-      scope: punctuation.terminator.rule.css
-    - match: '(?=;|$)'
-      pop: true
-
-  media-query:
-    - include: Sass.sublime-syntax#comment-block
-    - include: Sass.sublime-syntax#comment-line
-    - match: \b(?i:all|aural|braille|embossed|handheld|print|projection|screen|speech|tty|tv)\b
-      scope: support.constant.media.css
-    - match: '\b(?i:and|or|not|only)\b'
-      scope: keyword.operator.logic.media.css
-    - match: ','
-      scope: punctuation.definition.arbitrary-repetition.css
-    - match: \(
-      scope: punctuation.definition.group.begin.css
-      push:
-        - match: \)
-          scope: punctuation.definition.group.end.css
-          pop: true
-        - include: Sass.sublime-syntax#comment-block
-        - include: Sass.sublime-syntax#comment-line
-        - match: |-
-            (?x)
-            (
-                (-webkit-|-o-)?
-                ((min|max)-)?
-                (-moz-)?
-                (
-                    ((device-)?(height|width|aspect-ratio|pixel-ratio))|
-                    (color(-index)?)|monochrome|resolution
-                )
-            )|grid|scan|orientation
-            \s*(?=[:)])
-          captures:
-            0: support.type.property-name.media.css
-            2: support.type.vendor-prefix.css
-            5: support.type.vendor-prefix.css
-          push:
-            - match: (:)|(?=\))
-              captures:
-                1: punctuation.separator.key-value.css
-              pop: true
-        - match: \b(portrait|landscape|progressive|interlace)
-          scope: support.constant.property-value.css
-        - match: \s*(\d+)(/)(\d+)
-          captures:
-            1: constant.numeric.css
-            2: keyword.operator.arithmetic.css
-            3: constant.numeric.css
-        - include: Sass.sublime-syntax#numeric-values
-        - include: Sass.sublime-syntax#sass-value-expression
-
-  curly-braces:
-    - match: '\{'
-      scope: punctuation.section.property-list.begin.css
-    - match: '\}'
-      scope: punctuation.section.property-list.end.css
-
-  css-modules:
     - match: '\s*(:)(import|export)'
       scope: meta.selector.css entity.other.pseudo-class.css-modules.css
       captures:
@@ -660,35 +690,117 @@ contexts:
       push:
         - meta_scope: meta.selector.css meta.function-call.css
         - match: '\('
-          scope: punctuation.definition.group.begin.css
+          scope: punctuation.section.group.begin.css
           push:
             - meta_scope: meta.group.css
             - match: '\)'
-              scope: punctuation.definition.group.end.css
+              scope: punctuation.section.group.end.css
               pop: true
-            - include: Sass.sublime-syntax#selectors
-            - include: Sass.sublime-syntax#literal-string
-        - match: '\s*(\{)'
-          scope: punctuation.section.property-list.begin.css
-          push:
-            - meta_scope: meta.group.css-modules.css
-            - match: '\}'
-              scope: punctuation.section.property-list.end.css
-              pop: true
-            - include: Sass.sublime-syntax#comment-line
-            - include: Sass.sublime-syntax#comment-block
-            - match: '([a-zA-Z0-9_-]+)\s*(:)'
-              captures:
-                1: meta.property-name.css-modules.css support.type.property-name.css-modules.css
-                2: punctuation.separator.key-value.css
-                3: variable.other.css-modules.css
-              push:
-                - match: '(;|\s*(?=$))'
-                  captures:
-                    1: punctuation.terminator.rule.css
-                  pop: true
-                - include: Sass.sublime-syntax#literal-string
-                - include: Sass.sublime-syntax#unquoted-string
-        - match: ''
+            - include: Sass.sublime-syntax#quoted-strings
+        - match: '\s*(?=$)'
+          scope: punctuation.terminator.rule.sass
           pop: true
 
+    - include: Sass.sublime-syntax#comments
+    - include: Sass.sublime-syntax#sass-mixins
+    - include: Sass.sublime-syntax#selectors
+    - include: Sass.sublime-syntax#sass-interpolated-selectors
+    - include: Sass.sublime-syntax#at-rules
+    - include: rule-list-body
+
+###[ PROPERTY LISTS ]##########################################################
+
+  # Highly modified from CSS because there is no strict separation
+  # between selectors and properties in Sass,
+  # ie. there is no 'property list'
+
+  rule-list-body:
+    # Note: This context is used by HTML.sublime-syntax
+    - include: Sass.sublime-syntax#comments
+    - include: Sass.sublime-syntax#property-identifiers
+    - include: property-values
+    - include: Sass.sublime-syntax#rule-terminators
+
+  push-to-value:
+    - match: ';'
+      scope: punctuation.terminator.rule.css
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      push: property-value-content
+
+###[ PROPERTY IDENTIFIERS ]####################################################
+
+  property-identifier-content:
+    - meta_scope: meta.property-list.css
+    - include: Sass.sublime-syntax#comments
+    - include: Sass.sublime-syntax#vendor-prefixes
+    # specific properties with special treatment
+    - include: Sass.sublime-syntax#counter-property
+    - include: Sass.sublime-syntax#font-property
+    # common properties
+    - include: Sass.sublime-syntax#builtin-property
+    - include: Sass.sublime-syntax#custom-property
+    - include: push-to-value
+    - match: '\s*(?=$)'
+      pop: true
+
+###[ PROPERTY VALUES ]#########################################################
+
+  property-values:
+    - match: ';'
+      scope: punctuation.terminator.rule.css
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      push: property-value-content
+    # Sass nested property names
+    # Partial property names, split at "-"
+    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
+    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
+      scope: meta.property-name.css support.type.property-name.css
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
+    - match: '[a-zA-Z0-9_-]*((#)({)((\$)([a-zA-Z0-9_-][\w-]*))(}))[a-zA-Z0-9_-]*'
+      captures:
+        0: meta.property-name.css support.type.property-name
+        1: meta.group.interpolation.sass
+        2: punctuation.definition.variable.sass
+        3: punctuation.section.group.begin.sass
+        4: variable.other.sass
+        5: punctuation.definition.variable.sass
+        7: punctuation.section.group.end.sass
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
+
+  property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - match: '\!\s*(default|global|optional)\b'
+      scope: keyword.other.sass
+    - include: terminator-pop
+    - include: Sass.sublime-syntax#comments
+    - include: Sass.sublime-syntax#comma-delimiters
+    - include: Sass.sublime-syntax#common-operators
+    - include: Sass.sublime-syntax#builtin-values
+    - include: Sass.sublime-syntax#other-functions
+    - include: Sass.sublime-syntax#other-constants
+    - include: Sass.sublime-syntax#sass-value-expression
+
+###[ BUILTIN FUNCTIONS ]#######################################################
+
+  function-arguments-common:
+    - include: Sass.sublime-syntax#group-end
+    - include: terminator-pop
+    - include: Sass.sublime-syntax#comments
+    - include: Sass.sublime-syntax#var-functions
+    - include: Sass.sublime-syntax#sass-value-expression
+
+###[ PROTOTYPES ]##############################################################
+
+  terminator-pop:
+    - match: '\s*(?=$)'
+      pop: 1
+    - match: (?=[;){}]|$)
+      pop: 1

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -279,13 +279,18 @@ variables:
     | font-weight | font-variant | line-gap-override | size-adjust | unicode-range
     ){{break}}
 
-  # Page Margin Property Names
-  # https://www.w3.org/TR/css-page-3/#margin-at-rule
-  page_margin_property_names: |-
+  # @page Margin Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@page
+  page_margin_names: |-
     \b(?xi:
         (?: bottom | top ) - (?: left-corner | left | center | right | right-corner )
       | (?: left | right ) - (?: top | middle | bottom )
     ){{break}}
+
+  # @page Property Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@page
+  page_property_names: |-
+    \b(?xi: bleed | margin | marks | size ){{break}}
 
   # Property names are sorted by popularity in descending order.
   # Note:
@@ -331,7 +336,7 @@ variables:
     | margin-block-end | background-origin | animation-play-state | hyphens
     | stroke-linecap | font-stretch | object-position | page-break-inside
     | column-gap | counter-reset | counter-increment | background-position-y
-    | margin-block-start | size | grid-template-rows | column-count | quotes
+    | margin-block-start | grid-template-rows | column-count | quotes
     | padding-inline-end | text-decoration-skip | border-image | all
     | page-break-after | fill-opacity | font-variant-ligatures
     | scroll-boundary-behavior | empty-cells | list-style-image | justify-self
@@ -696,17 +701,881 @@ contexts:
             - match: '\)'
               scope: punctuation.section.group.end.css
               pop: true
-            - include: Sass.sublime-syntax#quoted-strings
+            - include: quoted-strings
         - match: '\s*(?=$)'
           scope: punctuation.terminator.rule.sass
           pop: true
 
-    - include: Sass.sublime-syntax#comments
+    - include: comments
     - include: Sass.sublime-syntax#sass-mixins
-    - include: Sass.sublime-syntax#selectors
+    - include: selectors
     - include: Sass.sublime-syntax#sass-interpolated-selectors
-    - include: Sass.sublime-syntax#at-rules
+    - include: at-rules
     - include: rule-list-body
+
+###[ COMMENTS ]################################################################
+
+  comments:
+    - include: comments-block
+    - include: comments-line
+
+  comments-block:
+    # empty block comment
+    - match: (/\*+)(\*/)
+      scope: comment.block.css
+      captures:
+         1: punctuation.definition.comment.begin.css
+         2: punctuation.definition.comment.end.css
+    # normal block comment
+    - match: /\*+
+      scope: punctuation.definition.comment.begin.css
+      push: comments-content
+
+  comments-content:
+    - meta_scope: comment.block.css
+    - match: \*+/
+      scope: punctuation.definition.comment.end.css
+      pop: 1
+    - match: ^\s*(\*)(?!/)
+      captures:
+        1: punctuation.definition.comment.css
+
+  comments-line:
+    - match: //
+      scope: punctuation.definition.comment.css
+      push:
+        - meta_scope: comment.line.double-slash.sass
+        - match: \n
+          pop: true
+
+###[ AT RULES ]################################################################
+
+  at-rules:
+    - include: Sass.sublime-syntax#sass-at-rules
+    - include: at-charset
+    - include: at-counter-style
+    - include: at-custom-media
+    - include: at-document
+    - include: at-font-face
+    - include: at-import
+    - include: at-keyframes
+    - include: at-media
+    - include: at-namespace
+    - include: at-page
+    - include: at-page-margin
+    - include: at-supports
+    - include: at-other
+
+  # @charset
+  # https://www.w3.org/TR/css-syntax-3/#at-ruledef-charset
+  at-charset:
+    - match: (@)(?i:charset){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-charset-content
+
+  at-charset-content:
+    - meta_scope: meta.at-rule.charset.css
+    - include: quoted-strings
+    - include: at-rule-end
+
+  # @counter-style
+  # https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule
+  at-counter-style:
+    - match: (@)(?i:counter-style){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-counter-style-content
+
+  at-counter-style-content:
+    - meta_scope: meta.at-rule.counter-style.css
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-counter-style-block-content
+    - include: at-counter-style-names
+    - include: at-rule-end
+
+  at-counter-style-block-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: at-counter-style-property-names
+    - include: property-values
+    - include: rule-terminators
+
+  at-counter-style-names:
+    - match: '{{counter_style_illegal_names}}'
+      scope: invalid.illegal.identifier.css
+    - match: '{{ident}}'
+      scope: entity.other.counter-style-name.css
+
+  at-counter-style-property-names:
+    - include: counter-style-fallback-properties
+    - include: counter-style-system-properties
+    - include: counter-style-speak-as-properties
+    - match: '{{counter_style_property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
+
+  # @custom-media
+  # https://??
+  at-custom-media:
+    - match: (@)(?i:custom-media){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push:
+        - at-custom-media-content
+        - at-custom-media-identifier
+
+  at-custom-media-identifier:
+    - match: '{{custom_ident}}'
+      scope: entity.other.custom-media.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+  at-custom-media-content:
+    - meta_scope: meta.at-rule.custom-media.css
+    - include: media-queries
+    - include: at-rule-end
+
+  # @document
+  # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
+  at-document:
+    - match: (@)(?i:document){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-document-content
+
+  at-document-content:
+    - meta_scope: meta.at-rule.document.css
+    - include: comma-delimiters
+    - include: url-functions
+    - include: at-document-functions
+    - include: at-rule-block
+    - include: at-rule-end
+
+  # @font-face
+  # https://www.w3.org/TR/css-fonts-4/#at-font-face-rule
+  at-font-face:
+    - match: (@)(?i:font-face){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-font-face-content
+
+  at-font-face-content:
+    - meta_scope: meta.at-rule.font-face.css
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-font-face-block-content
+    - include: at-rule-end
+
+  at-font-face-block-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: at-font-face-property-names
+    - include: property-values
+    - include: rule-terminators
+
+  at-font-face-property-names:
+    - match: \b(?i:font-family){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: font-property-value
+    - match: '{{font_face_property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
+
+  # @import
+  # https://www.w3.org/TR/css-cascade-4/#at-ruledef-import
+  at-import:
+    - match: (@)(?i:import){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-import-content
+
+  at-import-content:
+    - meta_scope: meta.at-rule.import.css
+    - include: quoted-strings
+    - include: url-functions
+    - include: media-queries
+    - include: at-rule-end
+
+  # @keyframes
+  # https://www.w3.org/TR/css3-animations/#at-ruledef-keyframes
+  at-keyframes:
+    - match: (@)(?i:keyframes){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-keyframe-content
+
+  at-keyframe-content:
+    - meta_scope: meta.at-rule.keyframe.css
+    - include: comma-delimiters
+    - include: at-keyframe-block
+    - include: at-keyframe-names
+    - include: at-rule-end
+
+  at-keyframe-names:
+    - include: Sass.sublime-syntax#sass-interpolation
+    - match: '{{illegal_custom_ident}}'
+      scope: invalid.illegal.identifier.css
+    - match: '{{ident}}'
+      scope: entity.other.animation-name.css
+    - include: quoted-strings
+
+  at-keyframe-block:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-keyframe-block-content
+
+  at-keyframe-block-content:
+    - meta_scope: meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: property-lists
+    - include: at-keyframe-selectors
+
+  at-keyframe-selectors:
+    - match: (?=[[:alnum:].,%])
+      push: at-keyframe-selector-content
+
+  at-keyframe-selector-content:
+    - meta_scope: meta.selector.css
+    - include: comma-delimiters
+    - include: percentage-constants
+    - match: \b(?i:from|to){{break}}
+      scope: keyword.other.selector.css
+    - include: selector-end
+
+  # @media
+  # https://drafts.csswg.org/css-conditional-3/#at-ruledef-media
+  at-media:
+    - match: (@)(?i:media){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-media-content
+
+  at-media-content:
+    - meta_scope: meta.at-rule.media.css
+    - include: media-queries
+    - include: at-rule-block
+    - include: at-rule-end
+
+  # @namespace
+  # https://www.w3.org/TR/css3-namespace/
+  at-namespace:
+    - match: (@)(?i:namespace){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push:
+        - at-namespace-content
+        - at-namespace-identifier
+
+  at-namespace-identifier:
+    - match: '{{ident}}(?!{{nmchar}}|\()'
+      scope: entity.other.namespace-prefix.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+  at-namespace-content:
+    - meta_scope: meta.at-rule.namespace.css
+    - include: var-functions
+    - include: url-functions
+    - include: quoted-urls
+    - include: at-rule-end
+
+  # @page
+  # https://www.w3.org/TR/css3-page/#at-ruledef-page
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@page
+  at-page:
+    - match: (@)(?i:page){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-page-content
+
+  at-page-content:
+    - meta_scope: meta.at-rule.page.css
+    - include: comma-delimiters
+    - include: at-page-block
+    - include: at-page-names
+    - include: at-rule-end
+
+  at-page-names:
+    - match: (:)(?i:blank|first|left|right|recto|verso){{break}}
+      captures:
+        0: entity.other.pseudo-class.css
+        1: punctuation.definition.entity.css
+    - match: (:){{nmchar}}*
+      captures:
+        # 0: invalid.illegal.pseudo-class.css
+        1: punctuation.definition.entity.css
+    - match: '{{ident}}'
+      scope: entity.other.page-name.css
+
+  at-page-block:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-page-block-content
+
+  at-page-block-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: at-page-margin
+    - include: at-page-property-list-content
+    - include: at-other
+
+  at-page-margin:
+    - match: (@){{page_margin_names}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-page-margin-content
+
+  at-page-margin-content:
+    - meta_scope: meta.at-rule.margin.css
+    - include: at-page-property-lists
+    - include: at-rule-end
+
+  at-page-property-lists:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-page-property-list-content
+
+  at-page-property-list-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: at-page-property-names
+    - include: property-values
+    - include: rule-terminators
+    - include: illegal-blocks
+    - include: illegal-groups
+
+  at-page-property-names:
+    - match: '{{page_property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
+    # Note: Consume unknown identifiers to maintain word boundaries.
+    - match: '{{generic_ident}}'
+
+  # @supports
+  # https://drafts.csswg.org/css-conditional-3/#at-supports
+  at-supports:
+    - match: (@)(?i:supports){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-supports-content
+
+  at-supports-content:
+    - meta_scope: meta.at-rule.supports.css
+    - include: at-supports-groups
+    - include: at-supports-operators
+    - include: at-rule-block
+    - include: at-rule-end
+
+  at-supports-operators:
+    - match: \b(?i:and|or|not){{break}}
+      scope: keyword.operator.logical.css
+
+  at-supports-groups:
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      push: at-supports-group-content
+
+  at-supports-group-content:
+    - meta_scope: meta.group.css
+    - include: group-end
+    - include: at-rule-end
+    - include: at-supports-groups
+    - include: at-supports-operators
+    - include: rule-list-body
+
+  # @<ident>
+  # Fallback context for incomplete or unknown at-rules.
+  # https://www.w3.org/TR/css-syntax-3/#at-rule
+  # https://www.w3.org/TR/CSS22/syndata.html#parsing-errors
+  at-other:
+    - match: (@){{ident}}
+      push: at-other-content
+
+  at-other-content:
+    - meta_scope: meta.at-rule.other.css
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-other-block-content
+    - include: at-rule-end
+
+  at-other-block-content:
+    - meta_scope: meta.block.css
+    - include: block-end2
+
+  at-rule-block:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-rule-block-content
+
+  at-rule-block-content:
+    - meta_scope: meta.block.css
+    - include: block-end2
+    - include: main
+
+  at-rule-end:
+    - match: (?=[;{}])
+      pop: 1
+    - include: comments
+
+###[ MEDIA QUERIES ]###########################################################
+
+  # https://drafts.csswg.org/mediaqueries-5/#media
+  media-queries:
+    - include: comma-delimiters
+    - include: media-query-conditions
+    - include: media-query-media-types
+
+  media-query-conditions:
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      push: media-query-group-content
+    - match: '[<>]=?|='
+      scope: keyword.operator.comparison.css
+    - match: \b(?i:and|or|not|only){{break}}
+      scope: keyword.operator.logic.css
+
+  media-query-group-content:
+    - meta_scope: meta.group.css
+    - match: (?=[,;{}])
+      pop: 1
+    - include: group-end
+    - include: comments
+    - include: media-query-conditions
+    - include: media-query-property-names
+    - include: media-query-property-values
+    - include: Sass.sublime-syntax#sass-value-expression
+    - include: var-functions
+    - include: calc-functions
+    - include: scalar-rational-constants
+    - include: numeric-constants
+
+  media-query-property-names:
+    - match: |-
+        (?xi:
+          ({{vendor_prefix}})?
+          (
+            (?: min- | max- )?
+            (?:
+              color (?: -gamut | -index )?
+            | monochrome | resolution | update
+            | (?: device- )? (?: height | width | aspect-ratio | pixel-ratio )
+            )
+          | (?:any-)?(?: pointer | hover )
+          | prefers-(?: reduced-motion | color-scheme )
+          | display-mode | grid | orientation | scan | scripting
+          | overflow-(?: block | inline )
+          )
+        ){{break}}
+      captures:
+        1: support.type.vendor-prefix.css
+        2: support.type.property-name.css
+
+  media-query-property-values:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      push: media-query-property-value-content
+
+  media-query-property-value-content:
+    - match: |-
+        \b(?xi:
+        # global css constants
+          all | inherit | initial | none | unset
+        # color-gamut / color-index:
+        | srgb | p3 | rec2020
+        # display-mode:
+        | browser | fullscreen | standalone | minimal-ui
+        # hover:
+        | hover
+        # orientation:
+        | landscape | portrait
+        # overflow:
+        | optional-paged | paged | scroll
+        # pointer:
+        | coarse | fine
+        # prefers-color-scheme:
+        | dark | light
+        # scan:
+        | interlace | progressive
+        # scripting:
+        | enabled | initial-only
+        # update:
+        | fast | normal | slow
+        ){{break}}
+      scope: support.constant.property-value.css
+      pop: 1
+    - include: else-pop
+
+  media-query-media-types:
+    # Media Types:
+    # https://www.w3.org/TR/CSS21/media.html
+    # https://drafts.csswg.org/mediaqueries-5/#media-types
+    - match: |-
+        \b(?xi:
+        # global css constants
+          all | inherit | initial | none | unset
+        # specs
+        | print | screen | speech
+        # deprecated
+        | aural | braille | embossed | handheld | projection | tty | tv
+        ){{break}}
+      scope: support.constant.media.css
+
+###[ SELECTORS ]###############################################################
+
+  # The original Sass syntax needs lookaheads for specific pseudo-classes
+  # and pseudo-elements, to understand if you're writing a selector
+  # or a property
+
+  selectors:
+    - include: Sass.sublime-syntax#sass-interpolated-selectors
+    - match: (?=\s*{{svg_tags}})
+      push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?!-|\s*:))
+      push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?={{pseudo_elements}}))
+      push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?=:{{regular_pseudo_classes}}))
+      push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?=:({{functional_pseudo_classes}})\())
+      push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+    - match: (?=\s*(?=:({{functional_pseudo_classes}}|{{functional_pseudo_classes}})\())
+      push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?=:(-(moz|ms|webkit)-){{ident}}))
+      push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+    - match: (?=\s*[#.:\[\*%>~+,&](?!{))
+      push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+
+  prefixed-selectors:
+    - match: \*
+      scope: variable.language.wildcard.asterisk.css
+    # Class and Id Selectors
+    # https://drafts.csswg.org/selectors-4/#class-html
+    - match: \.
+      scope: punctuation.definition.entity.css
+      push:
+        - meta_scope: entity.other.attribute-name.class.css
+        - include: Sass.sublime-syntax#sass-interpolation
+        - match: '{{generic_ident}}'
+          pop: 1
+        - include: immediately-pop
+    # https://drafts.csswg.org/selectors-4/#id-selectors
+    - match: \#
+      scope: punctuation.definition.entity.css
+      push:
+        - meta_scope: entity.other.attribute-name.id.css
+        - include: Sass.sublime-syntax#sass-interpolation
+        - match: '{{generic_ident}}'
+          pop: 1
+        - include: immediately-pop
+    # sass extend-only selectors
+    - match: \%
+      scope: punctuation.definition.entity.sass
+      push:
+        - meta_scope: entity.other.attribute-name.placeholder.sass
+        - include: Sass.sublime-syntax#sass-interpolation
+        - match: '{{generic_ident}}'
+          pop: 1
+        - include: immediately-pop
+    # Attribute Selectors
+    # https://drafts.csswg.org/selectors-4/#attribute-selectors
+    - match: \[
+      scope: punctuation.section.brackets.begin.css
+      push:
+        - attribute-selector-meta
+        - attribute-selector-key
+    # Pseudo Elements
+    # https://drafts.csswg.org/selectors-4/#pseudo-elements
+    - match: '::'
+      scope: punctuation.definition.pseudo-element.css
+      push:
+        - meta_include_prototype: false
+        - include: vendor-prefixes
+        - include: pseudo-element-function
+        - include: pseudo-element-regular
+        - include: immediately-pop
+    # Pseudo Classes
+    # https://drafts.csswg.org/selectors-4/#pseudo-classes
+    - match: ':'
+      scope: punctuation.definition.pseudo-class.css
+      push:
+        - meta_include_prototype: false
+        - include: vendor-prefixes
+        - include: pseudo-element-css2
+        - include: pseudo-class-function
+        - include: pseudo-class-regular
+        - include: immediately-pop
+    # Combinators
+    # https://drafts.csswg.org/selectors-4/#combinators
+    # https://drafts.csswg.org/css-scoping/#deep-combinator
+    - match: '{{combinators}}(?![>~+|])'
+      scope: keyword.operator.combinator.css
+
+  selector-content:
+    - meta_scope: meta.selector.css
+    - include: selector-end
+    - include: comma-delimiters
+    - include: Sass.sublime-syntax#sass-ampersand
+    - include: Sass.sublime-syntax#sass-interpolated-selectors
+
+    # Html Tags
+    - match: '{{html_tags}}'
+      scope: entity.name.tag.html.css
+    - match: '{{svg_tags}}'
+      scope: entity.name.tag.svg.css
+    # Custom Elements
+    # http://w3c.github.io/webcomponents/spec/custom/#custom-elements-core-concepts
+    - match: '{{custom_element_tags}}'
+      scope: entity.name.tag.custom.css
+    - include: prefixed-selectors
+    - match: '{{combinators}}{2,}|\|{3,}'
+      scope: invalid.illegal.combinator.css
+
+    # CSS modules
+    - match: '\s*(:)(local|global)(?=\()'
+      scope: meta.selector.css entity.other.pseudo-class.css-modules.css
+      captures:
+        1: punctuation.definition.entity.css
+      push:
+        - meta_scope: meta.selector.css meta.function-call.css
+        - match: '\('
+          scope: punctuation.section.group.begin.css
+          push:
+            - meta_scope: meta.group.css
+            - match: '\)'
+              scope: punctuation.section.group.end.css
+              pop: true
+            - include: quoted-strings
+        - match: ''
+          pop: true
+    - match: '\s*(:)(local|global)'
+      scope: meta.selector.css entity.other.pseudo-class.css-modules.css
+      captures:
+        1: punctuation.definition.entity.css
+
+  selector-end:
+    - match: (?=\s*[;@(){}])
+      pop: 1
+    - include: comments
+
+  # Qualified Names
+  # https://drafts.csswg.org/css-namespaces-3/#css-qnames
+  namespace-prefixes:
+    - match: (?:({{ident}})|(\*))?(\|)(?!=)
+      captures:
+        1: entity.other.namespace-prefix.css
+        2: variable.language.wildcard.asterisk.css
+        3: punctuation.separator.namespace.css
+
+  vendor-prefixes:
+    - match: '{{vendor_prefix}}'
+      scope: support.type.vendor-prefix.css
+
+###[ SELECTORS / ATTRIBUTE SELECTORS ]#########################################
+
+  attribute-selector-meta:
+    - meta_scope: meta.attribute-selector.css meta.brackets.css
+    - include: immediately-pop
+
+  attribute-selector-key:
+    - include: namespace-prefixes
+    - match: '{{ident}}'
+      scope: entity.other.attribute-name.css
+      set: attribute-selector-operator
+    - match: \*
+      scope: variable.language.wildcard.asterisk.css
+      set: attribute-selector-operator
+    - include: attribute-selector-operator
+
+  attribute-selector-operator:
+    - match: '[~*|^$]?='
+      scope: keyword.operator.logical.css
+      set:
+        - attribute-selector-flag
+        - attribute-selector-value
+    - include: attribute-selector-flag
+
+  attribute-selector-value:
+    - include: comments
+    - include: quoted-string
+    - match: '[^\s\]\[''"]+'
+      scope: meta.string.css string.unquoted.css
+      pop: 1
+    - include: else-pop
+
+  attribute-selector-flag:
+    - match: \b[iI]{{break}}
+      scope: keyword.other.flag.css
+      set: attribute-selector-end
+    - include: attribute-selector-end
+
+  attribute-selector-end:
+    - match: \]
+      scope: punctuation.section.brackets.end.css
+      pop: 1
+    - include: selector-end
+    - match: \S
+      scope: invalid.illegal.css
+
+###[ SELECTORS / PSEUDO CLASSES ]##############################################
+
+  # Functional Pseudo Classes
+  # https://drafts.csswg.org/selectors-4/#functional-pseudo-class
+  pseudo-class-function:
+    - include: pseudo-class-function-dir
+    - include: pseudo-class-function-lang
+    - include: pseudo-class-function-with-anb-args
+    - include: pseudo-class-function-with-selector-args
+    - include: pseudo-class-function-with-generic-args
+
+  # Special :dir() pseudo-class
+  # https://drafts.csswg.org/selectors-4/#the-dir-pseudo
+  pseudo-class-function-dir:
+    - match: (?i:dir)(?=\()
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: direction-constants
+
+  # Special :lang() pseudo-class
+  # https://drafts.csswg.org/selectors-4/#the-lang-pseudo
+  pseudo-class-function-lang:
+    - match: (?i:lang)(?=\()
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: quoted-strings
+            - include: language-ranges
+
+  # Functional Pseudo Classes with `An+B` param
+  # An+B Notation: https://drafts.csswg.org/css-syntax/#anb
+  pseudo-class-function-with-anb-args:
+    - match: |-
+        (?xi:
+        # https://drafts.csswg.org/selectors-4/#table-pseudos
+          nth-last-col
+        | nth-col
+        # https://drafts.csswg.org/selectors-4/#typed-child-index
+        | nth-last-child
+        | nth-child
+        | nth-last-of-type
+        | nth-of-type
+        )(?=\()
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: anb-notation-values
+            - include: scalar-integer-constants
+
+  anb-notation-values:
+    - match: \b(even|odd){{break}}
+      scope: support.constant.property-value.css
+    - match: (([-+]?)(\d*)(n))\s*(([-+])(\s*\d+))?
+      captures:
+        1: meta.number.integer.decimal.css
+        2: keyword.operator.arithmetic.css
+        3: constant.numeric.value.css
+        4: constant.numeric.suffix.css
+        5: meta.number.integer.decimal.css
+        6: keyword.operator.arithmetic.css
+        7: constant.numeric.value.css
+    - match: '[-+]\s+\d+n?|[-+]?\d+\s+n'
+      scope: invalid.illegal.numeric.css
+
+  # Functional Pseudo Classes with selector list
+  pseudo-class-function-with-selector-args:
+    - match: (?i:matches|is|where|not|has)(?=\()
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: selectors
+
+  # Functional Pseudo Classes with generic arguments
+  pseudo-class-function-with-generic-args:
+    - match: '{{ident}}(?=\()'
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set: other-functions-arguments
+
+  # Regular Pseudo Classes
+  # https://drafts.csswg.org/selectors-4/#pseudo-classes
+  pseudo-class-regular:
+    - match: '{{ident}}'
+      scope: entity.other.pseudo-class.css
+      pop: 1
+
+  # Legacy Pseudo Elements
+  # https://drafts.csswg.org/selectors-4/#pseudo-elements
+  pseudo-element-css2:
+    # Note: CSS1 & CSS2 compatibility requires those to be matched after `:`
+    - match: (?i:before|after|first-line|first-letter){{break}}
+      scope: entity.other.pseudo-element.css
+      pop: 1
+
+  # Functional Pseudo Elements
+  # https://drafts.csswg.org/selectors-4/#pseudo-elements
+  pseudo-element-function:
+    - match: '{{ident}}(?=\()'
+      scope: meta.function-call.identifier.css entity.other.pseudo-element.css
+      set: other-functions-arguments
+
+  # Pseudo Elements
+  # https://drafts.csswg.org/selectors-4/#pseudo-elements
+  pseudo-element-regular:
+    - match: '{{ident}}'
+      scope: entity.other.pseudo-element.css
+      pop: 1
 
 ###[ PROPERTY LISTS ]##########################################################
 
@@ -716,10 +1585,10 @@ contexts:
 
   rule-list-body:
     # Note: This context is used by HTML.sublime-syntax
-    - include: Sass.sublime-syntax#comments
-    - include: Sass.sublime-syntax#property-identifiers
+    - include: comments
+    - include: property-identifiers
     - include: property-values
-    - include: Sass.sublime-syntax#rule-terminators
+    - include: rule-terminators
 
   push-to-value:
     - match: ';'
@@ -730,19 +1599,35 @@ contexts:
 
 ###[ PROPERTY IDENTIFIERS ]####################################################
 
+  property-identifiers:
+    - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
+      push: property-identifier-content
+
   property-identifier-content:
-    - meta_scope: meta.property-list.css
-    - include: Sass.sublime-syntax#comments
-    - include: Sass.sublime-syntax#vendor-prefixes
+    - meta_scope: meta.property-name.css
+    - include: comments
+    - include: vendor-prefixes
     # specific properties with special treatment
-    - include: Sass.sublime-syntax#counter-property
-    - include: Sass.sublime-syntax#font-property
+    - include: counter-property
+    - include: font-property
     # common properties
-    - include: Sass.sublime-syntax#builtin-property
-    - include: Sass.sublime-syntax#custom-property
+    - include: builtin-property
+    - include: custom-property
+    
     - include: push-to-value
-    - match: '\s*(?=$)'
+    - match: '\s*(?=$|;)'
       pop: true
+
+  builtin-property:
+    - match: '{{property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
+
+  # Custom Properties
+  # https://drafts.csswg.org/css-variables/#typedef-custom-property
+  custom-property:
+    # custom property definition
+    - match: '{{custom_ident}}'
+      scope: meta.property-name.css entity.other.custom-property.css
 
 ###[ PROPERTY VALUES ]#########################################################
 
@@ -780,24 +1665,1582 @@ contexts:
     - match: '\!\s*(default|global|optional)\b'
       scope: keyword.other.sass
     - include: terminator-pop
-    - include: Sass.sublime-syntax#comments
-    - include: Sass.sublime-syntax#comma-delimiters
-    - include: Sass.sublime-syntax#common-operators
-    - include: Sass.sublime-syntax#builtin-values
-    - include: Sass.sublime-syntax#other-functions
-    - include: Sass.sublime-syntax#other-constants
+    - include: comments
+    - include: comma-delimiters
+    - include: common-operators
+    - include: builtin-values
+    - include: other-functions
+    - include: other-constants
     - include: Sass.sublime-syntax#sass-value-expression
+
+  builtin-values:
+    - include: quoted-strings
+    - include: builtin-functions
+    - include: color-values
+    - include: line-names
+    - include: unicode-ranges
+    - include: numeric-constants
+    - include: common-constants
+    - include: generic-font-names
+    - include: vendor-prefixes
+    - include: Sass.sublime-syntax#sass-value-expression
+
+  # When including `color-values` and `color-adjuster-functions`, make sure it is
+  # included after the color adjustors to prevent `color-values` from consuming
+  # conflicting function names & color constants such as `red`, `green`, or `blue`.
+  color-values:
+    - include: color-functions
+    - include: color-constants
+
+  # Counter Symbol Values
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-system
+  # https://drafts.csswg.org/css-counter-styles-3/#symbols-function
+  counter-symbol-values:
+    - include: image-values
+    - include: counter-system-constants
+    - include: scalar-integer-constants
+    - include: quoted-strings
+
+  # 2D Image Values
+  # https://drafts.csswg.org/css-images-4/#image-values
+  image-values:
+    - include: cross-fade-functions
+    - include: gradient-functions
+    - include: image-functions
+    - include: image-set-functions
+    - include: url-functions
+
+###[ COUNTER PROPERTY ]########################################################
+
+  counter-property:
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters
+    - match: \b(?i:counter-(increment|reset|set)){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      set: counter-property-value
+
+  counter-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set:
+        - property-value-content
+        - counter-identifier
+    - include: else-pop
+
+  counter-identifier:
+    - match: '{{ident}}'
+      scope: entity.other.counter-name.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+###[ COUNTER STYLE FALLBACK PROPERTY ]#########################################
+
+  # Counter Style Fallback
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-fallback
+  counter-style-fallback-properties:
+    - match: \b(?i:fallback){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-fallback-property-value
+
+  counter-style-fallback-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set: counter-style-fallback-property-value-content
+    - include: else-pop
+
+  counter-style-fallback-property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: var-functions
+    - include: counter-style-identifiers
+
+  counter-style-identifiers:
+    - match: '{{counter_style_names}}'
+      scope: support.constant.counter-style-name.css
+    - match: '{{ident}}'
+      scope: entity.other.counter-style-name.css
+
+###[ COUNTER STYLE SYSTEM PROPERTY ]###########################################
+
+  # Counter Style System
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-system
+  counter-style-system-properties:
+    - match: \b(?i:system){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-system-property-value
+
+  counter-style-system-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set: counter-style-system-property-value-content
+    - include: else-pop
+
+  counter-style-system-property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: var-functions
+    - include: counter-symbol-values
+    - match: \b(?i:extends){{break}}
+      scope: keyword.declaration.extends.css
+      push: counter-style-identifier
+
+  counter-style-identifier:
+    - match: '{{counter_style_names}}'
+      scope: support.constant.counter-style-name.css
+      pop: 1
+    - match: '{{ident}}'
+      scope: entity.other.counter-style-name.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+###[ COUNTER STYLE SPEAK AS PROPERTY ]#########################################
+
+  # Counter Style Speak As
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-speak-as
+  counter-style-speak-as-properties:
+    - match: \b(?i:speak-as){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-speak-as-property-value
+
+  counter-style-speak-as-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set: counter-style-speak-as-property-value-content
+    - include: else-pop
+
+  counter-style-speak-as-property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: var-functions
+    - include: quoted-strings
+    - include: counter-speak-as-constants
+    - include: counter-style-identifiers
+
+###[ FONT PROPERTY ]###########################################################
+
+  # Font and Font-Family Property
+  # https://drafts.csswg.org/css-fonts-3/#font-family-prop
+  # https://drafts.csswg.org/css-fonts-3/#font-prop
+  font-property:
+    - match: \b(?i:font(-family)?){{break}}
+      scope: support.type.property-name.css
+      set: font-property-value
+
+  font-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set: font-property-value-content
+    - include: else-pop
+
+  font-property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: comma-delimiters
+    - include: common-operators
+    - include: builtin-values
+    - include: font-family-names
 
 ###[ BUILTIN FUNCTIONS ]#######################################################
 
+  builtin-functions:
+    - include: at-counter-functions
+    - include: at-font-functions
+    - include: attr-functions
+    - include: calc-functions
+    - include: color-adjuster-functions
+    - include: cross-fade-functions
+    - include: filter-functions
+    - include: filters-functions
+    - include: gradient-functions
+    - include: image-functions
+    - include: image-set-functions
+    - include: minmax-functions
+    - include: repeat-functions
+    - include: shape-functions
+    - include: timing-functions
+    - include: toggle-functions
+    - include: transform-functions
+    - include: url-functions
+    - include: var-functions
+
   function-arguments-common:
-    - include: Sass.sublime-syntax#group-end
+    - include: group-end
     - include: terminator-pop
-    - include: Sass.sublime-syntax#comments
-    - include: Sass.sublime-syntax#var-functions
+    - include: comments
+    - include: var-functions
     - include: Sass.sublime-syntax#sass-value-expression
 
+###[ BUILTIN AT RULE FUNCTIONS ]###############################################
+
+  at-counter-functions:
+    # counter()
+    # https://drafts.csswg.org/css-lists-3/#funcdef-counter
+    # counters()
+    # https://drafts.csswg.org/css-lists-3/#funcdef-counters
+    - match: \b(?i:counters?)(?=\()
+      scope: meta.function-call.identifier.css support.function.counter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - - meta_scope: meta.function-call.arguments.css meta.group.css
+              - include: function-arguments-common
+              - include: comma-delimiters
+              - include: counter-style-identifiers
+              - include: quoted-strings
+            - counter-identifier
+
+    # symbols()
+    # https://drafts.csswg.org/css-counter-styles-3/#symbols-function
+    - match: \b(?i:symbols)(?=\()
+      scope: meta.function-call.identifier.css support.function.counter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: counter-symbol-values
+
+  at-document-functions:
+    # url-prefix()
+    # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-prefix
+    - match: \b(?i:url-prefix)(?=\()
+      scope: meta.function-call.identifier.css support.function.url-prefix.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-urls
+            - include: unquoted-urls
+
+    # domain()
+    # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-domain
+    - match: \b(?i:domain)(?=\()
+      scope: meta.function-call.identifier.css support.function.domain.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-urls
+            - include: unquoted-urls
+
+    # regexp()
+    # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-regexp
+    - match: \b(?i:regexp)(?=\()
+      scope: meta.function-call.identifier.css support.function.regexp.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-strings
+
+  at-font-functions:
+    # format()
+    # https://drafts.csswg.org/css-fonts-3/#descdef-src
+    # format() is also mentioned in `issue 2` at https://drafts.csswg.org/css-images-3/#issues-index
+    # but does not seem to be implemented in any manner
+    - match: \b(?i:format)(?=\()
+      scope: meta.function-call.identifier.css support.function.font-face.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-strings
+
+    # local()
+    # https://drafts.csswg.org/css-fonts-3/#descdef-src
+    - match: \b(?i:local)(?=\()
+      scope: meta.function-call.identifier.css support.function.font-face.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-strings
+            - include: generic-font-names
+            - include: font-family-names
+
+###[ BUILTIN COLOR FUNCTIONS ]#################################################
+
+  # Color Functions
+  # https://drafts.csswg.org/css-color
+  color-functions:
+    # rgb(), rgba()
+    # https://drafts.csswg.org/css-color/#rgb-functions
+    - match: \b(?i:rgba?)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # hsl(), hsla()
+    # https://drafts.csswg.org/css-color/#the-hsl-notation
+    # hwb() - Not yet implemented by browsers
+    # https://drafts.csswg.org/css-color/#funcdef-hwb
+    - match: \b(?i:hsla?|hwb)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: angle-constants
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # gray() - Not yet implemented by browsers
+    # https://drafts.csswg.org/css-color/#funcdef-gray
+    - match: \b(?i:gray)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # device-cmyk() - Not yet implemented by browsers
+    # https://drafts.csswg.org/css-color/#funcdef-device-cmyk
+    - match: \b(?i:device-cmyk)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: color-adjuster-functions # must be included before `color-values`
+            - include: color-values
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # color-mod() - Not yet implemented by browsers
+    # https://drafts.csswg.org/css-color/#funcdef-color-mod
+    - match: \b(?i:color)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: color-adjuster-functions # must be included before `color-values`
+            - include: color-values
+            - include: angle-constants
+            - include: scalar-constants
+
+  # Color Adjuster Functions - Not yet implemented by browsers
+  # https://drafts.csswg.org/css-color/#typedef-color-adjuster
+  color-adjuster-functions:
+    # red(), green(), blue(), alpha() - Not yet implemented by browsers
+    - match: \b(?i:red|green|blue|alpha|a)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-adjuster-operators
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # hue() - Not yet implemented by browsers
+    - match: \b(?i:hue|h)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-adjuster-operators
+            - include: angle-constants
+
+    # saturation(), lightness(), whiteness(), blackness() - Not yet implemented by browsers
+    - match: \b(?i:saturation|lightness|whiteness|blackness|[slwb])(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-adjuster-operators
+            - include: percentage-constants
+
+    # tint(), shade(), contrast() - Not yet implemented by browsers
+    # contrast() interferes with the contrast() filter function;
+    # therefore, it is not yet implemented here
+    - match: \b(?i:tint|shade)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: percentage-constants
+
+    # blend(), blenda() - Not yet implemented by browsers
+    - match: \b(?i:blenda|blend)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-values
+            - include: percentage-constants
+            - match: \b(?i:rgb|hsl|hwb){{break}}
+              scope: keyword.other.color-space.css
+
+###[ BUILTIN FILTER FUNCTIONS ]################################################
+
+  filter-functions:
+    # filter()
+    # https://drafts.fxtf.org/filters/#funcdef-filter
+    - match: \b(?i:filter)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: filters-functions
+            - include: image-values
+            - include: quoted-strings
+
+  # Filter Functions
+  # https://drafts.fxtf.org/filters/#typedef-filter-function
+  filters-functions:
+    # blur()
+    # https://drafts.fxtf.org/filters/#funcdef-filter-blur
+    - match: \b(?i:blur)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: length-constants
+
+    # brightness(), contrast(), grayscale(), invert(), opacity(), saturate(), sepia()
+    # https://drafts.fxtf.org/filters/#funcdef-filter-brightness
+    - match: \b(?i:brightness|contrast|grayscale|invert|opacity|saturate|sepia)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # drop-shadow()
+    # https://drafts.fxtf.org/filters/#funcdef-filter-drop-shadow
+    - match: \b(?i:drop-shadow)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-values
+            - include: length-constants
+
+    # hue-rotate()
+    # https://drafts.fxtf.org/filters/#funcdef-filter-hue-rotate
+    - match: \b(?i:hue-rotate)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: angle-constants
+
+###[ BUILTIN GRID FUNCTIONS ]##################################################
+
+  # minmax()
+  # https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-minmax
+  minmax-functions:
+    - match: \b(?i:minmax)(?=\()
+      scope: meta.function-call.identifier.css support.function.grid.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: grid-constants
+            - include: length-constants
+            - include: percentage-constants
+
+  # repeat()
+  # https://drafts.csswg.org/css-grid/#funcdef-repeat
+  repeat-functions:
+    - match: \b(?i:repeat)(?=\()
+      scope: meta.function-call.identifier.css support.function.grid.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:auto-fill|auto-fit){{break}}
+              scope: keyword.other.grid.css
+            - include: calc-functions
+            - include: minmax-functions
+            - include: grid-constants
+            - include: length-constants
+            - include: percentage-constants
+            - include: scalar-integer-constants
+            - include: line-names
+
+###[ BUILTIN IMAGE FUNCTIONS ]#################################################
+
+  # cross-fade()
+  # https://drafts.csswg.org/css-images-4/#funcdef-cross-fade
+  cross-fade-functions:
+    - match: \b(?i:cross-fade)(?=\()
+      scope: meta.function-call.identifier.css support.function.image.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: color-values
+            - include: image-values
+            - include: percentage-constants
+            - include: quoted-urls
+
+  # image()
+  # https://drafts.csswg.org/css-images-4/#funcdef-image
+  image-functions:
+    - match: \b(?i:image)(?=\()
+      scope: meta.function-call.identifier.css support.function.image.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: color-values
+            - include: image-values
+            - include: quoted-urls
+            - include: direction-constants
+
+  # image-set()
+  # https://drafts.csswg.org/css-images-4/#funcdef-image-set
+  image-set-functions:
+    - match: \b(?i:image-set)(?=\()
+      scope: meta.function-call.identifier.css support.function.image.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: color-values
+            - include: image-values
+            - include: quoted-urls
+            - include: resolution-constants
+            - match: ([0-9]+)(x)
+              scope: meta.number.integer.decimal.css
+              captures:
+                1: constant.numeric.value.css
+                2: constant.numeric.suffix.css
+
+  # Gradient Functions
+  # https://drafts.csswg.org/css-images-3/#gradients
+  gradient-functions:
+    # conic-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/conic-gradient()
+    # repeating-conic-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-conic-gradient()
+    - match: \b((?:repeating-)?conic-gradient)(?=\()
+      scope: meta.function-call.identifier.css support.function.gradient.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:at|from){{break}}
+              scope: keyword.other.gradient.css
+            - match: \b(?i:bottom|center|left|right|top){{break}}
+              scope: support.constant.property-value.css
+            - include: color-values
+            - include: angle-constants
+            - include: length-constants
+            - include: percentage-constants
+
+    # linear-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient()
+    # repeating-linear-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-linear-gradient()
+    - match: \b((?:repeating-)?linear-gradient)(?=\()
+      scope: meta.function-call.identifier.css support.function.gradient.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:to){{break}}
+              scope: keyword.other.gradient.css
+            - match: \b(?i:bottom|left|right|top){{break}}
+              scope: support.constant.property-value.css
+            - include: color-values
+            - include: angle-constants
+            - include: length-constants
+            - include: percentage-constants
+
+    # radial-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/radial-gradient()
+    # repeating-radial-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-radial-gradient()
+    - match: \b((?:repeating-)?radial-gradient)(?=\()
+      scope: meta.function-call.identifier.css support.function.gradient.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:at|circle|ellipse){{break}}
+              scope: keyword.other.gradient.css
+            - match: \b(?i:bottom|center|left|right|top|(closest|farthest)-(corner|side)){{break}}
+              scope: support.constant.property-value.css
+            - include: color-values
+            - include: length-constants
+            - include: percentage-constants
+
+###[ BUILTIN SHAPE FUNCTIONS ]#################################################
+
+  # Shape Functions
+  # https://www.w3.org/TR/css-shapes-1/#typedef-basic-shape
+  shape-functions:
+    # rect() - Deprecated
+    # https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect
+    - match: \b(?i:rect)(?=\()
+      scope: meta.function-call.identifier.css support.function.shape.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - match: \b(?i:auto){{break}}
+              scope: support.constant.property-value.css
+            - include: calc-functions
+            - include: length-constants
+
+    # inset()
+    # https://www.w3.org/TR/css-shapes-1/#funcdef-inset
+    - match: \b(?i:inset)(?=\()
+      scope: meta.function-call.identifier.css support.function.shape.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - match: \b(?i:round){{break}}
+              scope: keyword.other.shape.css
+            - include: calc-functions
+            - include: length-constants
+            - include: percentage-constants
+
+    # circle()
+    # https://www.w3.org/TR/css-shapes-1/#funcdef-circle
+    # ellipse()
+    # https://www.w3.org/TR/css-shapes-1/#funcdef-ellipse
+    - match: \b(?i:circle|ellipse)(?=\()
+      scope: meta.function-call.identifier.css support.function.shape.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - match: \b(?i:at){{break}}
+              scope: keyword.other.shape.css
+            - match: \b(?i:top|right|bottom|left|center|closest-side|farthest-side){{break}}
+              scope: support.constant.property-value.css
+            - include: calc-functions
+            - include: length-constants
+            - include: percentage-constants
+
+    # polygon()
+    # https://www.w3.org/TR/css-shapes-1/#funcdef-polygon
+    - match: \b(?i:polygon)(?=\()
+      scope: meta.function-call.identifier.css support.function.shape.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:nonzero|evenodd){{break}}
+              scope: support.constant.property-value.css
+            - include: calc-functions
+            - include: length-constants
+            - include: percentage-constants
+
+###[ BUILTIN TIMING FUNCTIONS ]################################################
+
+  # Timing Functions
+  # https://www.w3.org/TR/web-animations-1/#timing-functions
+  timing-functions:
+    # cubic-bezier()
+    # https://www.w3.org/TR/web-animations-1/#cubic-bzier-timing-function
+    - match: \b(?i:cubic-bezier)(?=\()
+      scope: meta.function-call.identifier.css support.function.timing.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: scalar-constants
+
+    # steps()
+    # https://www.w3.org/TR/web-animations-1/#step-timing-function
+    - match: \b(?i:steps)(?=\()
+      scope: meta.function-call.identifier.css support.function.timing.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - match: \b(?i:end|middle|start){{break}}
+              scope: keyword.other.timing.css
+            - include: scalar-integer-constants
+
+###[ BUILTIN TRANSFORM FUNCTIONS ]#############################################
+
+  # Transform Functions
+  # https://www.w3.org/TR/css-transforms-1/#transform-functions
+  transform-functions:
+    # transform functions with comma separated <number> types
+    # matrix(), scale(), matrix3d(), scale3d()
+    - match: \b(?i:matrix3d|scale3d|matrix|scale)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: scalar-constants
+
+    # transform functions with comma separated <number> or <length> types
+    # translate(), translate3d()
+    - match: \b(?i:translate(3d)?)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: percentage-constants
+            - include: length-constants
+            - include: scalar-constants
+
+    # transform functions with a single <number> or <length> type
+    # translateX(), translateY()
+    - match: \b(?i:translate[XY])(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: percentage-constants
+            - include: length-constants
+            - include: scalar-constants
+
+    # transform functions with a single <angle> type
+    # rotate(), skewX(), skewY(), rotateX(), rotateY(), rotateZ()
+    - match: \b(?i:rotate[XYZ]?|skew[XY])(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: angle-constants
+
+    # transform functions with comma separated <angle> types
+    # skew()
+    - match: \b(?i:skew)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: angle-constants
+
+    # transform functions with a single <length> type
+    # translateZ(), perspective()
+    - match: \b(?i:translateZ|perspective)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: length-constants
+
+    # transform functions with a comma separated <number> or <angle> types
+    # rotate3d()
+    - match: \b(?i:rotate3d)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: angle-constants
+            - include: scalar-constants
+
+    # transform functions with a single <number> type
+    # scaleX(), scaleY(), scaleZ()
+    - match: \b(?i:scale[XYZ])(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: scalar-constants
+
+###[ BUILTIN VALUE FUNCTIONS ]#################################################
+
+  # attr()
+  # https://www.w3.org/TR/css3-values/#funcdef-attr
+  attr-functions:
+    - match: \b(?i:attr)(?=\()
+      scope: meta.function-call.identifier.css support.function.attr.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - attr-function-arguments-value
+            - attr-function-arguments-identifier
+
+  attr-function-arguments-identifier:
+    - include: namespace-prefixes
+    - include: quoted-string
+    - include: var-function
+    - match: '{{ident}}'
+      scope: entity.other.attribute-name.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+  attr-function-arguments-value:
+    - meta_scope: meta.function-call.arguments.css meta.group.css
+    - include: function-arguments-common
+    - include: comma-delimiters
+    - match: '{{units}}'
+      scope: keyword.other.unit.css
+    - include: color-values
+    - include: common-constants
+    - include: generic-font-names
+    - include: numeric-constants
+
+  calc-functions:
+    # calc()
+    # https://www.w3.org/TR/css3-values/#funcdef-calc
+    - match: \b(?i:calc)(?=\()
+      scope: meta.function-call.identifier.css support.function.calc.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: calc-function-arguments-content
+
+    # clamp()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/clamp()
+    # max()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/max()
+    # min()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/min()
+    - match: \b(?i:clamp|max|min)(?=\()
+      scope: meta.function-call.identifier.css support.function.calc.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: calc-function-arguments-content
+            - include: comma-delimiters
+
+  calc-function-arguments-content:
+    - meta_scope: meta.group.css
+    - match: \)
+      scope: punctuation.section.group.end.css
+      set: maybe-illegal-operator
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      push: calc-function-arguments-content
+    - include: terminator-pop
+    - include: comments
+    - include: attr-functions
+    - include: calc-functions
+    - include: var-functions
+    - match: '{{float}}({{units}})?'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+      push: maybe-illegal-operator
+    - match: '{{integer}}({{units}})?'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+      push: maybe-illegal-operator
+    - match: '[-+*/]'
+      scope: keyword.operator.arithmetic.css
+
+  toggle-functions:
+    # toggle()
+    # https://www.w3.org/TR/css3-values/#toggle-notation
+    - match: \b(?i:toggle)(?=\()
+      scope: meta.function-call.identifier.css support.function.toggle.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: vendor-prefixes
+            - include: color-values
+            - include: common-constants
+            - include: numeric-constants
+            - include: quoted-strings
+
+  # url()
+  # https://drafts.csswg.org/css-values-3/#urls
+  url-functions:
+    - match: \b(?i:url)(?=\()
+      scope: meta.function-call.identifier.css support.function.url.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-urls
+            - include: unquoted-urls
+
+  # var()
+  # https://drafts.csswg.org/css-variables/#funcdef-var
+  # Note: Match valid groups before `var-functions` context is included.
+  var-functions:
+    - match: \b(?i:var)(?=\()
+      scope: meta.function-call.identifier.css support.function.var.css
+      push: var-function-arguments
+
+  var-function:
+    - match: \b(?i:var)(?=\()
+      scope: meta.function-call.identifier.css support.function.var.css
+      set: var-function-arguments
+
+  var-function-arguments:
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      set:
+        - var-function-arguments-defaults
+        - var-function-arguments-identifier
+
+  var-function-arguments-defaults:
+    - meta_scope: meta.function-call.arguments.css meta.group.css
+    - include: group-end
+    - include: font-property-value-content
+
+  var-function-arguments-identifier:
+    - match: '{{custom_ident}}'
+      scope: variable.other.custom-property.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+###[ OTHER FUNCTIONS ]#########################################################
+
+  other-functions:
+    - match: '{{ident}}(?=\()'
+      scope: meta.function-call.identifier.css variable.function.css
+      push: other-functions-arguments
+
+  other-functions-arguments:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      set:
+        - meta_scope: meta.function-call.arguments.css meta.group.css
+        - include: function-arguments-common
+        - include: comma-delimiters
+        - include: calc-functions
+        - include: quoted-strings
+        - include: numeric-constants
+        - include: other-constants
+
+###[ CONSTANTS ]###############################################################
+
+  color-constants:
+    # https://www.w3.org/TR/CSS22/syndata.html#color-units
+    - match: '{{standard_colors}}'
+      scope: support.constant.color.w3c.standard.css
+    # https://www.w3.org/TR/css3-color/#svg-color
+    - match: '{{extended_colors}}'
+      scope: support.constant.color.w3c.extended.css
+    # Special Color Keywords
+    # https://www.w3.org/TR/css3-color/#currentcolor
+    # https://www.w3.org/TR/css3-color/#transparent-def
+    - match: \b(?i:currentColor|transparent){{break}}
+      scope: support.constant.color.w3c.special.css
+    # Hex Color
+    - match: (#)(\h{3}|\h{6}){{break}}
+      scope: constant.other.color.rgb-value.css
+      captures:
+        1: punctuation.definition.constant.css
+    # RGBA Hexadecimal Colors
+    # https://en.wikipedia.org/wiki/RGBA_color_space#RGBA_hexadecimal_.28word-order.29
+    - match: (#)(\h{4}|\h{8}){{break}}
+      scope: constant.other.color.rgba-value.css
+      captures:
+        1: punctuation.definition.constant.css
+
+  common-constants:
+    - match: '{{property_value_constants}}'
+      scope: support.constant.property-value.css
+
+  counter-speak-as-constants:
+    - match: '{{counter_speak_as_constants}}'
+      scope: support.constant.property-value.css
+
+  counter-system-constants:
+    - match: '{{counter_system_constants}}'
+      scope: support.constant.symbol-type.css
+
+  direction-constants:
+    - match: \b(ltr|rtl){{break}}
+      scope: support.constant.property-value.css
+
+  # Generic Font Families
+  # https://drafts.csswg.org/css-fonts-3/#family-name-value
+  generic-font-names:
+    - match: '{{font_family_constants}}'
+      scope: support.constant.property-value.css
+
+  grid-constants:
+    - match: \b(?i:auto|max-content|min-content){{break}}
+      scope: support.constant.property-value.css
+
+  other-constants:
+    - match: '{{ident}}'
+      scope: constant.other.css
+
+###[ NUMERIC CONSTANTS ]#######################################################
+
+  # https://www.w3.org/TR/css3-values/#numeric-constantss
+  numeric-constants:
+    - match: '{{float}}({{units}})?'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{units}})?'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  # Make sure `scalar-constants` is included after any other numeric values
+  # as `scalar-constants` will consume all numeric values.
+  scalar-constants:
+    - include: scalar-float-constants
+    - include: scalar-integer-constants
+
+  scalar-float-constants:
+    - match: '{{float}}'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+
+  scalar-integer-constants:
+    - match: '{{integer}}'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+
+  scalar-rational-constants:
+    - match: \d+(/)\d+
+      scope: meta.number.rational.css constant.numeric.value.css
+      captures:
+        1: keyword.operator.arithmetic.css
+
+  angle-constants:
+    - match: '{{float}}({{angle_units}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{angle_units}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+    - match: \b0\b(?!%)
+      scope: meta.number.integer.decimal.css constant.numeric.value.css
+
+  frequency-constants:
+    - match: '{{float}}({{frequency_units}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{frequency_units}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  length-constants:
+    - match: '{{float}}({{font_relative_lengths}}|{{viewport_percentage_lengths}}|{{absolute_lengths}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{font_relative_lengths}}|{{viewport_percentage_lengths}}|{{absolute_lengths}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+    - match: \b0\b(?!%)
+      scope: meta.number.integer.decimal.css constant.numeric.value.css
+
+  resolution-constants:
+    - match: '{{float}}({{resolution_units}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{resolution_units}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  percentage-constants:
+    - match: '{{float}}(%)'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}(%)'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  time-constants:
+    - match: '{{float}}({{duration_units}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{duration_units}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  # Unicode Ranges
+  # https://www.w3.org/TR/css-syntax-3/#urange
+  unicode-ranges:
+    - match: ([Uu]\+)([\h?]{1,6}(?:(-)\h{1,6})?)
+      scope: meta.number.unicode-range.css
+      captures:
+        1: constant.numeric.prefix.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.range.css
+
+###[ STRING CONSTANTS ]########################################################
+
+  # Font Family Names
+  # https://drafts.csswg.org/css-fonts-3/#family-name-value
+  font-family-names:
+    - match: '{{ident}}(?:\s+{{ident}}(?!\())*'
+      scope: meta.string.css string.unquoted.css
+
+  # Language Ranges
+  # https://drafts.csswg.org/selectors-4/#language-range
+  language-ranges:
+    - match: (?={{nmstart}}|\*)
+      push:
+        - meta_include_prototype: false
+        - meta_scope: meta.string.css string.unquoted.css
+        - include: string-content
+        - match: \*
+          scope: variable.language.wildcard.asterisk.css
+        - match: (?!{{nmchar}})
+          pop: 1
+
+  # Named Grid Lines
+  # https://drafts.csswg.org/css-grid/#named-lines
+  line-names:
+    - match: \[
+      scope: punctuation.section.brackets.begin.css
+      push: line-names-content
+
+  line-names-content:
+    - meta_scope: meta.line-names.css meta.brackets.css
+    - match: \]
+      scope: punctuation.section.brackets.end.css
+      pop: 1
+    - match: '{{ident}}'
+      scope: meta.string.css string.unquoted.line-name.css
+    - include: terminator-pop
+
+  quoted-strings:
+    - match: \"
+      scope: punctuation.definition.string.begin.css
+      push: double-quoted-string-content
+    - match: \'
+      scope: punctuation.definition.string.begin.css
+      push: single-quoted-string-content
+
+  quoted-string:
+    - match: \"
+      scope: punctuation.definition.string.begin.css
+      set: double-quoted-string-content
+    - match: \'
+      scope: punctuation.definition.string.begin.css
+      set: single-quoted-string-content
+
+  double-quoted-string-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.css string.quoted.double.css
+    - match: \"
+      scope: punctuation.definition.string.end.css
+      pop: 1
+    - include: string-content
+
+  single-quoted-string-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.css string.quoted.single.css
+    - match: \'
+      scope: punctuation.definition.string.end.css
+      pop: 1
+    - include: string-content
+
+  string-content:
+    - meta_include_prototype: false
+    - match: \n
+      scope: invalid.illegal.newline.css
+      pop: 1
+    - match: \\\s*\n
+      scope: constant.character.escape.newline.css
+    - match: \\(?:\h{1,6}|.)
+      scope: constant.character.escape.css
+    - include: Sass.sublime-syntax#sass-interpolation
+
+###[ URL STRING CONSTANTS ]####################################################
+
+  quoted-urls:
+    - match: \"
+      scope:
+        meta.string.css string.quoted.double.css
+        punctuation.definition.string.begin.css
+      push: double-quoted-url-content
+    - match: \'
+      scope:
+        meta.string.css string.quoted.single.css
+        punctuation.definition.string.begin.css
+      push: single-quoted-url-content
+
+  double-quoted-url-content:
+    - meta_include_prototype: false
+    - meta_content_scope:
+        meta.path.url.css
+        meta.string.css string.quoted.double.css
+    - match: \"
+      scope:
+        meta.string.css string.quoted.double.css
+        punctuation.definition.string.end.css
+      pop: 1
+    - include: string-content
+    - include: url-content
+
+  single-quoted-url-content:
+    - meta_include_prototype: false
+    - meta_content_scope:
+        meta.path.url.css
+        meta.string.css string.quoted.single.css
+    - match: \'
+      scope:
+        meta.string.css string.quoted.single.css
+        punctuation.definition.string.end.css
+      pop: 1
+    - include: string-content
+    - include: url-content
+
+  # Unquoted URL token
+  # https://drafts.csswg.org/css-syntax-3/#consume-a-url-token
+  unquoted-urls:
+    - match: (?=[[:alnum:]/])
+      push: unquoted-url-content
+
+  unquoted-url-content:
+    - meta_include_prototype: false
+    - meta_content_scope:
+        meta.path.url.css
+        meta.string.css string.unquoted.css
+    - match: '["''(]'
+      scope: invalid.illegal.unexpected-token.css
+      set:
+        - meta_include_prototype: false
+        - match: (?=\))
+          pop: 1
+        - include: string-content
+    - match: (?=\))
+      pop: 1
+    - include: url-content
+
+  url-content:
+    - include: string-content
+    - match: (%)\h{2}
+      scope: constant.character.escape.url.css
+      captures:
+        1: punctuation.definition.escape.css
+    - match: '[/&?#]|://'
+      scope: punctuation.separator.path.css
+
+###[ OPERATORS ]###############################################################
+
+  common-operators:
+    - match: \!\s*(?i:important){{break}}
+      scope: keyword.other.important.css
+    - match: /
+      scope: keyword.operator.arithmetic.css
+
+  color-adjuster-operators:
+    - match: '[-+*](?=\s)'
+      scope: keyword.operator.arithmetic.css
+    - match: '[-+*/]'
+      scope: invalid.illegal.operator.css
+
+  maybe-illegal-operator:
+    - match: '[-+](?=\s*\d)'
+      scope: invalid.illegal.operator.css
+      pop: 1
+    - match: \s*([-+])(?=\d)
+      captures:
+        1: invalid.illegal.operator.css
+      pop: 1
+    - include: immediately-pop
+
+###[ PUNCTUATION ]#############################################################
+
+  comma-delimiters:
+    - match: ','
+      scope: punctuation.separator.sequence.css
+
+  block-end2:
+    - match: \}
+      scope: punctuation.section.block.end.css
+      pop: 2
+
+  group-end:
+    - match: \)
+      scope: punctuation.section.group.end.css
+      pop: 1
+
+  rule-terminators:
+    - match: ;
+      scope: punctuation.terminator.rule.css
+
 ###[ PROTOTYPES ]##############################################################
+
+  else-pop:
+    - match: (?=\S)
+      pop: 1
+
+  immediately-pop:
+    - match: ''
+      pop: 1
 
   terminator-pop:
     - match: '\s*(?=$)'

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -1911,6 +1911,7 @@ contexts:
     - include: terminator-pop
     - include: comments
     - include: var-functions
+    - include: builtin-values
     - include: sass-value-expression
 
 ###[ BUILTIN AT RULE FUNCTIONS ]###############################################

--- a/Syntaxes/SCSS.sublime-syntax
+++ b/Syntaxes/SCSS.sublime-syntax
@@ -679,6 +679,7 @@ contexts:
         1: keyword.control.at-rule.content.sass
         2: punctuation.definition.keyword.sass
       push:
+        - include: terminator-pop
         - match: '\s*(?=$)'
           pop: 1
 
@@ -703,8 +704,29 @@ contexts:
               scope: punctuation.section.group.end.css
               pop: 1
             - include: quoted-strings
-        - match: '\s*(?=$)'
-          scope: punctuation.terminator.rule.sass
+        - match: '\s*(\{)'
+          captures:
+            1: punctuation.section.block.begin.css
+          push:
+            - meta_scope: meta.group.css-modules.css
+            - match: '\}'
+              scope: punctuation.section.block.end.css
+              pop: 1
+            - include: Sass.sublime-syntax#comments
+            - match: '([a-zA-Z0-9_-]+)\s*(:)'
+              captures:
+                1: meta.property-name.css-modules.css support.type.property-name.css-modules.css
+                2: punctuation.separator.key-value.css
+                3: variable.other.css-modules.css
+              push:
+                - match: '(;|\s*(?=$))'
+                  captures:
+                    1: punctuation.terminator.rule.css
+                  pop: 1
+                - include: Sass.sublime-syntax#quoted-strings
+                - match: '\b[^\s''"]+\b'
+                  scope: string.unquoted.css
+        - match: ''
           pop: 1
 
     - include: comments
@@ -713,6 +735,10 @@ contexts:
     - include: at-rules
     - include: rule-list-body
     - include: Sass.sublime-syntax#sass-interpolated-selectors
+    - match: \{
+      scope: punctuation.section.block.begin.css
+    - match: \}
+      scope: punctuation.section.block.end.css
 
 ###[ COMMENTS ]################################################################
 
@@ -1377,6 +1403,7 @@ contexts:
             - match: '\)'
               scope: punctuation.section.group.end.css
               pop: 1
+            - include: selectors
             - include: quoted-strings
         - match: ''
           pop: 1
@@ -1619,7 +1646,7 @@ contexts:
         0: support.type.property-name
       push:
         - meta_scope: meta.property-name.css
-        - include: sass-interpolation
+        - include: Sass.sublime-syntax#sass-interpolation
         - match: '[a-zA-Z0-9_-]*'
           captures:
             0: support.type.property-name

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -168,10 +168,11 @@ variables:
   html_web_tags: |-
     \b(?xi: slot | template ){{break}}
 
+  # removed the content tag because it's also a property and that mucks up the logic
   html_deprecated_tags: |-
     \b(?xi:
         acronym | applet | basefont | bgsound | big | blink | center | command
-      | content | dir | element | font | frame | frameset | image | isindex
+      | dir | element | font | frame | frameset | image | isindex
       | keygen | listing | marquee | menuitem | multicol | nextid | nobr
       | noembed | noframes | plaintext | shadow | spacer | strike | tt | xmp
     ){{break}}
@@ -633,25 +634,23 @@ variables:
       normal | bold | bolder | lighter | italic | oblique | small-caps
     ){{break}}
 
+###[ PSEUDO SELECTORS FOR SASS ]###############################################
+  pseudo_elements: |-
+    (?x:
+        (:{1,2})(?:before|after|first-line|first-letter) # CSS1 & CSS2 require : or ::
+      | (::)(-(?:moz|ms|webkit)-)?(?:{{ident}}) # CSS3 requires ::
+    ){{break}}
+
+  regular_pseudo_classes: '\b(active|any-link|blank|checked|current|default|defined|disabled|drop|empty|enabled|first|first-child|first-of-type|fullscreen|future|focus|focus-visible|focus-within|host|hover|indeterminate|in-range|invalid|last-child|last-of-type|left|link|local-link|only-child|only-of-type|optional|out-of-range|past|placeholder-shown|read-only|read-write|required|right|root|scope|target|target-within|user-invalid|valid|visited)\b(?![-])'
+  functional_pseudo_classes: '\b(dir|lang|matches|not|has|drop|nth-last-child|nth-child|nth-last-of-type|nth-of-type){{break}}'
+
+
 ###############################################################################
 
 contexts:
   main:
     - match: '\{|\}|;'
       scope: invalid.illegal.sass
-    - include: frontmatter
-    - include: comments
-    - include: sass-mixin-directives
-    - include: selectors
-    - include: interpolated-selectors
-    - include: at-rules
-    - include: property-lists
-    - include: illegal-groups
-    - include: css-modules
-
-###[ COMMENTS ]################################################################
-
-  frontmatter:
     - match: '^---$'
       scope: frontmatter.jekyll punctuation.section.frontmatter.begin.jekyll
       embed: scope:source.yaml
@@ -659,6 +658,16 @@ contexts:
       escape: '^---$'
       escape_captures:
         0: frontmatter.jekyll punctuation.section.frontmatter.end.jekyll
+    - include: comments
+    - include: sass-mixins
+    - include: selectors
+    - include: interpolated-selectors
+    - include: at-rules
+    - include: rule-list-body
+    - include: illegal-groups
+    # - include: css-modules # need to re-implement?
+
+###[ COMMENTS ]################################################################
 
   comments:
     - include: comment-block
@@ -701,200 +710,6 @@ contexts:
     - include: at-page-margin
     - include: at-supports
     - include: at-other
-
-  sass-at-rules:
-    - match: '(@)(each){{break}}'
-      captures:
-        0: keyword.control.flow.sass
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.each.sass
-        - include: sass-variables
-        - include: comma-delimiter
-        - match: '(?=$)'
-          pop: true
-        - match: \b(in){{break}}
-          scope: keyword.operator.sass
-          push:
-            - match: '(?=$)'
-              pop: true
-            - include: comment-block
-            - include: comment-line
-            - include: comma-delimiter
-            - include: var-function
-            - include: sass-variables
-            - include: sass-functions
-            - include: sass-custom-functions
-            - include: sass-interpolation
-            - include: sass-maps
-            - include: unquoted-string
-            - include: sass-operators
-    - match: '(@)(for|while){{break}}'
-      captures:
-        0: keyword.control.flow.sass
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '(?=$)'
-          pop: true
-        - include: sass-script-expression
-    - match: '(@)(if|else if|else){{break}}'
-      captures:
-        0: keyword.control.flow.conditional.sass
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '(?=$)'
-          pop: true
-        - include: sass-script-expression
-    - match: '(@)(warn|error){{break}}'
-      captures:
-        0: keyword.control.at-rule.warn.sass
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '(?=$)'
-          pop: true
-        - include: sass-script-expression
-    - match: '(@)(debug){{break}}'
-      captures:
-        0: keyword.control.at-rule.debugger.sass
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '(?=$)'
-          pop: true
-        - include: sass-script-expression
-    - match: '(@)(at-root){{break}}'
-      captures:
-        0: keyword.control.directive.at-root.sass
-        1: punctuation.definition.keyword.sass
-    - match: '(@)(extend){{break}}'
-      captures:
-        0: keyword.control.directive.extend.sass
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.extend.sass
-        - match: '(?=$)'
-          pop: true
-        - match: \!\s*(default|global|optional){{break}}
-          scope: keyword.other.sass
-        - include: selectors
-        - include: custom-element-selectors
-    - match: '((@)(mixin|function))\s+([\w-]+)'
-      captures:
-        1: keyword.control.directive.sass
-        2: punctuation.definition.keyword.sass
-        4: entity.name.function.sass
-      push:
-        - meta_scope: meta.function.declaration.sass
-        - match: '\s*(?=$)'
-          pop: true
-        - match: '\('
-          scope: punctuation.definition.group.begin.sass
-          push:
-            - meta_scope: meta.function.parameters.sass
-            - match: '\)'
-              scope: punctuation.definition.group.end.sass
-              pop: true
-            - include: comma-delimiter
-            - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
-              scope: variable.parameter.sass
-              captures:
-                1: punctuation.definition.variable.sass
-              push:
-                - match: '(?=[,\)])'
-                  pop: true
-                - match: ':'
-                  scope: punctuation.separator.key-value.css
-                - match: '\b(false|true|null)\b'
-                  scope: constant.language.sass
-                - include: property-values
-    - match: '((@)(include))\s+(([a-z]+)(\.))?([\w-]+)'
-      captures:
-        0: variable.function.sass
-        1: keyword.control.directive.sass
-        2: punctuation.definition.keyword.sass
-        5: entity.name.namespace.sass
-        6: punctuation.separator.namespace.sass
-      push:
-        - meta_scope: meta.function-call.sass
-        - match: '\s*(?=$)'
-          pop: true
-        - match: '\('
-          scope: punctuation.definition.group.begin.sass
-          push:
-            - meta_scope: meta.function-call.arguments.sass
-            - include: comment-block
-            - include: comment-line
-            - include: sass-variables
-            - include: sass-functions
-            - include: sass-operators
-            - include: comma-delimiter
-            - include: property-values
-            - include: literal-string
-            - match: '{{ident}}'
-              scope: string.unquoted.sass
-            - include: selectors
-            - include: custom-element-selectors
-            - match: '\)'
-              scope: punctuation.definition.group.end.sass
-              pop: true
-    - match: '(@)(return){{break}}'
-      captures:
-        0: keyword.control.directive.return.sass
-        1: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.sass
-        - match: '\s*(?=$)'
-          pop: true
-        - include: property-values
-    - match: '\s*((@)(use|forward){{break}})\s*'
-      captures:
-        1: keyword.control.directive.module.sass
-        2: punctuation.definition.keyword.sass
-      push:
-        - meta_scope: meta.at-rule.module.sass
-        - match: '\s*(?=$)'
-          scope: punctuation.terminator.rule.sass
-          pop: true
-        - match: '\b(as)\b\s+([a-zA-Z0-9_-]*(\*)?)'
-          captures:
-            1: keyword.control.as.sass
-            2: meta.generic-name.sass
-            3: constant.language.import-all.sass
-        - match: '\b(show|hide)\b'
-          scope: keyword.control.show-hide.sass
-          push:
-            - match: '(?=$)'
-              pop: true
-            - include: comment-block
-            - include: sass-variables
-            - include: sass-functions
-            - include: sass-operators
-            - include: comma-delimiter
-            - match: '{{ident}}'
-              scope: meta.generic-name.sass
-        - match: '(with)\s+(\()'
-          captures:
-            1: keyword.control.with.sass
-            2: punctuation.definition.group.begin.sass
-          push:
-            - match: '\)(?=$)'
-              scope: punctuation.definition.group.end.sass
-              pop: true
-            - match: ':'
-              scope: punctuation.separator.key-value.css
-            - include: comment-block
-            - include: comment-line
-            - include: sass-variables
-            - include: sass-functions
-            - include: sass-operators
-            - include: comma-delimiter
-            - include: property-values
-        - include: comment-block
-        - include: comment-line
-        - include: literal-string
 
   # @charset
   # https://www.w3.org/TR/css-syntax-3/#at-ruledef-charset
@@ -1073,7 +888,7 @@ contexts:
     - meta_scope: meta.block.css
     - include: block-end2
     - include: comments
-    - include: property-lists
+    # - include: property-lists
     - include: at-keyframe-selectors
 
   at-keyframe-selectors:
@@ -1166,7 +981,6 @@ contexts:
     - include: block-end2
     - include: at-page-margin
     - include: at-other
-    - include: property-lists
     - include: rule-list-body
 
   # @top-center, ...
@@ -1249,7 +1063,6 @@ contexts:
     - match: (?=[;{}])
       pop: 1
     - include: comments
-
 
 ###[ MEDIA QUERIES ]###########################################################
 
@@ -1350,7 +1163,6 @@ contexts:
         ){{break}}
       scope: support.constant.media.css
 
-
 ###[ SELECTORS ]###############################################################
 
   # The original Sass syntax needs lookaheads for specific pseudo-classes
@@ -1358,53 +1170,33 @@ contexts:
   # or a property
 
   selectors:
-    - match: (?=[:.*#[:alpha:]\[]|{{combinators}})
-      push: selector-content
+    - match: (?=^\s*{{svg_tags}})
+      push:
+        - include: selector-content
+    - match: (?=^\s*{{html_tags}}(?![-:]))
+      push:
+        - include: selector-content
+    - match: (?=^\s*{{html_tags}}(?={{pseudo_elements}}))
+      push:
+        - include: selector-content
+    - match: (?=^\s*{{html_tags}}(?=:{{regular_pseudo_classes}}))
+      push:
+        - include: selector-content
+    - match: (?=^\s*{{html_tags}}(?=:({{functional_pseudo_classes}})\())
+      push:
+        - include: selector-content
+    - match: (?=^\s*{{html_tags}}(?=:(-(moz|ms|webkit)-){{ident}}))
+      push:
+        - include: selector-content
+    - match: (?=^\s*[#.:\[\*%>~+,&])
+      push:
+        - include: selector-content
 
   selector-content:
     - meta_scope: meta.selector.css
     - include: selector-end
     - include: comma-delimiters
-    # ampersand
-    - match: '\s*(&)'
-      captures:
-        1: keyword.operator.ampersand.sass
-      push:
-        - meta_scope: meta.selector.css
-        - match: '[-_]+'
-          scope: entity.other.attribute-name.css
-          push:
-            - match: '{{ident}}'
-              scope: entity.other.attribute-name.css
-            - include: sass-interpolation
-            - include: selector-parts
-        - include: selector-content
-    # # standard elements + pseudo elements
-    # - match: '\s*({{element_names}})(?={{pseudo_elements}})'
-    #   captures:
-    #     1: entity.name.tag.css
-    #   push:
-    #     - meta_scope: meta.selector.css
-    #     - include: selector-parts
-    # # standard elements + pseudoclasses
-    # - match: '\s*({{element_names}})(?=:{{regular_pseudo_classes}})'
-    #   captures:
-    #     1: entity.name.tag.css
-    #   push:
-    #     - meta_scope: meta.selector.css
-    #     - include: selector-parts
-    # - match: '\s*({{element_names}})(?=:({{functional_pseudo_classes}})\()'
-    #   captures:
-    #     1: entity.name.tag.css
-    #   push:
-    #     - meta_scope: meta.selector.css
-    #     - include: selector-parts
-    # - match: '\s*({{element_names}})(?=:(-(moz|ms|webkit)-){{ident}})'
-    #   captures:
-    #     1: entity.name.tag.css
-    #   push:
-    #     - meta_scope: meta.selector.css
-    #     - include: selector-parts
+    - include: sass-ampersand
 
     # Html Tags
     - match: '{{html_tags}}'
@@ -1498,50 +1290,6 @@ contexts:
   vendor-prefixes:
     - match: '{{vendor_prefix}}'
       scope: support.type.vendor-prefix.css
-
-###[ SASS INTERPOLATED SELECTORS ]#########################################
-
-  interpolated-selector-body:
-    - match: '({)'
-      scope: punctuation.definition.group.begin.sass
-      push:
-        - match: '(})'
-          scope: punctuation.definition.group.end.sass
-          pop: true
-        - include: sass-script-expression
-    - include: selector-parts
-
-  interpolated-selectors:
-    # - match: '\s*(#)(?={.*}{{pseudo_elements}})'
-    #   captures:
-    #     1: punctuation.definition.variable.sass
-    #   push:
-    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
-    #     - include: interpolated-selector-body
-    # - match: '\s*(#)(?={.*}:{{regular_pseudo_classes}})'
-    #   captures:
-    #     1: punctuation.definition.variable.sass
-    #   push:
-    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
-    #     - include: interpolated-selector-body
-    # - match: '\s*(#)(?={.*}:({{functional_pseudo_classes}})\()'
-    #   captures:
-    #     1: punctuation.definition.variable.sass
-    #   push:
-    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
-    #     - include: interpolated-selector-body
-    - match: '\s*(#)(?={.*}:(-(moz|ms|webkit)-){{ident}})'
-      captures:
-        1: punctuation.definition.variable.sass
-      push:
-        - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
-    - match: '\s*(#)(?={.*}(?![-:]))'
-      captures:
-        1: punctuation.definition.variable.sass
-      push:
-        - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
 
 ###[ SELECTORS / ATTRIBUTE SELECTORS ]#########################################
 
@@ -1724,7 +1472,8 @@ contexts:
   # between selectors and properties in Sass,
   # ie. there is no 'property list'
 
-  properties:
+  rule-list-body:
+    # Note: This context is used by HTML.sublime-syntax
     - include: comments
     - include: property-identifiers
     - include: property-values
@@ -1799,7 +1548,6 @@ contexts:
     - include: sass-maps
 
   builtin-values:
-    - include: sass-value-expression
     - include: quoted-strings
     - include: builtin-functions
     - include: color-values
@@ -1809,6 +1557,7 @@ contexts:
     - include: common-constants
     - include: generic-font-names
     - include: vendor-prefixes
+    - include: sass-value-expression
 
   # When including `color-values` and `color-adjuster-functions`, make sure it is
   # included after the color adjustors to prevent `color-values` from consuming
@@ -3395,33 +3144,17 @@ contexts:
     - match: (?=[;){}])
       pop: 1
 
-
 ###############################################################################
 ###[ Sass ]####################################################################
 ###############################################################################
 
-  sass-custom-functions:
-    - match: '\b(({{ident}})(\.))?([a-z_-]+)(?=\()'
-      scope: support.function.sass
-      captures:
-        2: entity.name.namespace.sass
-        3: punctuation.separator.namespace.sass
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-arguments
-
   sass-script-expression:
     - include: sass-value-expression
-    - include: color-values
-    - include: numeric-values
-    - match: '\b(false|true|null)\b'
-      scope: constant.language.sass
-    - include: literal-string
-    - include: unquoted-string
+    - include: builtin-values
 
   sass-value-expression:
     - include: comments
-    - include: comma-delimiter
+    - include: comma-delimiters
     - include: sass-maps
     - include: sass-variables
     - include: sass-functions
@@ -3467,7 +3200,17 @@ contexts:
         1: support.function.sass
       push:
         - meta_scope: meta.function-call.sass
-        - include: function-arguments
+        - include: function-arguments-common
+
+  sass-custom-functions:
+    - match: '\b(({{ident}})(\.))?([a-z_-]+)(?=\()'
+      scope: support.function.sass
+      captures:
+        2: entity.name.namespace.sass
+        3: punctuation.separator.namespace.sass
+      push:
+        - meta_scope: meta.function-call.css
+        - include: function-arguments-common
 
   sass-interpolation:
     - match: '(#)({)'
@@ -3490,43 +3233,7 @@ contexts:
       captures:
         1: keyword.operator.sass
 
-  sass-mixin-def:
-    - match: '\('
-      scope: punctuation.definition.group.begin.sass
-      push:
-        - meta_scope: meta.function.parameters.sass
-        - match: '\)'
-          scope: punctuation.definition.group.end.sass
-          pop: true
-        - include: comma-delimiter
-        - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
-          scope: variable.parameter.sass
-          captures:
-            1: punctuation.definition.variable.sass
-          push:
-            - match: '(?=[,\)])'
-              pop: true
-            - match: ':'
-              scope: punctuation.separator.key-value.css
-            - include: property-values
-
-  sass-mixin-call:
-    - match: '\('
-      scope: punctuation.definition.group.begin.sass
-      push:
-        - meta_scope: meta.function-call.arguments.sass
-        - include: sass-value-expression
-        - include: comma-delimiter
-        - include: property-values
-        - include: literal-string
-        - match: '{{ident}}'
-          scope: string.unquoted.sass
-        - include: selectors
-        - match: '\)'
-          scope: punctuation.definition.group.end.sass
-          pop: true
-
-  sass-mixin-directives:
+  sass-mixins:
     - match: '\s*((\=)([\w-]+))'
       captures:
         1: entity.name.function.sass
@@ -3535,7 +3242,24 @@ contexts:
         - meta_scope: meta.function.declaration.sass
         - match: '(?=$)'
           pop: true
-        - include: sass-mixin-def
+        - match: '\('
+          scope: punctuation.definition.group.begin.sass
+          push:
+            - meta_scope: meta.function.parameters.sass
+            - match: '\)'
+              scope: punctuation.definition.group.end.sass
+              pop: true
+            - include: comma-delimiters
+            - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
+              scope: variable.parameter.sass
+              captures:
+                1: punctuation.definition.variable.sass
+              push:
+                - match: '(?=[,\)])'
+                  pop: true
+                - match: ':'
+                  scope: punctuation.separator.key-value.css
+                - include: property-values
     - match: '\s*((\+)([\w-]+))'
       captures:
         1: variable.function.sass
@@ -3544,4 +3268,271 @@ contexts:
         - meta_scope: meta.function-call.sass
         - match: '(?=$)'
           pop: true
-        - include: sass-mixin-call
+        - match: '\('
+          scope: punctuation.definition.group.begin.sass
+          push:
+            - meta_scope: meta.function-call.arguments.sass
+            - include: sass-value-expression
+            - include: comma-delimiters
+            - include: property-values
+            - include: quoted-strings
+            - match: '{{ident}}'
+              scope: string.unquoted.sass
+            - include: selectors
+            - match: '\)'
+              scope: punctuation.definition.group.end.sass
+              pop: true
+
+###[ SASS AMPERSAND ]#########################################
+
+  sass-ampersand:
+    - match: '\s*(&)'
+      captures:
+        1: keyword.operator.ampersand.sass
+      push:
+        - meta_scope: meta.selector.css
+        - match: '[-_]+'
+          scope: entity.other.attribute-name.css
+          push:
+            - match: '{{ident}}'
+              scope: entity.other.attribute-name.css
+            - include: sass-interpolation
+            - include: selectors
+        - include: selector-content
+
+###[ SASS AT-RULE FUNCTIONS ]#########################################
+
+  sass-at-rules:
+    - match: '(@)(each){{break}}'
+      captures:
+        0: keyword.control.flow.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.each.sass
+        - include: sass-variables
+        - include: comma-delimiters
+        - match: '(?=$)'
+          pop: true
+        - match: \b(in){{break}}
+          scope: keyword.operator.sass
+          push:
+            - match: '(?=$)'
+              pop: true
+            - include: comment-block
+            - include: comment-line
+            - include: comma-delimiters
+            - include: var-function
+            - include: sass-variables
+            - include: sass-functions
+            - include: sass-custom-functions
+            - include: sass-interpolation
+            - include: sass-maps
+            - include: sass-operators
+    - match: '(@)(for|while){{break}}'
+      captures:
+        0: keyword.control.flow.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - match: '(?=$)'
+          pop: true
+        - include: sass-script-expression
+    - match: '(@)(if|else if|else){{break}}'
+      captures:
+        0: keyword.control.flow.conditional.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - match: '(?=$)'
+          pop: true
+        - include: sass-script-expression
+    - match: '(@)(warn|error){{break}}'
+      captures:
+        0: keyword.control.at-rule.warn.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - match: '(?=$)'
+          pop: true
+        - include: sass-script-expression
+    - match: '(@)(debug){{break}}'
+      captures:
+        0: keyword.control.at-rule.debugger.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - match: '(?=$)'
+          pop: true
+        - include: sass-script-expression
+    - match: '(@)(at-root){{break}}'
+      captures:
+        0: keyword.control.directive.at-root.sass
+        1: punctuation.definition.keyword.sass
+    - match: '(@)(extend){{break}}'
+      captures:
+        0: keyword.control.directive.extend.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.extend.sass
+        - match: '(?=$)'
+          pop: true
+        - match: \!\s*(default|global|optional){{break}}
+          scope: keyword.other.sass
+        - include: selectors
+    - match: '((@)(mixin|function))\s+([\w-]+)'
+      captures:
+        1: keyword.control.directive.sass
+        2: punctuation.definition.keyword.sass
+        4: entity.name.function.sass
+      push:
+        - meta_scope: meta.function.declaration.sass
+        - match: '\s*(?=$)'
+          pop: true
+        - match: '\('
+          scope: punctuation.definition.group.begin.sass
+          push:
+            - meta_scope: meta.function.parameters.sass
+            - match: '\)'
+              scope: punctuation.definition.group.end.sass
+              pop: true
+            - include: comma-delimiters
+            - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
+              scope: variable.parameter.sass
+              captures:
+                1: punctuation.definition.variable.sass
+              push:
+                - match: '(?=[,\)])'
+                  pop: true
+                - match: ':'
+                  scope: punctuation.separator.key-value.css
+                - match: '\b(false|true|null)\b'
+                  scope: constant.language.sass
+                - include: property-values
+    - match: '((@)(include))\s+(([a-z]+)(\.))?([\w-]+)'
+      captures:
+        0: variable.function.sass
+        1: keyword.control.directive.sass
+        2: punctuation.definition.keyword.sass
+        5: entity.name.namespace.sass
+        6: punctuation.separator.namespace.sass
+      push:
+        - meta_scope: meta.function-call.sass
+        - match: '\s*(?=$)'
+          pop: true
+        - match: '\('
+          scope: punctuation.definition.group.begin.sass
+          push:
+            - meta_scope: meta.function-call.arguments.sass
+            - include: comment-block
+            - include: comment-line
+            - include: sass-variables
+            - include: sass-functions
+            - include: sass-operators
+            - include: comma-delimiters
+            - include: property-values
+            - include: quoted-strings
+            - match: '{{ident}}'
+              scope: string.unquoted.sass
+            - include: selectors
+            - match: '\)'
+              scope: punctuation.definition.group.end.sass
+              pop: true
+    - match: '(@)(return){{break}}'
+      captures:
+        0: keyword.control.directive.return.sass
+        1: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.sass
+        - match: '\s*(?=$)'
+          pop: true
+        - include: property-values
+    - match: '\s*((@)(use|forward){{break}})\s*'
+      captures:
+        1: keyword.control.directive.module.sass
+        2: punctuation.definition.keyword.sass
+      push:
+        - meta_scope: meta.at-rule.module.sass
+        - match: '\s*(?=$)'
+          scope: punctuation.terminator.rule.sass
+          pop: true
+        - match: '\b(as)\b\s+([a-zA-Z0-9_-]*(\*)?)'
+          captures:
+            1: keyword.control.as.sass
+            2: meta.generic-name.sass
+            3: constant.language.import-all.sass
+        - match: '\b(show|hide)\b'
+          scope: keyword.control.show-hide.sass
+          push:
+            - match: '(?=$)'
+              pop: true
+            - include: comment-block
+            - include: sass-variables
+            - include: sass-functions
+            - include: sass-operators
+            - include: comma-delimiters
+            - match: '{{ident}}'
+              scope: meta.generic-name.sass
+        - match: '(with)\s+(\()'
+          captures:
+            1: keyword.control.with.sass
+            2: punctuation.definition.group.begin.sass
+          push:
+            - match: '\)(?=$)'
+              scope: punctuation.definition.group.end.sass
+              pop: true
+            - match: ':'
+              scope: punctuation.separator.key-value.css
+            - include: comment-block
+            - include: comment-line
+            - include: sass-variables
+            - include: sass-functions
+            - include: sass-operators
+            - include: comma-delimiters
+            - include: property-values
+        - include: comment-block
+        - include: comment-line
+        - include: quoted-strings
+
+###[ SASS INTERPOLATED SELECTORS ]#########################################
+
+  interpolated-selector-body:
+    - match: '({)'
+      scope: punctuation.definition.group.begin.sass
+      push:
+        - match: '(})'
+          scope: punctuation.definition.group.end.sass
+          pop: true
+        - include: sass-script-expression
+    - include: selector-content
+
+  interpolated-selectors:
+    # - match: '\s*(#)(?={.*}{{pseudo_elements}})'
+    #   captures:
+    #     1: punctuation.definition.variable.sass
+    #   push:
+    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
+    #     - include: interpolated-selector-body
+    # - match: '\s*(#)(?={.*}:{{regular_pseudo_classes}})'
+    #   captures:
+    #     1: punctuation.definition.variable.sass
+    #   push:
+    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
+    #     - include: interpolated-selector-body
+    # - match: '\s*(#)(?={.*}:({{functional_pseudo_classes}})\()'
+    #   captures:
+    #     1: punctuation.definition.variable.sass
+    #   push:
+    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
+    #     - include: interpolated-selector-body
+    - match: '\s*(#)(?={.*}:(-(moz|ms|webkit)-){{ident}})'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: interpolated-selector-body
+    - match: '\s*(#)(?={.*}(?![-:]))'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: interpolated-selector-body

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1247,7 +1247,7 @@ contexts:
 
   selectors:
     - include: sass-interpolated-selectors
-    - match: (?=\s*{{svg_tags}})
+    - match: (?=\s*{{svg_tags}}(?!-|\s*:))
       push:
         - meta_scope: meta.selector.css
         - include: selector-content

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -73,7 +73,8 @@ variables:
 
   # Custom Element Names
   # https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts
-  custom_element_tags: \b[a-z]{{custom_element_chars}}*-{{custom_element_chars}}*{{break}}
+  # adjusted from CSS so it doesn't match on interpolation (#{)
+  custom_element_tags: \b[a-z]{{custom_element_chars}}*-{{custom_element_chars}}*(?!#{){{break}}
   # Note: Excludes `.` as it is used to identify attribute access
   custom_element_chars: |-
     (?x:
@@ -713,9 +714,9 @@ contexts:
     - include: comments
     - include: sass-mixins
     - include: selectors
-    - include: sass-interpolated-selectors
     - include: at-rules
     - include: rule-list-body
+    - include: sass-interpolated-selectors
 
 ###[ COMMENTS ]################################################################
 
@@ -1604,8 +1605,29 @@ contexts:
 ###[ PROPERTY IDENTIFIERS ]####################################################
 
   property-identifiers:
+    # Sass nested property names
+    # Partial property names, split at "-"
+    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
+    - match: '[a-zA-Z0-9_-]*(?=#{)'
+      captures:
+        0: support.type.property-name
+      push:
+        - meta_scope: meta.property-name.css
+        - include: sass-interpolation
+        - match: '[a-zA-Z0-9_-]*'
+          captures:
+            0: support.type.property-name
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
     - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
       push: property-identifier-content
+    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
+      scope: meta.property-name.css support.type.property-name.css
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
 
   property-identifier-content:
     - meta_scope: meta.property-name.css
@@ -1641,28 +1663,6 @@ contexts:
     - match: ':'
       scope: punctuation.separator.key-value.css
       push: property-value-content
-    # Sass nested property names
-    # Partial property names, split at "-"
-    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
-    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - include: push-to-value
-        - match: '\s*(?=$)'
-          pop: true
-    - match: '[a-zA-Z0-9_-]*((#)({)((\$)([a-zA-Z0-9_-][\w-]*))(}))[a-zA-Z0-9_-]*'
-      captures:
-        0: meta.property-name.css support.type.property-name
-        1: meta.group.interpolation.sass
-        2: punctuation.definition.variable.sass
-        3: punctuation.section.group.begin.sass
-        4: variable.other.sass
-        5: punctuation.definition.variable.sass
-        7: punctuation.section.group.end.sass
-      push:
-        - include: push-to-value
-        - match: '\s*(?=$)'
-          pop: true
 
   property-value-content:
     - meta_content_scope: meta.property-value.css

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -671,6 +671,15 @@ contexts:
         - match: '\s*(?=$)'
           pop: true
 
+    # Sass content at-rule
+    - match: '((@)content){{break}}'
+      captures:
+        1: keyword.control.at-rule.content.sass
+        2: punctuation.definition.keyword.sass
+      push:
+        - match: '\s*(?=$)'
+          pop: true
+
     # CSS modules
     - match: '\b(composes)\b'
       scope: meta.property-name.css-modules.css support.type.property-name

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1170,26 +1170,37 @@ contexts:
   # or a property
 
   selectors:
-    - match: (?=^\s*{{svg_tags}})
+    - match: (?=\s*{{svg_tags}})
       push:
+        - meta_scope: meta.selector.css
         - include: selector-content
-    - match: (?=^\s*{{html_tags}}(?![-:]))
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?![-:]))
       push:
+        - meta_scope: meta.selector.css
         - include: selector-content
-    - match: (?=^\s*{{html_tags}}(?={{pseudo_elements}}))
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?={{pseudo_elements}}))
       push:
+        - meta_scope: meta.selector.css
         - include: selector-content
-    - match: (?=^\s*{{html_tags}}(?=:{{regular_pseudo_classes}}))
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?=:{{regular_pseudo_classes}}))
       push:
+        - meta_scope: meta.selector.css
         - include: selector-content
-    - match: (?=^\s*{{html_tags}}(?=:({{functional_pseudo_classes}})\())
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?=:({{functional_pseudo_classes}})\())
       push:
+        - meta_scope: meta.selector.css
         - include: selector-content
-    - match: (?=^\s*{{html_tags}}(?=:(-(moz|ms|webkit)-){{ident}}))
+    - match: (?=\s*(?=:({{functional_pseudo_classes}}|{{functional_pseudo_classes}})\())
       push:
+        - meta_scope: meta.selector.css
         - include: selector-content
-    - match: (?=^\s*[#.:\[\*%>~+,&])
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?=:(-(moz|ms|webkit)-){{ident}}))
       push:
+        - meta_scope: meta.selector.css
+        - include: selector-content
+    - match: (?=\s*[#.:\[\*%>~+,&])
+      push:
+        - meta_scope: meta.selector.css
         - include: selector-content
 
   selector-content:
@@ -1274,7 +1285,7 @@ contexts:
       scope: invalid.illegal.combinator.css
 
   selector-end:
-    - match: (?=\s*[;@(){}])
+    - match: (?=\s*[;@(){}]|$)
       pop: 1
     - include: comments
 
@@ -1428,8 +1439,8 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - include: selectors
+            - include: function-arguments-common
 
   # Functional Pseudo Classes with generic arguments
   pseudo-class-function-with-generic-args:
@@ -3141,7 +3152,7 @@ contexts:
       pop: 1
 
   terminator-pop:
-    - match: (?=[;){}])
+    - match: (?=[;){}]|$)
       pop: 1
 
 ###############################################################################

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1241,22 +1241,7 @@ contexts:
         - meta_scope: meta.selector.css
         - include: selector-content
 
-  selector-content:
-    - meta_scope: meta.selector.css
-    - include: selector-end
-    - include: comma-delimiters
-    - include: sass-ampersand
-    - include: sass-interpolated-selectors
-
-    # Html Tags
-    - match: '{{html_tags}}'
-      scope: entity.name.tag.html.css
-    - match: '{{svg_tags}}'
-      scope: entity.name.tag.svg.css
-    # Custom Elements
-    # http://w3c.github.io/webcomponents/spec/custom/#custom-elements-core-concepts
-    - match: '{{custom_element_tags}}'
-      scope: entity.name.tag.custom.css
+  prefixed-selectors:
     - match: \*
       scope: variable.language.wildcard.asterisk.css
     # Class and Id Selectors
@@ -1320,6 +1305,24 @@ contexts:
     # https://drafts.csswg.org/css-scoping/#deep-combinator
     - match: '{{combinators}}(?![>~+|])'
       scope: keyword.operator.combinator.css
+
+  selector-content:
+    - meta_scope: meta.selector.css
+    - include: selector-end
+    - include: comma-delimiters
+    - include: sass-ampersand
+    - include: sass-interpolated-selectors
+
+    # Html Tags
+    - match: '{{html_tags}}'
+      scope: entity.name.tag.html.css
+    - match: '{{svg_tags}}'
+      scope: entity.name.tag.svg.css
+    # Custom Elements
+    # http://w3c.github.io/webcomponents/spec/custom/#custom-elements-core-concepts
+    - match: '{{custom_element_tags}}'
+      scope: entity.name.tag.custom.css
+    - include: prefixed-selectors
     - match: '{{combinators}}{2,}|\|{3,}'
       scope: invalid.illegal.combinator.css
 
@@ -3396,16 +3399,17 @@ contexts:
           scope: punctuation.definition.group.begin.sass
           push:
             - meta_scope: meta.function-call.arguments.sass
+            - match: '\)'
+              scope: punctuation.definition.group.end.sass
+              pop: true
             - include: sass-value-expression
             - include: comma-delimiters
             - include: property-value-content
             - include: quoted-strings
+            - include: sass-ampersand
+            - include: prefixed-selectors
             - match: '{{ident}}'
-              scope: string.unquoted.sass
-            - include: selectors
-            - match: '\)'
-              scope: punctuation.definition.group.end.sass
-              pop: true
+              scope: constant.other.sass
 
 ###[ SASS AMPERSAND ]#########################################
 
@@ -3549,6 +3553,9 @@ contexts:
           scope: punctuation.definition.group.begin.sass
           push:
             - meta_scope: meta.function-call.arguments.sass
+            - match: '\)'
+              scope: punctuation.definition.group.end.sass
+              pop: true
             - include: comments
             - include: sass-variables
             - include: sass-functions
@@ -3556,12 +3563,10 @@ contexts:
             - include: comma-delimiters
             - include: property-value-content
             - include: quoted-strings
+            - include: sass-ampersand
+            - include: prefixed-selectors
             - match: '{{ident}}'
-              scope: string.unquoted.sass
-            - include: selectors
-            - match: '\)'
-              scope: punctuation.definition.group.end.sass
-              pop: true
+              scope: constant.other.sass
     - match: '(@)(return){{break}}'
       captures:
         0: keyword.control.directive.return.sass

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1207,11 +1207,12 @@ contexts:
   # or a property
 
   selectors:
+    - include: sass-interpolated-selectors
     - match: (?=\s*{{svg_tags}})
       push:
         - meta_scope: meta.selector.css
         - include: selector-content
-    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?![-:]))
+    - match: (?=\s*({{html_tags}}|{{custom_element_tags}})(?!-|\s*:))
       push:
         - meta_scope: meta.selector.css
         - include: selector-content
@@ -1245,6 +1246,7 @@ contexts:
     - include: selector-end
     - include: comma-delimiters
     - include: sass-ampersand
+    - include: sass-interpolated-selectors
 
     # Html Tags
     - match: '{{html_tags}}'
@@ -3615,44 +3617,43 @@ contexts:
 
 ###[ SASS INTERPOLATED SELECTORS ]#########################################
 
-  interpolated-selector-body:
+  sass-interpolated-selector-body:
     - match: '({)'
       scope: punctuation.definition.group.begin.sass
       push:
         - match: '(})'
           scope: punctuation.definition.group.end.sass
-          pop: true
+          pop: 2
         - include: sass-script-expression
-    - include: selector-content
 
-  interpolated-selectors:
-    # - match: '\s*(#)(?={.*}{{pseudo_elements}})'
-    #   captures:
-    #     1: punctuation.definition.variable.sass
-    #   push:
-    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
-    #     - include: interpolated-selector-body
-    # - match: '\s*(#)(?={.*}:{{regular_pseudo_classes}})'
-    #   captures:
-    #     1: punctuation.definition.variable.sass
-    #   push:
-    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
-    #     - include: interpolated-selector-body
-    # - match: '\s*(#)(?={.*}:({{functional_pseudo_classes}})\()'
-    #   captures:
-    #     1: punctuation.definition.variable.sass
-    #   push:
-    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
-    #     - include: interpolated-selector-body
+  sass-interpolated-selectors:
+    - match: '\s*(#)(?={.*}{{pseudo_elements}})'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: sass-interpolated-selector-body
+    - match: '\s*(#)(?={.*}:{{regular_pseudo_classes}})'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: sass-interpolated-selector-body
+    - match: '\s*(#)(?={.*}:({{functional_pseudo_classes}})\()'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: sass-interpolated-selector-body
     - match: '\s*(#)(?={.*}:(-(moz|ms|webkit)-){{ident}})'
       captures:
         1: punctuation.definition.variable.sass
       push:
         - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
+        - include: sass-interpolated-selector-body
     - match: '\s*(#)(?={.*}(?![-:]))'
       captures:
         1: punctuation.definition.variable.sass
       push:
         - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
+        - include: sass-interpolated-selector-body

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -665,12 +665,26 @@ contexts:
     - include: at-rules
     - include: rule-list-body
     - include: illegal-groups
+
+
+    # Sass nested property names
+    # Partial property names, split at "-"
+    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
+    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
+      scope: meta.property-name.css support.type.property-name.css
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
+    # Sass variable declarations
     - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
       captures:
         0: variable.declaration.sass
         1: punctuation.definition.variable.sass
       push:
         - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
     # - include: css-modules # need to re-implement?
 
 ###[ COMMENTS ]################################################################
@@ -3357,6 +3371,9 @@ contexts:
               scope: entity.other.attribute-name.css
             - include: sass-interpolation
             - include: selectors
+            - include: comments
+            - match: '(?=$)'
+              pop: true
         - include: selector-content
 
 ###[ SASS AT-RULE FUNCTIONS ]#########################################
@@ -3377,8 +3394,7 @@ contexts:
           push:
             - match: '(?=$)'
               pop: true
-            - include: comment-block
-            - include: comment-line
+            - include: comments
             - include: comma-delimiters
             - include: var-function
             - include: sass-variables
@@ -3482,8 +3498,7 @@ contexts:
           scope: punctuation.definition.group.begin.sass
           push:
             - meta_scope: meta.function-call.arguments.sass
-            - include: comment-block
-            - include: comment-line
+            - include: comments
             - include: sass-variables
             - include: sass-functions
             - include: sass-operators
@@ -3541,15 +3556,13 @@ contexts:
               pop: true
             - match: ':'
               scope: punctuation.separator.key-value.css
-            - include: comment-block
-            - include: comment-line
+            - include: comments
             - include: sass-variables
             - include: sass-functions
             - include: sass-operators
             - include: comma-delimiters
             - include: property-value-content
-        - include: comment-block
-        - include: comment-line
+        - include: comments
         - include: quoted-strings
 
 ###[ SASS INTERPOLATED SELECTORS ]#########################################

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1286,7 +1286,7 @@ contexts:
       scope: variable.language.wildcard.asterisk.css
     # Class and Id Selectors
     # https://drafts.csswg.org/selectors-4/#class-html
-    - match: \.
+    - match: \.(?={{nmchar}})
       scope: punctuation.definition.entity.css
       push:
         - meta_scope: entity.other.attribute-name.class.css
@@ -1295,7 +1295,7 @@ contexts:
           pop: 1
         - include: immediately-pop
     # https://drafts.csswg.org/selectors-4/#id-selectors
-    - match: \#
+    - match: \#(?={{nmchar}})
       scope: punctuation.definition.entity.css
       push:
         - meta_scope: entity.other.attribute-name.id.css
@@ -1304,7 +1304,7 @@ contexts:
           pop: 1
         - include: immediately-pop
     # sass extend-only selectors
-    - match: \%
+    - match: \%(?={{nmchar}})
       scope: punctuation.definition.entity.sass
       push:
         - meta_scope: entity.other.attribute-name.placeholder.sass
@@ -1543,8 +1543,8 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - include: selectors
+            - include: function-arguments-common
 
   # Functional Pseudo Classes with generic arguments
   pseudo-class-function-with-generic-args:

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1617,7 +1617,7 @@ contexts:
     # common properties
     - include: builtin-property
     - include: custom-property
-    
+
     - include: push-to-value
     - match: '\s*(?=$)'
       pop: true
@@ -3386,8 +3386,8 @@ contexts:
   sass-mixins:
     - match: '\s*((\=)([\w-]+))'
       captures:
-        1: entity.name.function.sass
-        2: punctuation.definition.keyword.sass
+        2: keyword.control.directive.sass
+        3: entity.name.function.sass
       push:
         - meta_scope: meta.function.declaration.sass
         - match: '(?=$)'
@@ -3412,8 +3412,8 @@ contexts:
                 - include: property-value-content
     - match: '\s*((\+)([\w-]+))'
       captures:
-        1: variable.function.sass
-        2: punctuation.definition.keyword.sass
+        2: keyword.control.directive.sass
+        3: variable.function.sass
       push:
         - meta_scope: meta.function-call.sass
         - match: '(?=$)'
@@ -3558,11 +3558,11 @@ contexts:
                 - include: property-value-content
     - match: '((@)(include))\s+(([a-z]+)(\.))?([\w-]+)'
       captures:
-        0: variable.function.sass
         1: keyword.control.directive.sass
         2: punctuation.definition.keyword.sass
         5: entity.name.namespace.sass
         6: punctuation.separator.namespace.sass
+        7: variable.function.sass
       push:
         - meta_scope: meta.function-call.sass
         - match: '\s*(?=$)'

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -280,13 +280,18 @@ variables:
     | font-weight | font-variant | line-gap-override | size-adjust | unicode-range
     ){{break}}
 
-  # Page Margin Property Names
-  # https://www.w3.org/TR/css-page-3/#margin-at-rule
-  page_margin_property_names: |-
+  # @page Margin Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@page
+  page_margin_names: |-
     \b(?xi:
         (?: bottom | top ) - (?: left-corner | left | center | right | right-corner )
       | (?: left | right ) - (?: top | middle | bottom )
     ){{break}}
+
+  # @page Property Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@page
+  page_property_names: |-
+    \b(?xi: bleed | margin | marks | size ){{break}}
 
   # Property names are sorted by popularity in descending order.
   # Note:
@@ -332,7 +337,7 @@ variables:
     | margin-block-end | background-origin | animation-play-state | hyphens
     | stroke-linecap | font-stretch | object-position | page-break-inside
     | column-gap | counter-reset | counter-increment | background-position-y
-    | margin-block-start | size | grid-template-rows | column-count | quotes
+    | margin-block-start | grid-template-rows | column-count | quotes
     | padding-inline-end | text-decoration-skip | border-image | all
     | page-break-after | fill-opacity | font-variant-ligatures
     | scroll-boundary-behavior | empty-cells | list-style-image | justify-self
@@ -715,22 +720,31 @@ contexts:
 ###[ COMMENTS ]################################################################
 
   comments:
-    - include: comment-block
-    - include: comment-line
+    - include: comments-block
+    - include: comments-line
 
-  comment-block:
-    - match: /\*
-      scope: punctuation.definition.comment.css
-      push:
-        - meta_scope: comment.block.css
-        - match: \*/
-          scope: punctuation.definition.comment.css
-          pop: true
-        - match: ^\s*(\*)(?!/)
-          captures:
-            1: punctuation.definition.comment.css
+  comments-block:
+    # empty block comment
+    - match: (/\*+)(\*/)
+      scope: comment.block.css
+      captures:
+         1: punctuation.definition.comment.begin.css
+         2: punctuation.definition.comment.end.css
+    # normal block comment
+    - match: /\*+
+      scope: punctuation.definition.comment.begin.css
+      push: comments-content
 
-  comment-line:
+  comments-content:
+    - meta_scope: comment.block.css
+    - match: \*+/
+      scope: punctuation.definition.comment.end.css
+      pop: 1
+    - match: ^\s*(\*)(?!/)
+      captures:
+        1: punctuation.definition.comment.css
+
+  comments-line:
     - match: //
       scope: punctuation.definition.comment.css
       push:
@@ -767,7 +781,6 @@ contexts:
 
   at-charset-content:
     - meta_scope: meta.at-rule.charset.css
-    - include: comments
     - include: quoted-strings
     - include: at-rule-end
 
@@ -929,7 +942,7 @@ contexts:
     - meta_scope: meta.block.css
     - include: block-end2
     - include: comments
-    # - include: property-lists
+    - include: property-lists
     - include: at-keyframe-selectors
 
   at-keyframe-selectors:
@@ -986,6 +999,7 @@ contexts:
 
   # @page
   # https://www.w3.org/TR/css3-page/#at-ruledef-page
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@page
   at-page:
     - match: (@)(?i:page){{break}}
       captures:
@@ -1001,7 +1015,7 @@ contexts:
     - include: at-rule-end
 
   at-page-names:
-    - match: (:)(?i:blank|first|left|right){{break}}
+    - match: (:)(?i:blank|first|left|right|recto|verso){{break}}
       captures:
         0: entity.other.pseudo-class.css
         1: punctuation.definition.entity.css
@@ -1019,15 +1033,12 @@ contexts:
 
   at-page-block-content:
     - meta_scope: meta.property-list.css meta.block.css
-    - include: block-end2
     - include: at-page-margin
+    - include: at-page-property-list-content
     - include: at-other
-    - include: rule-list-body
 
-  # @top-center, ...
-  # https://www.w3.org/TR/css-page-3/#margin-at-rule
   at-page-margin:
-    - match: (@){{page_margin_property_names}}
+    - match: (@){{page_margin_names}}
       captures:
         0: keyword.control.directive.css
         1: punctuation.definition.keyword.css
@@ -1035,8 +1046,29 @@ contexts:
 
   at-page-margin-content:
     - meta_scope: meta.at-rule.margin.css
-    - include: at-page-block
+    - include: at-page-property-lists
     - include: at-rule-end
+
+  at-page-property-lists:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-page-property-list-content
+
+  at-page-property-list-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: at-page-property-names
+    - include: property-values
+    - include: rule-terminators
+    - include: illegal-blocks
+    - include: illegal-groups
+
+  at-page-property-names:
+    - match: '{{page_property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
+    # Note: Consume unknown identifiers to maintain word boundaries.
+    - match: '{{generic_ident}}'
 
   # @supports
   # https://drafts.csswg.org/css-conditional-3/#at-supports
@@ -1107,6 +1139,7 @@ contexts:
 
 ###[ MEDIA QUERIES ]###########################################################
 
+  # https://drafts.csswg.org/mediaqueries-5/#media
   media-queries:
     - include: comma-delimiters
     - include: media-query-conditions
@@ -1148,6 +1181,7 @@ contexts:
             | (?: device- )? (?: height | width | aspect-ratio | pixel-ratio )
             )
           | (?:any-)?(?: pointer | hover )
+          | prefers-(?: reduced-motion | color-scheme )
           | display-mode | grid | orientation | scan | scripting
           | overflow-(?: block | inline )
           )
@@ -1178,6 +1212,8 @@ contexts:
         | optional-paged | paged | scroll
         # pointer:
         | coarse | fine
+        # prefers-color-scheme:
+        | dark | light
         # scan:
         | interlace | progressive
         # scripting:
@@ -1507,8 +1543,8 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: selectors
             - include: function-arguments-common
+            - include: selectors
 
   # Functional Pseudo Classes with generic arguments
   pseudo-class-function-with-generic-args:
@@ -1560,7 +1596,7 @@ contexts:
 
   push-to-value:
     - match: ';'
-      scope: punctuation.terminator.rule.css
+      scope: invalid.illegal.sass
     - match: ':'
       scope: punctuation.separator.key-value.css
       push: property-value-content
@@ -1572,7 +1608,7 @@ contexts:
       push: property-identifier-content
 
   property-identifier-content:
-    - meta_scope: meta.property-list.css
+    - meta_scope: meta.property-name.css
     - include: comments
     - include: vendor-prefixes
     # specific properties with special treatment
@@ -1581,6 +1617,7 @@ contexts:
     # common properties
     - include: builtin-property
     - include: custom-property
+    
     - include: push-to-value
     - match: '\s*(?=$)'
       pop: true
@@ -1696,7 +1733,7 @@ contexts:
   counter-identifier:
     - match: '{{ident}}'
       scope: entity.other.counter-name.css
-    - include: push-to-value
+      pop: 1
     - include: comments
     - include: else-pop
 
@@ -1794,7 +1831,7 @@ contexts:
   # https://drafts.csswg.org/css-fonts-3/#font-prop
   font-property:
     - match: \b(?i:font(-family)?){{break}}
-      scope: meta.property-name.css support.type.property-name.css
+      scope: support.type.property-name.css
       set: font-property-value
 
   font-property-value:
@@ -2318,12 +2355,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - match: \b(?i:at|from){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|center|left|right|top){{break}}
               scope: support.constant.property-value.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - include: color-values
             - include: angle-constants
             - include: length-constants
@@ -2341,12 +2378,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - match: \b(?i:to){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|left|right|top){{break}}
               scope: support.constant.property-value.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - include: color-values
             - include: angle-constants
             - include: length-constants
@@ -2364,12 +2401,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - match: \b(?i:at|circle|ellipse){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|center|left|right|top|(closest|farthest)-(corner|side)){{break}}
               scope: support.constant.property-value.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - include: color-values
             - include: length-constants
             - include: percentage-constants

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -3279,7 +3279,7 @@ contexts:
       captures:
         0: punctuation.section.group.begin.sass
       push:
-        - meta_scope: meta.group.css meta.map.arguments.css
+        - meta_scope: meta.group.css meta.map.arguments.sass
         - match: '\)'
           captures:
             0: punctuation.section.group.end.sass

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -5,15 +5,15 @@ name: Sass
 file_extensions:
   - sass
 scope: source.sass
-
+version: 2
 
 variables:
-  unicode: '\\\h{1,6}[ \t\n\f]?'
-  escape: '(?:{{unicode}}|\\[^\n\f\h])'
-  nonascii: '[\p{L}\p{M}\p{S}\p{N}&&[[:^ascii:]]]'
-  nmstart: '(?:[[_a-zA-Z]{{nonascii}}]|{{escape}})'
-  nmchar: '(?:[[-\w]{{nonascii}}]|{{escape}})'
-  ident: '(?:--{{nmchar}}+|-?{{nmstart}}{{nmchar}}*)'
+  # Basic tokens
+  # https://www.w3.org/TR/css3-selectors/#lex
+  unicode: \\\h{1,6}[ \t\n\f]?
+  escape: (?:{{unicode}}|\\[^\n\f\h])
+  nmstart: (?:[_[:alpha:][:^ascii:]]|{{escape}})
+  nmchar: (?:[-_[:alnum:][:^ascii:]]|{{escape}})
 
   # Identifier Break
   # The proper pattern would be (?!{{nmchar}}), but its impact on performance
@@ -24,16 +24,52 @@ variables:
   #    matching (?!{{escape}}) which also effects performance negative.
   break: (?=[[^-_[:alnum:]\\]&&[[:ascii:]]]|\Z)
 
-  integer: '([-+]?)(\d+)'
-  float: '([-+]?)(\d*(\.)\d+(?:[eE][-+]?\d+)?|\d+[eE][-+]?\d+)'
+  # Identifiers
+  # https://www.w3.org/TR/css-syntax-3/#typedef-ident-token
+  # https://www.w3.org/TR/css3-selectors/#lex
+  ident: (?:{{custom_ident}}|{{generic_ident}})
+  custom_ident: (?:--{{nmchar}}*)
+  generic_ident: (?:-?{{nmstart}}{{nmchar}}*)
 
-  font_relative_lengths: '(?i:em|ex|ch|rem)'
-  viewport_percentage_lengths: '(?i:vw|vh|vmin|vmax)'
-  absolute_lengths: '(?i:cm|mm|q|in|pt|pc|px|fr)'
-  angle_units: '(?i:deg|grad|rad|turn)'
-  duration_units: '(?i:s|ms)'
-  frequency_units: '(?i:Hz|kHz)'
-  resolution_units: '(?i:dpi|dpcm|dppx)'
+  # Ilegal Custom Identifier Names
+  # https://www.w3.org/TR/css-values-4/#custom-idents
+  illegal_custom_ident: |-
+    \b{{illegal_custom_ident_tokens}}{{break}}
+  illegal_custom_ident_tokens: |-
+    (?xi: auto | default | inherit | initial | none | unset )
+
+  # Types
+  # https://www.w3.org/TR/css3-values/#numeric-types
+  # https://www.w3.org/TR/css-syntax-3/#number-token-diagram
+  integer: ([-+]?)(\d+)
+  float: ([-+]?)(\d*(\.)\d+(?:[eE][-+]?\d+)?|\d+[eE][-+]?\d+)
+
+  # Units
+  # https://www.w3.org/TR/css3-values/#lengths
+  units: |-
+    (?x:
+      %
+    | {{absolute_lengths}}
+    | {{angle_units}}
+    | {{duration_units}}
+    | {{font_relative_lengths}}
+    | {{frequency_units}}
+    | {{resolution_units}}
+    | {{viewport_percentage_lengths}}
+    )
+  font_relative_lengths: (?i:em|ex|ch|rem)\b
+  viewport_percentage_lengths: (?i:vw|vh|vmin|vmax)\b
+  absolute_lengths: (?i:cm|mm|q|in|pt|pc|px|fr)\b
+  angle_units: (?i:deg|grad|rad|turn)\b
+  duration_units: (?i:s|ms)\b
+  frequency_units: (?i:Hz|kHz)\b
+  resolution_units: (?i:dpi|dpcm|dppx)\b
+
+  # Combinators
+  # https://drafts.csswg.org/selectors-4/#combinators
+  combinators: (?:>{1,3}|[~+]|\|{2})
+
+  vendor_prefix: -(?:webkit|moz|ms|o)-
 
   # Custom Element Names
   # https://html.spec.whatwg.org/multipage/custom-elements.html#custom-elements-core-concepts
@@ -57,11 +93,151 @@ variables:
     | [\x{10000}-\x{EFFFF}]
     )
 
-  combinators: '(?:>{1,3}|[~+])'
+  # HTML tags
+  # https://developer.mozilla.org/en-US/docs/Web/HTML/Element
+  # Note: Sections are sorted by expected frequency.
+  html_tags:  |-
+    (?x:
+      {{html_inline_tags}}
+    | {{html_text_tags}}
+    | {{html_section_tags}}
+    | {{html_table_tags}}
+    | {{html_embedded_tags}}
+    | {{html_forms_tags}}
+    | {{html_media_tags}}
+    | {{html_interactive_tags}}
+    | {{html_script_tags}}
+    | {{html_web_tags}}
+    | {{html_markup_tags}}
+    | {{html_header_tags}}
+    | {{html_root_tags}}
+    | {{html_deprecated_tags}}
+    )
 
-  counter_styles: |-
-    (?xi:
-        arabic-indic | armenian | bengali | cambodian | circle
+  html_root_tags: |-
+    \b(?xi: html | body ){{break}}
+
+  html_header_tags: |-
+    \b(?xi: base | head | link | meta | script | style | title ){{break}}
+
+  html_section_tags: |-
+    \b(?xi:
+        address | article | aside | footer | header | h1 | h2 | h3 | h4 | h5 | h6
+      | hgroup | main | nav | section
+    ){{break}}
+
+  html_text_tags: |-
+    \b(?xi:
+        blockquote | cite | dd | dt | dl | div | figcaption | figure | hr | li
+      | ol | p | pre | ul
+    ){{break}}
+
+  html_inline_tags: |-
+    \b(?xi:
+        a | abbr | b | bdi | bdo | br | code | data | time | dfn | em | i | kbd
+      | mark | q | rb | ruby | rp | rt | rtc | s | samp | small | span | strong
+      | sub | sup | u | var | wbr
+    ){{break}}
+
+  html_media_tags: |-
+    \b(?xi: area | audio | source | img | map | track | video ){{break}}
+
+  html_embedded_tags: |-
+    \b(?xi: embed | iframe | object | param | picture | source ){{break}}
+
+  html_script_tags: |-
+    \b(?xi: canvas | noscript | script ){{break}}
+
+  html_markup_tags: |-
+    \b(?xi: del | ins ){{break}}
+
+  html_table_tags: |-
+    \b(?xi:
+        caption | col | colgroup | table | tbody | tr | td | tfoot | th | thead
+    ){{break}}
+
+  html_forms_tags: |-
+    \b(?xi:
+        button | datalist | option | fieldset | label | form | input | legend
+      | meter | optgroup | select | output | progress | textarea
+    ){{break}}
+
+  html_interactive_tags: |-
+    \b(?xi: details | dialog | menu | summary ){{break}}
+
+  html_web_tags: |-
+    \b(?xi: slot | template ){{break}}
+
+  html_deprecated_tags: |-
+    \b(?xi:
+        acronym | applet | basefont | bgsound | big | blink | center | command
+      | content | dir | element | font | frame | frameset | image | isindex
+      | keygen | listing | marquee | menuitem | multicol | nextid | nobr
+      | noembed | noframes | plaintext | shadow | spacer | strike | tt | xmp
+    ){{break}}
+
+  # SVG tag names
+  # maintained from previous CSS.sublime-syntax
+  svg_tags: |-
+    \b(?xi:
+        circle | clipPath | defs | ellipse | eventsource | filter | foreignObject
+      | g | glyph | glyphRef | line | linearGradient | marker | mask | path
+      | pattern | polygon | polyline | radialGradient | rect | stop | svg
+      | switch | symbol | text | textPath | tref | tspan | use
+      # custom element like tags reserved for SVG/MathML
+      | annotation-xml | color-profile | missing-glyph
+      | font-face(?: -src | -uri | -format | -name )?
+    ){{break}}
+
+  # Predefined Color Values (Standard Set)
+  # https://www.w3.org/TR/CSS22/syndata.html#color-units
+  standard_colors: |-
+    \b(?xi:
+        aqua | black | blue | fuchsia | gray | green | lime | maroon | navy
+      | olive | orange | purple | red | silver | teal | white | yellow
+    ){{break}}
+
+  # Predefined Color Values (Extended Set)
+  # https://www.w3.org/TR/css3-color/#svg-color
+  extended_colors: |-
+    \b(?xi:
+        aliceblue | antiquewhite | aquamarine | azure | beige | bisque
+      | blanchedalmond | blueviolet | brown | burlywood | cadetblue | chartreuse
+      | chocolate | coral | cornflowerblue | cornsilk | crimson | cyan | darkblue
+      | darkcyan | darkgoldenrod | darkgray | darkgreen | darkgrey | darkkhaki
+      | darkmagenta | darkolivegreen | darkorange | darkorchid | darkred
+      | darksalmon | darkseagreen | darkslateblue | darkslategray | darkslategrey
+      | darkturquoise | darkviolet | deeppink | deepskyblue | dimgray | dimgrey
+      | dodgerblue | firebrick | floralwhite | forestgreen | gainsboro
+      | ghostwhite | gold | goldenrod | greenyellow | grey | honeydew | hotpink
+      | indianred | indigo | ivory | khaki | lavender | lavenderblush | lawngreen
+      | lemonchiffon | lightblue | lightcoral | lightcyan | lightgoldenrodyellow
+      | lightgray | lightgreen | lightgrey | lightpink | lightsalmon
+      | lightseagreen | lightskyblue | lightslategray | lightslategrey
+      | lightsteelblue | lightyellow | limegreen | linen | magenta
+      | mediumaquamarine | mediumblue | mediumorchid | mediumpurple
+      | mediumseagreen | mediumslateblue | mediumspringgreen | mediumturquoise
+      | mediumvioletred | midnightblue | mintcream | mistyrose | moccasin
+      | navajowhite | oldlace | olivedrab | orangered | orchid | palegoldenrod
+      | palegreen | paleturquoise | palevioletred | papayawhip | peachpuff | peru
+      | pink | plum | powderblue | rebeccapurple | rosybrown | royalblue
+      | saddlebrown | salmon | sandybrown | seagreen | seashell | sienna
+      | skyblue | slateblue | slategray | slategrey | snow | springgreen
+      | steelblue | tan | thistle | tomato | turquoise | violet | wheat
+      | whitesmoke | yellowgreen
+    ){{break}}
+
+
+  # Illegal Counter Style Definition Names
+  # https://drafts.csswg.org/css-counter-styles-3/#typedef-counter-style-name
+  counter_style_illegal_names: |-
+    \b(?xi: decimal | disc | {{illegal_custom_ident_tokens}} ){{break}}
+
+  # Predefined Counter Styles
+  # https://drafts.csswg.org/css-counter-styles-3/#predefined-counters
+  counter_style_names: |-
+    \b(?xi:
+        none | arabic-indic | armenian | bengali | cambodian | circle
       | cjk-decimal | cjk-earthly-branch | cjk-heavenly-stem | decimal-leading-zero
       | decimal | devanagari | disclosure-closed | disclosure-open | disc
       | ethiopic-numeric | georgian | gujarati | gurmukhi | hebrew
@@ -74,116 +250,406 @@ variables:
       | square | tamil | telugu | thai | tibetan
       | trad-chinese-formal | trad-chinese-informal
       | upper-alpha | upper-armenian | upper-latin | upper-roman
+    ){{break}}
+
+  # @counter-style Property Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@counter-style
+  counter_style_property_names: |-
+    \b(?xi:
+      additive-symbols | negative | pad | prefix | range
+    | suffix | symbols (?# | fallback | speak-as | system )
+    ){{break}}
+
+  # Predefined Counter Speak As Property Constants
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-speak-as
+  counter_speak_as_constants: |-
+    \b(?xi: auto | bullets | numbers | words | spell-out ){{break}}
+
+  # Predefined Counter Style System Constants
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-system
+  counter_system_constants: |-
+    \b(?xi: cyclic | numeric | alphabetic | symbolic | additive | fixed ){{break}}
+
+  # @font-face Property Names
+  # https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face
+  font_face_property_names: |-
+    \b(?xi:
+      ascent-override | descent-override | font-display | (?# font-family | ) src
+    | font-feature-settings | font-variation-settings | font-stretch | font-style
+    | font-weight | font-variant | line-gap-override | size-adjust | unicode-range
+    ){{break}}
+
+  # Page Margin Property Names
+  # https://www.w3.org/TR/css-page-3/#margin-at-rule
+  page_margin_property_names: |-
+    \b(?xi:
+        (?: bottom | top ) - (?: left-corner | left | center | right | right-corner )
+      | (?: left | right ) - (?: top | middle | bottom )
+    ){{break}}
+
+  # Property names are sorted by popularity in descending order.
+  # Note:
+  # 1) Popularity data taken from https://www.chromestatus.com/metrics/css/popularity
+  # 2) Properties starting with `alias-` or `webkit-` are removed
+  property_names: |-
+    \b(?xi:
+      width | height | display | position | padding | border | margin | top
+    | left | margin-top | color | font-size | background-color | text-align
+    | opacity | font-weight | font-family | background | overflow | line-height
+    | float | box-sizing | text-decoration | z-index | cursor | margin-left
+    | border-radius | vertical-align | margin-bottom | margin-right | right
+    | padding-top | padding-left | max-width | box-shadow | bottom | content
+    | padding-right | transform | white-space | min-height | padding-bottom
+    | background-image | border-bottom | visibility | outline
+    | background-position | min-width | transition | border-top | border-color
+    | background-repeat | text-transform | background-size | max-height
+    | list-style | clear | font-style | justify-content | border-left
+    | align-items | border-right | border-width | font | text-overflow
+    | overflow-y | pointer-events | border-style | flex-direction | animation
+    | overflow-x | letter-spacing | flex | word-wrap | flex-wrap | fill
+    | transform-origin | list-style-type | border-collapse
+    | border-top-left-radius | border-bottom-left-radius | user-select | clip
+    | text-shadow | border-bottom-right-radius | word-break | flex-grow
+    | border-top-right-radius | border-bottom-color | border-top-color
+    | flex-shrink | align-self | text-rendering | animation-timing-function
+    | direction | background-clip | zoom | border-spacing | text-indent
+    | outline-offset | border-left-color | transition-property
+    | border-right-color | animation-name | stroke | touch-action
+    | animation-duration | transition-delay | filter | overflow-wrap
+    | animation-delay | border-bottom-width | variable | font-variant
+    | flex-basis | transition-duration | border-top-width | animation-fill-mode
+    | object-fit | transition-timing-function | will-change | outline-width
+    | order | outline-style | stroke-width | border-right-width | align-content
+    | resize | table-layout | appearance | animation-iteration-count
+    | border-left-width | flex-flow | stroke-dashoffset | stroke-dasharray
+    | backface-visibility | unicode-bidi | border-bottom-style
+    | text-size-adjust | border-top-style | animation-direction | word-spacing
+    | contain | speak | grid-template-columns | font-feature-settings
+    | perspective | list-style-position | clip-path | image-rendering
+    | font-display | transform-style | border-left-style | outline-color
+    | background-position-x | background-attachment | border-right-style
+    | margin-block-end | background-origin | animation-play-state | hyphens
+    | stroke-linecap | font-stretch | object-position | page-break-inside
+    | column-gap | counter-reset | counter-increment | background-position-y
+    | margin-block-start | size | grid-template-rows | column-count | quotes
+    | padding-inline-end | text-decoration-skip | border-image | all
+    | page-break-after | fill-opacity | font-variant-ligatures
+    | scroll-boundary-behavior | empty-cells | list-style-image | justify-self
+    | overflow-anchor | padding-inline-start | grid-gap | text-decoration-color
+    | margin-inline-start | caret-color | grid-column-gap | aspect-ratio
+    | stroke-opacity | margin-inline-end | grid-column | perspective-origin
+    | caption-side | columns | scroll-behavior | justify-items | line-break
+    | grid-row-gap | column-width | orphans | widows | backdrop-filter
+    | mix-blend-mode | tab-size | stop-color | column-rule | grid-area
+    | stroke-miterlimit | text-align-last | page-break-before
+    | grid-column-start | border-image-slice | border-image-repeat
+    | text-decoration-style | border-image-width | grid-column-end | grid-row
+    | scroll-snap-align | scroll-snap-type | border-image-outset
+    | text-decoration-line | column-fill | border-inline-end-width
+    | border-inline-start-width | grid-row-start | stroke-linejoin
+    | inset-inline-end | inset-inline-start | grid-auto-flow | grid-auto-rows
+    | grid-template-areas | border-image-source | fill-rule | font-kerning
+    | grid-row-end | font-variant-numeric | break-inside | shape-outside
+    | color-scheme | shape-image-threshold | scroll-boundary-behavior-y
+    | text-decoration-skip-ink | page | isolation | background-blend-mode
+    | page-orientation | inset | gap | scroll-snap-margin | column-rule-color
+    | place-items | column-rule-style | shape-rendering | content-visibility
+    | grid-auto-columns | scroll-boundary-behavior-x | writing-mode | clip-rule
+    | font-variant-caps | scroll-padding | text-anchor | mask | row-gap
+    | background-repeat-x | intrinsic-size | text-underline-position
+    | font-variant-east-asian | column-span | vector-effect | dominant-baseline
+    | stop-opacity | break-after | grid-template | break-before | mask-type
+    | scroll-snap-stop | border-inline-start-color | border-inline-end-color | r
+    | alignment-baseline | text-decoration-thickness | column-rule-width | d
+    | image-orientation | rx | text-orientation | cx | baseline-shift
+    | scroll-padding-top | padding-block-start | padding-block-end | cy
+    | min-inline-size | inline-size | background-repeat-y | shape-margin
+    | block-size | marker | min-block-size | paint-order | ry
+    | scroll-snap-margin-top | border-block-end-color | border-block-end-width
+    | border-inline-start-style | border-inline-end-style
+    | border-block-end-style | font-variation-settings
+    | border-block-start-width | border-block-start-color
+    | border-block-start-style | place-content | y | x | ruby-position
+    | text-combine-upright | color-interpolation-filters | color-interpolation
+    | color-rendering | transform-box | marker-end | flood-color | marker-start
+    | marker-mid | flood-opacity | lighting-color | forced-color-adjust
+    | buffered-rendering | place-self | offset-path | scroll-padding-left
+    | offset-distance | offset-rotate | text-underline-offset | max-inline-size
+    | max-block-size | border-inline-end | scroll-snap-margin-inline-start
+    | scroll-padding-inline-start | scroll-snap-margin-block-end
+    | scroll-snap-margin-block-start | scroll-padding-block-end
+    | scroll-snap-margin-inline-end | scroll-padding-block-start
+    | scroll-padding-inline-end | font-optical-sizing | grid
+    | scroll-padding-bottom | scroll-snap-margin-left | inset-block-end
+    | overscroll-behavior-block | overscroll-behavior-inline | inset-block-start
+    | scroll-snap-margin-right | scroll-padding-right
+    | scroll-snap-margin-bottom | border-inline-start | margin-inline
+    | border-end-start-radius | border-end-end-radius | margin-block
+    | border-start-start-radius | border-start-end-radius | padding-inline
+    | counter-set | padding-block | border-block-end | offset
+    | border-block-start | inset-inline | inset-block | scroll-snap-margin-block
+    | scroll-padding-inline | scroll-padding-block | scroll-snap-margin-inline
+    | border-block | offset-rotation | border-inline | border-block-color
+    | border-inline-width | border-inline-color | border-block-style
+    | border-block-width | border-inline-style | motion | motion-offset
+    | motion-path | font-size-adjust | text-justify | scale | scrollbar-gutter
+    | animation-timeline | rotate | translate | snap-height | math-style
+    | math-shift | math-depth | offset-anchor | offset-position
+    | glyph-orientation-vertical | internal-callback | text-line-through
+    | text-line-through-color | text-line-through-mode | text-line-through-style
+    | text-line-through-width | text-overline | text-overline-color
+    | text-overline-mode | text-overline-style | text-overline-width
+    | text-underline | text-underline-color | text-underline-mode
+    | text-underline-style | text-underline-width | shape-inside | shape-padding
+    | enable-background | color-profile | glyph-orientation-horizontal | kerning
+    | image-resolution | max-zoom | min-zoom | orientation | user-zoom
+    | mask-source-type | touch-action-delay | scroll-blocks-on | motion-rotation
+    | scroll-snap-points-x | scroll-snap-points-y | scroll-snap-coordinate
+    | scroll-snap-destination | apply-at-rule | viewport-fit | overflow-block
+    | syntax | content-size | intrinsic-block-size | intrinsic-height
+    | intrinsic-inline-size | intrinsic-width | render-subtree
+    | origin-trial-test-property | subtree-visibility
+    | math-superscript-shift-style | start
+    # END OF QUERY RESULTS
+    # BEGIN OF legacy properties which existed before the last query
+    | box-direction | line-box-contain | mask-image | mask-origin | flex-order
+    | font-synthesis | line-clamp | flex-negative | blend-mode
+    | font-variant-position | flex-align | column-break-before
+    | flex-item-align | azimuth | user-drag | mask-repeat | box-flex
+    | flex-preferred-size | font-language-override | box-align
+    | text-emphasis-color | box-ordinal-group | mask-composite
+    | transform-origin-y | pause | tap-highlight-color | text-fill-color
+    | text-emphasis-style | transform-origin-x | text-emphasis-position
+    | box-pack | box-decoration-break | box-orient
+    | text-emphasis | mask-clip | nbsp-mode | pause-after | pitch
+    | text-height | mask-position | flex-line-pack | perspective-origin-x
+    | mask-size | font-variant-alternates | perspective-origin-y
+    | font-smoothing | overflow-scrolling | flex-positive | pitch-range
+    ){{break}}
+
+  property_value_constants: |-
+    (?x:
+      {{font_display_constants}}
+    | {{font_property_constants}}
+    | {{font_size_constants}}
+    | {{font_style_constants}}
+    | {{unsorted_property_constants}}
     )
 
-  element_names: '\b(a|abbr|acronym|address|applet|area|article|aside|audio|b|base|basefont|bdi|bdo|big|blockquote|body|br|button|canvas|caption|cite|code|col|colgroup|content|data|datalist|dd|del|details|dfn|dir|dialog|div|dl|dt|element|em|embed|eventsource|fieldset|figure|figcaption|footer|form|frame|frameset|h[1-6]|head|header|hgroup|hr|html|i|iframe|img|input|ins|isindex|kbd|keygen|label|legend|li|link|main|map|mark|menu|meta|meter|nav|noframes|noscript|object|ol|optgroup|option|output|p|param|picture|pre|progress|q|rp|rt|rtc|s|samp|script|section|select|shadow|small|source|span|strike|strong|style|sub|summary|sup|svg|table|tbody|td|template|textarea|tfoot|th|thead|time|title|tr|track|tt|u|ul|var|video|wbr|xmp|circle|clipPath|defs|ellipse|filter|foreignObject|g|glyph|glyphRef|image|line|linearGradient|marker|mask|path|pattern|polygon|polyline|radialGradient|rect|stop|switch|symbol|text|textPath|tref|tspan|use)\b'
-  custom_elements: '\b([a-z](?:{{custom_element_chars}})*-(?:{{custom_element_chars}})*)\b(?!{{ident}})'
-
-  pseudo_elements: |-
-    (?x:
-        (:{1,2})(?:before|after|first-line|first-letter) # CSS1 & CSS2 require : or ::
-      | (::)(-(?:moz|ms|webkit)-)?(?:{{ident}}) # CSS3 requires ::
+  unsorted_property_constants: |-
+    \b(?xi:
+      absolute|active|add
+    | all(-(petite|small)-caps|-scroll)?
+    | alpha(betic)?
+    | alternate(-reverse)?
+    | always|annotation|antialiased|at
+    | auto(hiding-scrollbar|-flow)?
+    | avoid(-column|-page|-region)?
+    | background(-color|-image|-position|-size)?
+    | backwards|balance|baseline|below|bevel|bicubic|bidi-override|blink
+    | block-line-height
+    | blur
+    | border(-bottom|-left|-right|-top)?-(color|radius|width|style)
+    | border-(bottom|top)-(left|right)-radius
+    | border-image(-outset|-repeat|-slice|-source|-width)?
+    | border(-bottom|-left|-right|-top|-collapse|-spacing|-box)?
+    | both|bottom
+    | box(-shadow)?
+    | break-(all|word)
+    | brightness
+    | butt(on)?
+    | capitalize
+    | cent(er|ral)
+    | char(acter-variant)?
+    | cjk-ideographic|clip|clone|close-quote
+    | closest-(corner|side)
+    | col-resize|collapse
+    | color(-stop|-burn|-dodge)?
+    | column((-count|-gap|-reverse|-rule(-color|-width)?|-width)|s)?
+    | common-ligatures|condensed|consider-shifts|contain
+    | content(-box|s)?
+    | contextual|contrast|cover
+    | crisp(-e|E)dges
+    | crop
+    | cross(hair)?
+    | da(rken|shed)
+    | default|dense|diagonal-fractions|difference|disabled
+    | discretionary-ligatures|disregard-shifts
+    | distribute(-all-lines|-letter|-space)?
+    | dotted|double|drop-shadow
+    | (nwse|nesw|ns|ew|sw|se|nw|ne|w|s|e|n)-resize
+    | ease(-in-out|-in|-out)?
+    | element|ellipsis|embed|end|EndColorStr|evenodd
+    | exclu(de(-ruby)?|sion)
+    | expanded
+    | (extra|semi|ultra)-(condensed|expanded)
+    | farthest-(corner|side)?
+    | fill(-box|-opacity)?
+    | filter|first|fixed|flat
+    | fit-content
+    | flex((-basis|-end|-grow|-shrink|-start)|box)?
+    | flip|flood-color
+    | font(-size(-adjust)?|-stretch|-weight)?
+    | forwards
+    | from(-image)?
+    | full-width|geometricPrecision|glyphs|gradient|grayscale
+    | grid(-height)?
+    | groove|hand|hanging|hard-light|height|help|hidden|hide
+    | historical-(forms|ligatures)
+    | horizontal(-tb)?
+    | hue
+    | ideograph(-alpha|-numeric|-parenthesis|-space|ic)
+    | inactive|include-ruby|infinite|inherit|initial
+    | inline(-block|-box|-flex(box)?|-line-height|-table)?
+    | inset|inside
+    | inter(-ideograph|-word|sect)
+    | invert|isolat(e|ion)
+    | jis(04|78|83|90)
+    | justify(-all)?
+    | keep-all
+    | landscape|ledger|legal|letter|A[3-5]|(JIS-)?B[4-5]|portrait
+    | last|left|letter-spacing|legacy
+    | light(e[nr]|ing-color)
+    | line(-edge|-height|-through)?
+    | linear(-gradient|RGB)?
+    | lining-nums|list-item|local|loose|lowercase|lr-tb|ltr
+    | lumin(osity|ance)|manual
+    | margin(-bottom|-box|-left|-right|-top)?
+    | marker(-offset|s)?
+    | mathematical
+    | max-(content|height|lines|size|width)
+    | medium|middle
+    | min-(content|height|width)
+    | miter|mixed|move|multiply|newspaper
+    | no-(change|clip|(close|open)-quote|(common|discretionary|historical)-ligatures|contextual|drop|repeat)
+    | none|nonzero|not-allowed|nowrap
+    | offset(-after|-before|-end|-start)?
+    | oldstyle-nums|opacity|open-quote
+    | optimize(Legibility|Precision|Quality|Speed)
+    | order|ordinal|ornaments
+    | outline(-color|-offset|-width)?
+    | outset|outside|over(line|-edge|lay)
+    | padding(-bottom|-box|-left|-right|-top)?
+    | page|painted|paused
+    | perspective-origin
+    | petite-caps|pixelated|pointer
+    | pre(-line|-wrap)?
+    | preserve-3d
+    | progid:DXImageTransform.Microsoft.(Alpha|Blur|dropshadow|gradient|Shadow)
+    | progress
+    | proportional-(nums|width)
+    | radial-gradient|recto|region|relative
+    | repeat(-[xy])?
+    | repeating-(linear|radial)-gradient
+    | replaced|reset-size|reverse|ridge|right
+    | round
+    | row(-resize|-reverse)?
+    | run-in
+    | ruby(-base|-text)?(-container)?
+    | rtl|running|saturat(e|ion)|screen
+    | safe
+    | scroll(-position|bar)?
+    | separate|sepia
+    | scale-down
+    | shape-(image-threshold|margin|outside)
+    | show
+    | sideways(-lr|-rl)?
+    | simplified
+    | slashed-zero|slice
+    | smooth|snap|solid|soft-light
+    | space(-around|-between|-evenly)?
+    | span|sRGB
+    | stack(ed-fractions)?
+    | start(ColorStr)?
+    | static
+    | step-(end|start)
+    | sticky
+    | stop-(color|opacity)
+    | stretch|strict
+    | stroke(-box|-dash(array|offset)|-miterlimit|-opacity|-width)?
+    | style(set)?
+    | stylistic
+    | sub(grid|pixel-antialiased|tract)?
+    | super|swash
+    | table(-caption|-cell|(-column|-footer|-header|-row)-group|-column|-row)?
+    | tabular-nums|tb-rl
+    | text((-bottom|-(decoration|emphasis)-color|-indent|-(over|under|after|before)-edge|-shadow|-size(-adjust)?|-top)|field)?
+    | thi(ck|n)
+    | titling-ca(ps|se)
+    | to[p]?
+    | touch|traditional
+    | transform(-origin)?
+    | under(-edge|line)?
+    | unicase|unsafe|unset|uppercase|upright
+    | use-(glyph-orientation|script)
+    | verso
+    | vertical(-align|-ideographic|-lr|-rl|-text)?
+    | view-box
+    | viewport-fill(-opacity)?
+    | visibility
+    | visible(Fill|Painted|Stroke)?
+    | wait|wavy|weight|whitespace|width|word-spacing
+    | wrap(-reverse)?
+    | z-index|zero
+    | zoom(-in|-out)?
     ){{break}}
 
-  regular_pseudo_classes: '\b(active|any-link|blank|checked|current|default|defined|disabled|drop|empty|enabled|first|first-child|first-of-type|fullscreen|future|focus|focus-visible|focus-within|host|hover|indeterminate|in-range|invalid|last-child|last-of-type|left|link|local-link|only-child|only-of-type|optional|out-of-range|past|placeholder-shown|read-only|read-write|required|right|root|scope|target|target-within|user-invalid|valid|visited)\b(?![-])'
-  functional_pseudo_classes: '\b(dir|lang|matches|not|has|drop|nth-last-child|nth-child|nth-last-of-type|nth-of-type){{break}}'
-
-  property_names: |-
-    \b(?x)(
-        display|width|background-color|height|position|font-family|font-weight
-      | top|opacity|cursor|background-image|right|visibility|box-sizing
-      | user-select|left|float|margin-left|margin-top|line-height
-      | padding-left|z-index|margin-bottom|margin-right|margin
-      | vertical-align|padding-top|white-space|border-radius|padding-bottom
-      | padding-right|padding|bottom|clear|max-width|box-shadow|content
-      | border-color|min-height|min-width|font-style|border-width
-      | border-collapse|background-size|text-overflow|max-height|text-transform
-      | text-shadow|text-indent|border-style|overflow-y|list-style-type
-      | word-wrap|border-spacing|appearance|zoom|overflow-x|border-top-left-radius
-      | border-bottom-left-radius|border-top-color|pointer-events
-      | border-bottom-color|align-items|justify-content|letter-spacing
-      | border-top-right-radius|border-bottom-right-radius|border-right-width
-      | font-smoothing|border-bottom-width|border-right-color|direction
-      | border-top-width|src|border-left-color|border-left-width
-      | tap-highlight-color|table-layout|background-clip|word-break
-      | transform-origin|resize|filter|backdrop-filter|backface-visibility|text-rendering
-      | box-orient|transition-property|transition-duration|word-spacing
-      | quotes|outline-offset|animation-timing-function|animation-duration
-      | animation-name|transition-timing-function|border-bottom-style
-      | border-bottom|transition-delay|transition|unicode-bidi|border-top-style
-      | border-top|unicode-range|list-style-position|orphans|outline-width
-      | line-clamp|order|flex-direction|box-pack|animation-fill-mode
-      | outline-color|list-style-image|list-style|touch-action|flex-grow
-      | border-left-style|border-left|animation-iteration-count
-      | page-break-inside|box-flex|box-align|page-break-after|animation-delay
-      | widows|border-right-style|border-right|flex-align|outline-style
-      | outline|background-origin|animation-direction|fill-opacity
-      | background-attachment|flex-wrap|transform-style|counter-increment
-      | overflow-wrap|counter-reset|animation-play-state|animation
-      | will-change|box-ordinal-group|image-rendering|mask-image|flex-flow
-      | background-position-y|stroke-width|background-position-x|background-position
-      | background-blend-mode|flex-shrink|flex-basis|flex-order|flex-item-align
-      | flex-line-pack|flex-negative|flex-pack|flex-positive|flex-preferred-size
-      | flex|user-drag|font-stretch|column-count|empty-cells|align-self
-      | caption-side|mask-size|column-gap|mask-repeat|box-direction
-      | font-feature-settings|mask-position|align-content|object-fit
-      | columns|text-fill-color|clip-path|stop-color|font-kerning
-      | page-break-before|stroke-dasharray|size|fill-rule|border-image-slice
-      | column-width|break-inside|column-break-before|border-image-width
-      | stroke-dashoffset|border-image-repeat|border-image-outset|line-break
-      | stroke-linejoin|stroke-linecap|stroke-miterlimit|stroke-opacity
-      | stroke|shape-rendering|border-image-source|border-image|border
-      | tab-size|writing-mode|perspective-origin-y|perspective-origin-x
-      | perspective-origin|perspective|text-align-last|text-align|clip-rule
-      | clip|text-anchor|column-rule-color|box-decoration-break|column-fill
-      | fill|column-rule-style|mix-blend-mode|text-emphasis-color
-      | baseline-shift|dominant-baseline|page|alignment-baseline
-      | column-rule-width|column-rule|break-after|font-variant-ligatures
-      | transform-origin-y|transform-origin-x|transform|object-position
-      | break-before|column-span|isolation|shape-outside|all
-      | color-interpolation-filters|marker|marker-end|marker-start
-      | marker-mid|color-rendering|color-interpolation|background-repeat-x
-      | background-repeat-y|background-repeat|background|mask-type
-      | flood-color|flood-opacity|text-orientation|mask-composite
-      | text-emphasis-style|paint-order|lighting-color|shape-margin
-      | text-emphasis-position|text-emphasis|shape-image-threshold
-      | mask-clip|mask-origin|mask|font-variant-caps|font-variant-alternates
-      | font-variant-east-asian|font-variant-numeric|font-variant-position
-      | font-variant|font-size-adjust|font-size|font-language-override
-      | font-display|font-synthesis|font|line-box-contain|text-justify
-      | text-decoration-color|text-decoration-style|text-decoration-line
-      | text-decoration|text-underline-position|grid-template-rows
-      | grid-template-columns|grid-template-areas|grid-template|rotate|scale
-      | translate|scroll-behavior|grid-column-start|grid-column-end
-      | grid-column-gap|grid-row-start|grid-row-end|grid-auto-rows
-      | grid-area|grid-auto-flow|grid-auto-columns|image-orientation
-      | hyphens|overflow-scrolling|overflow|color-profile|kerning
-      | nbsp-mode|color|image-resolution|grid-row-gap|grid-row|grid-column
-      | blend-mode|azimuth|pause-after|pause-before|pause|pitch-range|pitch
-      | text-height|system|negative|prefix|suffix|range|pad|fallback
-      | additive-symbols|symbols|speak-as|speak|grid-gap|grid
+  # https://www.w3.org/TR/css-fonts-4/#font-display-desc
+  font_display_constants: |-
+    \b(?xi:
+    block | swap | fallback | optional
     ){{break}}
 
+  # Generic Font Families
+  font_family_constants: |-
+    \b(?xi:
+    # CSS 2 fonts
+    # https://www.w3.org/TR/CSS22/fonts.html#generic-font-families
+      sans-serif | serif | cursive | monospace | fantasy
+    # CSS 3 level 4 fonts
+    # https://www.w3.org/TR/2019/WD-css-fonts-4-20191113/#generic-family-value
+    | emoji | math | fangsong | system-ui
+    # https://www.w3.org/TR/2019/WD-css-fonts-4-20191113/#standard-font-families
+    | ui-sans-serif | ui-serif | ui-monospace | ui-rounded
+    ){{break}}
+
+  # https://www.w3.org/TR/CSS22/fonts.html#font-shorthand
+  font_property_constants: |-
+    \b(?xi:
+      caption | icon | menu | message-box | small-caption | status-bar
+    ){{break}}
+
+  # https://www.w3.org/TR/CSS22/fonts.html#font-size-props
+  font_size_constants: |-
+    \b(?xi:
+      larger | large | medium | small | smaller | x{1,2}-(?: large | small )
+    ){{break}}
+
+  # https://www.w3.org/TR/CSS22/fonts.html#font-boldness
+  # https://www.w3.org/TR/CSS22/fonts.html#font-styling
+  # https://www.w3.org/TR/CSS22/fonts.html#small-caps
+  font_style_constants: |-
+    \b(?xi:
+      normal | bold | bolder | lighter | italic | oblique | small-caps
+    ){{break}}
+
+###############################################################################
 
 contexts:
   main:
     - match: '\{|\}|;'
       scope: invalid.illegal.sass
     - include: frontmatter
-    - include: comment-block
-    - include: comment-line
+    - include: comments
     - include: sass-mixin-directives
     - include: selectors
-    - include: properties
-    - include: keyframe-operators
     - include: interpolated-selectors
-    - include: custom-element-selectors
     - include: at-rules
+    - include: property-lists
+    - include: illegal-groups
     - include: css-modules
-    - match: '\s*(,)\s*'
-      captures:
-        1: punctuation.separator.css
 
+###[ COMMENTS ]################################################################
 
   frontmatter:
     - match: '^---$'
@@ -194,511 +660,52 @@ contexts:
       escape_captures:
         0: frontmatter.jekyll punctuation.section.frontmatter.end.jekyll
 
-
-  selectors:
-    # wild card
-    - match: '\s*(\*)'
-      captures:
-        1: entity.name.tag.wildcard.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    # ampersand
-    - match: '\s*(&)'
-      captures:
-        1: keyword.operator.ampersand.sass
-      push:
-        - meta_scope: meta.selector.css
-        - match: '[-_]+'
-          scope: entity.other.attribute-name.css
-          push:
-            - match: '{{ident}}'
-              scope: entity.other.attribute-name.css
-            - include: sass-interpolation
-            - include: selector-parts
-        - include: selector-parts
-    # standard elements + pseudo elements
-    - match: '\s*({{element_names}})(?={{pseudo_elements}})'
-      captures:
-        1: entity.name.tag.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    # standard elements + pseudoclasses
-    - match: '\s*({{element_names}})(?=:{{regular_pseudo_classes}})'
-      captures:
-        1: entity.name.tag.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    - match: '\s*({{element_names}})(?=:({{functional_pseudo_classes}})\()'
-      captures:
-        1: entity.name.tag.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    - match: '\s*({{element_names}})(?=:(-(moz|ms|webkit)-){{ident}})'
-      captures:
-        1: entity.name.tag.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    # standard elements
-    - match: '\s*({{element_names}})(?![-:])'
-      # stop this at word break and not -, plus : is for pseudos
-      captures:
-        1: entity.name.tag.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    # classes
-    - match: '\s*(\.)(?={{ident}}|#)'
-      captures:
-        1: entity.other.attribute-name.class.css punctuation.definition.entity.css
-      push:
-        - meta_scope: meta.selector.css
-        - match: '{{ident}}'
-          scope: entity.other.attribute-name.class.css
-        - include: sass-interpolation
-        - include: selector-parts
-    # id's
-    - match: '\s*(\#)(?={{ident}}|#)'
-      captures:
-        1: entity.other.attribute-name.id.css punctuation.definition.entity.css
-      push:
-        - meta_scope: meta.selector.css
-        - match: '{{ident}}'
-          scope: entity.other.attribute-name.id.css
-        - include: sass-interpolation
-        - include: selector-parts
-    # extend-only selectors
-    - match: '\s*(%){{ident}}*'
-      captures:
-        0: entity.other.attribute-name.placeholder.sass
-        1: punctuation.definition.entity.sass
-      push:
-        - meta_scope: meta.selector.css
-        - match: '{{ident}}'
-          scope: entity.other.attribute-name.placeholder.css
-        - include: sass-interpolation
-        - include: selector-parts
-    # attributes
-    - match: '\s*(?=\[)'
-      push:
-        - meta_scope: meta.selector.css
-        - match: '\['
-          scope: punctuation.definition.entity.css
-          push:
-            - meta_scope: meta.attribute-selector.css
-            - match: '\]'
-              scope: punctuation.definition.entity.css
-              pop: true
-            - include: qualified-name
-            - match: '({{ident}})'
-              scope: entity.other.attribute-name.css
-            - match: '\s*([~*|^$]?=)\s*'
-              captures:
-                1: keyword.operator.attribute-selector.css
-              push:
-                - match: '[^\s\]\[''"]'
-                  scope: string.unquoted.css
-                - include: literal-string
-                - match: '(?=(\s|\]))'
-                  pop: true
-            - match: '(?:\s+([iI]))?'  # case insensitive flag
-              captures:
-                1: keyword.other.css
-        - include: selector-parts
-    - include: pseudo-elements
-    - include: pseudo-classes
-    - match: '^\s*({{combinators}})(?![>~+])\s*'
-      captures:
-        0: meta.selector.css
-        1: punctuation.separator.combinator.css
-
-
-  interpolated-selector-body:
-    - match: '({)'
-      scope: punctuation.definition.group.begin.sass
-      push:
-        - match: '(})'
-          scope: punctuation.definition.group.end.sass
-          pop: true
-        - include: sass-script-expression
-    - include: selector-parts
-
-  interpolated-selectors:
-    - match: '\s*(#)(?={.*}{{pseudo_elements}})'
-      captures:
-        1: punctuation.definition.variable.sass
-      push:
-        - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
-    - match: '\s*(#)(?={.*}:{{regular_pseudo_classes}})'
-      captures:
-        1: punctuation.definition.variable.sass
-      push:
-        - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
-    - match: '\s*(#)(?={.*}:({{functional_pseudo_classes}})\()'
-      captures:
-        1: punctuation.definition.variable.sass
-      push:
-        - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
-    - match: '\s*(#)(?={.*}:(-(moz|ms|webkit)-){{ident}})'
-      captures:
-        1: punctuation.definition.variable.sass
-      push:
-        - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
-    - match: '\s*(#)(?={.*}(?![-:]))'
-      captures:
-        1: punctuation.definition.variable.sass
-      push:
-        - meta_scope: meta.selector.css meta.group.interpolation.sass
-        - include: interpolated-selector-body
-
-  custom-element-selectors:
-    # custom elements + pseudo elements
-    - match: '\s*({{custom_elements}})(?={{pseudo_elements}})'
-      captures:
-        1: entity.name.tag.custom.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    # custom elements + pseudoclasses
-    - match: '\s*({{custom_elements}})(?=:{{regular_pseudo_classes}})'
-      captures:
-        1: entity.name.tag.custom.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    - match: '\s*({{custom_elements}})(?=:({{functional_pseudo_classes}})\()'
-      captures:
-        1: entity.name.tag.custom.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    - match: '\s*({{custom_elements}})(?=:(-(moz|ms|webkit)-){{ident}})'
-      captures:
-        1: entity.name.tag.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-    # custom elements
-    - match: '\s*({{custom_elements}})(?!-|\s*:)'
-      captures:
-        1: entity.name.tag.custom.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-
-  selector-parts:
-    - match: '\s*(,)\s*'
-      captures:
-        1: punctuation.separator.css
-      pop: true
-    - match: '\s*({{combinators}})(?![>~+])\s*'
-      captures:
-        1: punctuation.separator.combinator.css
-      pop: true
-    - match: '\s*(?=\{)' # { of course only for scss, but doesn't hurt here
-      pop: true
-    - match: '(?=[.#\[&])' # look ahead for classes, id's and attr's
-      pop: true
-    - match: '(?=\))' # if passed as a parameter
-      pop: true
+  comments:
     - include: comment-block
-    - include: pseudo-elements
-    - include: pseudo-classes
-    - match: '\s*(?=$|//|/\*)'
-      pop: true
-    - match: '\s*(?=\b)'
-      pop: true
-
-  pseudo-elements:
-    - match: '\s*{{pseudo_elements}}'
-      scope: entity.other.pseudo-element.css
-      captures:
-        1: punctuation.definition.entity.css
-        2: punctuation.definition.entity.css
-        3: support.type.vendor-prefix.css
-
-  pseudo-classes:
-    - match: '\s*(:)(dir|lang)(?=\()'
-      scope: entity.other.pseudo-class.css
-      captures:
-        1: punctuation.definition.entity.css
-      push:
-        - meta_scope: meta.selector.css meta.function-call.css
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '\)'
-              scope: punctuation.definition.group.end.css
-              pop: true
-            - include: var-function
-            - include: unquoted-string
-        - match: ''
-          pop: true
-        - include: selector-parts
-
-    - match: '\s*(:)(matches|is|where|not|has)(?=\()'
-      scope: entity.other.pseudo-class.css
-      captures:
-        1: punctuation.definition.entity.css
-      push:
-        - meta_scope: meta.selector.css meta.function-call.css
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '\)'
-              scope: punctuation.definition.group.end.css
-              pop: true
-            - match: ','
-              scope: punctuation.separator.css
-            - include: selectors
-            - include: custom-element-selectors
-        - match: ''
-          pop: true
-        - include: selector-parts
-
-    - match: '\s*(:)(drop)(?=\()'
-      scope: entity.other.pseudo-class.css
-      captures:
-        1: punctuation.definition.entity.css
-      push:
-        - meta_scope: meta.selector.css meta.function-call.css
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '\)'
-              scope: punctuation.definition.group.end.css
-              pop: true
-            - match: \b(active|valid|invalid)\b
-              scope: keyword.other.pseudo-class.css
-            - include: var-function
-        - match: ''
-          pop: true
-        - include: selector-parts
-
-    - match: '\s*(:)(nth-last-child|nth-child|nth-last-of-type|nth-of-type)(?=\()'
-      scope: entity.other.pseudo-class.css
-      captures:
-        1: punctuation.definition.entity.css
-      push:
-        - meta_scope: meta.selector.css meta.function-call.css
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '\)'
-              scope: punctuation.definition.group.end.css
-              pop: true
-            - match: \b(even|odd){{break}}
-              scope: keyword.other.pseudo-class.css
-            - match: '(([-+]?)(\d*)(n))\s*(([-+])(\s*\d+))?'
-              captures:
-                1: meta.number.integer.decimal.css
-                2: keyword.operator.arithmetic.css
-                3: constant.numeric.value.css
-                4: constant.numeric.suffix.css
-                5: meta.number.integer.decimal.css
-                6: keyword.operator.arithmetic.css
-                7: constant.numeric.value.css
-            - match: '[-+]\s+\d+n?|[-+]?\d+\s+n'
-              scope: invalid.illegal.numeric.css
-            - include: var-function
-            - include: integer-type
-        - match: ''
-          pop: true
-        - include: selector-parts
-
-    - match: '\s*(:)(-(moz|ms|webkit)-){{ident}}'
-      scope: entity.other.pseudo-class.css
-      captures:
-        1: punctuation.definition.entity.css
-        2: support.type.vendor-prefix.css
-      push:
-        - meta_scope: meta.selector.css
-        - include: selector-parts
-
-    - match: '\s*(:)({{regular_pseudo_classes}})'
-      scope: meta.selector.css entity.other.pseudo-class.css
-      captures:
-        1: punctuation.definition.entity.css
-
-    - match: '\s*(:)(local|global)(?=\()'
-      scope: meta.selector.css entity.other.pseudo-class.css-modules.css
-      captures:
-        1: punctuation.definition.entity.css
-      push:
-        - meta_scope: meta.selector.css meta.function-call.css
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '\)'
-              scope: punctuation.definition.group.end.css
-              pop: true
-            - include: selectors
-            - include: literal-string
-        - match: ''
-          pop: true
-    - match: '\s*(:)(local|global)'
-      scope: meta.selector.css entity.other.pseudo-class.css-modules.css
-      captures:
-        1: punctuation.definition.entity.css
-
-  properties:
     - include: comment-line
-    - include: comment-block
-    - match: '^\s+(:)({{property_names}})(?=\s)'
-      captures:
-        1: punctuation.separator.key-value.css
-        2: meta.property-name.css support.type.property-name.css
-      push:
-        - meta_scope: meta.property-value.css
-        - match: '\s*(?=$)'
-          pop: true
-        - include: property-values
-    - match: '\b(font-family|font|family){{break}}(?=\s*:)'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - match: '(?=\s*[)])'
-          pop: true
-        - match: ':'
-          scope: punctuation.separator.key-value.css
-          push:
-            - meta_content_scope: meta.property-value.css
-            - match: '(?=\s*([)]))'
-              pop: true
-            - include: comment-line
-            - include: comment-block
-            - include: numeric-values
-            - include: property-value-constants
-            - include: var-function
-            - include: sass-maps
-            - include: sass-variables
-            - include: sass-functions
-            - include: sass-custom-functions
-            - match: '{{ident}}(\s+{{ident}})*\b(?!:)'
-              scope: string.unquoted.css
-            - include: literal-string
-            - include: unquoted-concatenated-string
-            - include: sass-operators
-            - include: comma-delimiter
-            - match: '(?=$)'
-              pop: true
-        - match: ''
-          pop: true
-    - match: '{{property_names}}'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - include: property-value-wrapper
-    - match: '(-(?:webkit|moz|ms|o)-)({{ident}})(?=\s*:)'
-      captures:
-        0: meta.property-name.css
-        1: support.type.vendor-prefix.css
-        2: support.type.property-name.css
-      push:
-        - include: property-value-wrapper
-    - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
-      captures:
-        0: variable.declaration.sass
-        1: punctuation.definition.variable.sass
-      push:
-        - include: property-value-wrapper
-    - match: '(--)({{nmchar}}+)'
-      captures:
-        0: meta.property-name.css support.type.custom-property.css
-        1: punctuation.definition.custom-property.css
-        2: support.type.custom-property.name.css
-      push:
-        - include: property-value-wrapper
-    # Partial property names, split at "-"
-    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
-    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - include: property-value-wrapper
-    - match: '[a-zA-Z0-9_-]*((#)({)((\$)([a-zA-Z0-9_-][\w-]*))(}))[a-zA-Z0-9_-]*'
-      captures:
-        0: meta.property-name.css support.type.property-name
-        1: meta.group.interpolation.sass
-        2: punctuation.definition.variable.sass
-        3: punctuation.definition.group.begin.sass
-        4: variable.other.sass
-        5: punctuation.definition.variable.sass
-        7: punctuation.definition.group.end.sass
-      push:
-        - include: property-value-wrapper
-    - match: '\b(composes)\b'
-      scope: meta.property-name.css-modules.css support.type.property-name
-      push:
-        - include: property-value-wrapper
 
-  property-value-wrapper:
-    - match: '(\s*)($)'
-      pop: true
-      captures:
-        1: meta.property-value.css
-    - match: '(?=\s*\))'
-      pop: true
-    - match: '\s*(:)'
-      captures:
-        1: punctuation.separator.key-value.css
+  comment-block:
+    - match: /\*
+      scope: punctuation.definition.comment.css
       push:
-        - meta_content_scope: meta.property-value.css
-        - match: '(?=\s*(\)|$))'
+        - meta_scope: comment.block.css
+        - match: \*/
+          scope: punctuation.definition.comment.css
           pop: true
-        - include: property-values
-    - match: ''
-      pop: true
+        - match: ^\s*(\*)(?!/)
+          captures:
+            1: punctuation.definition.comment.css
 
-  property-values:
-    - match: ';'
-      scope: invalid.illegal.sass
-    - match: '\!\s*important{{break}}'
-      scope: keyword.other.important.css
-      captures:
-        1: punctuation.definition.keyword.css
-    - match: '\!\s*(default|global|optional)'
-      scope: keyword.other.sass
-    - match: /
-      scope: keyword.operator.arithmetic.css
-    - include: comma-delimiter
-    - include: vendor-prefix
-    - include: comment-line
-    - include: comment-block
-    - include: builtin-functions
-    - include: line-names
-    - include: unicode-range
-    - include: numeric-values
-    - include: color-values
-    - include: property-value-constants
-    - include: literal-string
-    - include: sass-maps
-    - include: sass-variables
-    - include: sass-functions
-    - include: sass-custom-functions
-    - include: sass-interpolation
-    - include: unquoted-concatenated-string
-    - include: sass-operators
-    - match: '\s*(,)\s*'
-      captures:
-        1: punctuation.separator.css
-    - match: '{{ident}}' # e.g. animation-name
-      scope: string.unquoted.css
+  comment-line:
+    - match: //
+      scope: punctuation.definition.comment.css
+      push:
+        - meta_scope: comment.line.double-slash.sass
+        - match: \n
+          pop: true
+
+###[ AT RULES ]################################################################
 
   at-rules:
-    - match: '(@)(each)\b'
-      scope: keyword.control.flow.sass
+    - include: sass-at-rules
+    - include: at-charset
+    - include: at-counter-style
+    - include: at-custom-media
+    - include: at-document
+    - include: at-font-face
+    - include: at-import
+    - include: at-keyframes
+    - include: at-media
+    - include: at-namespace
+    - include: at-page
+    - include: at-page-margin
+    - include: at-supports
+    - include: at-other
+
+  sass-at-rules:
+    - match: '(@)(each){{break}}'
       captures:
+        0: keyword.control.flow.sass
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.each.sass
@@ -706,7 +713,7 @@ contexts:
         - include: comma-delimiter
         - match: '(?=$)'
           pop: true
-        - match: \b(in)\b
+        - match: \b(in){{break}}
           scope: keyword.operator.sass
           push:
             - match: '(?=$)'
@@ -722,61 +729,61 @@ contexts:
             - include: sass-maps
             - include: unquoted-string
             - include: sass-operators
-    - match: '(@)(for|while)\b'
-      scope: keyword.control.flow.sass
+    - match: '(@)(for|while){{break}}'
       captures:
+        0: keyword.control.flow.sass
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
         - match: '(?=$)'
           pop: true
         - include: sass-script-expression
-    - match: '(@)(if|else if|else)\b'
-      scope: keyword.control.flow.conditional.sass
+    - match: '(@)(if|else if|else){{break}}'
       captures:
+        0: keyword.control.flow.conditional.sass
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
         - match: '(?=$)'
           pop: true
         - include: sass-script-expression
-    - match: '(@)(warn|error)\b'
-      scope: keyword.control.at-rule.warn.sass
+    - match: '(@)(warn|error){{break}}'
       captures:
+        0: keyword.control.at-rule.warn.sass
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
         - match: '(?=$)'
           pop: true
         - include: sass-script-expression
-    - match: '(@)(debug)\b'
-      scope: keyword.control.at-rule.debugger.sass
+    - match: '(@)(debug){{break}}'
       captures:
+        0: keyword.control.at-rule.debugger.sass
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
         - match: '(?=$)'
           pop: true
         - include: sass-script-expression
-    - match: '(@)(at-root)\b'
-      scope: keyword.control.at-rule.at-root.sass
+    - match: '(@)(at-root){{break}}'
       captures:
+        0: keyword.control.directive.at-root.sass
         1: punctuation.definition.keyword.sass
-    - match: '(@)(extend)\b'
-      scope: keyword.control.at-rule.extend.sass
+    - match: '(@)(extend){{break}}'
       captures:
+        0: keyword.control.directive.extend.sass
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.extend.sass
         - match: '(?=$)'
           pop: true
-        - match: \!\s*(default|global|optional)
+        - match: \!\s*(default|global|optional){{break}}
           scope: keyword.other.sass
         - include: selectors
         - include: custom-element-selectors
     - match: '((@)(mixin|function))\s+([\w-]+)'
       captures:
-        1: keyword.control.at-rule.sass
+        1: keyword.control.directive.sass
         2: punctuation.definition.keyword.sass
         4: entity.name.function.sass
       push:
@@ -806,7 +813,7 @@ contexts:
     - match: '((@)(include))\s+(([a-z]+)(\.))?([\w-]+)'
       captures:
         0: variable.function.sass
-        1: keyword.control.at-rule.sass
+        1: keyword.control.directive.sass
         2: punctuation.definition.keyword.sass
         5: entity.name.namespace.sass
         6: punctuation.separator.namespace.sass
@@ -833,18 +840,18 @@ contexts:
             - match: '\)'
               scope: punctuation.definition.group.end.sass
               pop: true
-    - match: '(@)(return)\b'
-      scope: keyword.control.at-rule.return.sass
+    - match: '(@)(return){{break}}'
       captures:
+        0: keyword.control.directive.return.sass
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
         - match: '\s*(?=$)'
           pop: true
         - include: property-values
-    - match: '\s*((@)(use|forward)\b)\s*'
+    - match: '\s*((@)(use|forward){{break}})\s*'
       captures:
-        1: keyword.control.at-rule.module.sass
+        1: keyword.control.directive.module.sass
         2: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.module.sass
@@ -888,228 +895,2510 @@ contexts:
         - include: comment-block
         - include: comment-line
         - include: literal-string
-    - match: '((@)(?:-(?:webkit|moz|o)-)?(charset|namespace|font-face){{break}})'
+
+  # @charset
+  # https://www.w3.org/TR/css-syntax-3/#at-ruledef-charset
+  at-charset:
+    - match: (@)(?i:charset){{break}}
       captures:
-        1: keyword.control.at-rule.css
-        2: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.css
-        - match: '\s*(?=$)'
-          pop: true
-        - match: '(url)(\()'
-          captures:
-            1: meta.function-call.css support.function.url.css
-            2: punctuation.definition.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '\)'
-              scope: punctuation.definition.group.end.css
-              pop: true
-            - include: literal-string
-            - include: unquoted-string
-        - include: comment-block
-        - include: comment-line
-        - include: literal-string
-    - match: '\s*((@)counter-style\b)\s+(?:(?i:\b(decimal|none)\b)|({{ident}}))?\s*(?=\{|$)'
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-charset-content
+
+  at-charset-content:
+    - meta_scope: meta.at-rule.charset.css
+    - include: comments
+    - include: quoted-strings
+    - include: at-rule-end
+
+  # @counter-style
+  # https://drafts.csswg.org/css-counter-styles-3/#the-counter-style-rule
+  at-counter-style:
+    - match: (@)(?i:counter-style){{break}}
       captures:
-        1: keyword.control.at-rule.counter-style.css
-        2: punctuation.definition.keyword.css
-        3: invalid.illegal.counter-style-name.css
-        4: entity.other.counter-style-name.css
-      push:
-        - meta_scope: meta.at-rule.counter-style.css
-        - include: comment-block
-        - include: comment-line
-        - match: '(?=$)'
-          pop: true
-    - match: '(?=\s*@custom-media){{break}}'
-      push:
-        - match: '(?=$)'
-          pop: true
-        - match: '\s*((@)custom-media)'
-          captures:
-            1: keyword.control.at-rule.custom-media.css
-            2: punctuation.definition.keyword.css
-            3: support.constant.custom-media.css
-          push:
-            - meta_scope: meta.at-rule.custom-media.css
-            - match: '\s*(?=$)'
-              pop: true
-            - include: media-query
-    - match: '((@)document){{break}}'
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-counter-style-content
+
+  at-counter-style-content:
+    - meta_scope: meta.at-rule.counter-style.css
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-counter-style-block-content
+    - include: at-counter-style-names
+    - include: at-rule-end
+
+  at-counter-style-block-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: at-counter-style-property-names
+    - include: property-values
+    - include: rule-terminators
+    - include: illegal-blocks
+    - include: illegal-groups
+
+  at-counter-style-names:
+    - match: '{{counter_style_illegal_names}}'
+      scope: invalid.illegal.identifier.css
+    - match: '{{ident}}'
+      scope: entity.other.counter-style-name.css
+
+  at-counter-style-property-names:
+    - include: counter-style-fallback-properties
+    - include: counter-style-system-properties
+    - include: counter-style-speak-as-properties
+    - match: '{{counter_style_property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
+
+  # @custom-media
+  # https://??
+  at-custom-media:
+    - match: (@)(?i:custom-media){{break}}
       captures:
-        1: keyword.control.at-rule.document.css
-        2: punctuation.definition.keyword.css
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
       push:
-        - meta_scope: meta.at-rule.document.css
-        - match: '(?=$)'
-          pop: true
-        - include: comment-block
-        - include: comment-line
-        - include: url-function
-        - include: url-prefix-function
-        - include: domain-function
-        - include: regexp-function
-        - include: comma-delimiter
-    - match: '\s*((@)import){{break}}\s*'
+        - at-custom-media-content
+        - at-custom-media-identifier
+
+  at-custom-media-identifier:
+    - match: '{{custom_ident}}'
+      scope: entity.other.custom-media.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+  at-custom-media-content:
+    - meta_scope: meta.at-rule.custom-media.css
+    - include: media-queries
+    - include: at-rule-end
+
+  # @document
+  # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#at-document
+  at-document:
+    - match: (@)(?i:document){{break}}
       captures:
-        1: keyword.control.at-rule.import.css
-        2: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.import.css
-        - match: '(?=$)'
-          pop: true
-        - match: '(\()(reference|inline|less|css|once|multiple|optional)(\))'
-          captures:
-            0: meta.at-rule.arguments.sass
-            1: punctuation.definition.group.begin.sass
-            2: constant.other.sass
-            3: punctuation.definition.group.end.sass
-        - include: comment-block
-        - include: comment-line
-        - include: literal-string
-        - include: url-function
-        - include: media-query
-    - match: '\s*((@)(-webkit-|-moz-|-o-)?keyframes){{break}}'
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-document-content
+
+  at-document-content:
+    - meta_scope: meta.at-rule.document.css
+    - include: comma-delimiters
+    - include: url-functions
+    - include: at-document-functions
+    - include: at-rule-block
+    - include: at-rule-end
+
+  # @font-face
+  # https://www.w3.org/TR/css-fonts-4/#at-font-face-rule
+  at-font-face:
+    - match: (@)(?i:font-face){{break}}
       captures:
-        1: keyword.control.at-rule.keyframe.css
-        2: punctuation.definition.keyword.css
-      push:
-        - meta_scope: meta.at-rule.keyframe.css
-        - match: '\s*(?=$)'
-          pop: true
-        - include: comment-block
-        - include: comment-line
-        - include: sass-interpolation
-        - match: '\s*({{ident}})?'
-          captures:
-            1: entity.other.animation-name.css
-        - match: '\s*(?:(,)|(?=[{]))'
-          captures:
-            1: punctuation.definition.arbitrary-repetition.css
-    - match: '\s*((@)media){{break}}'
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-font-face-content
+
+  at-font-face-content:
+    - meta_scope: meta.at-rule.font-face.css
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-font-face-block-content
+    - include: at-rule-end
+
+  at-font-face-block-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: at-font-face-property-names
+    - include: property-values
+    - include: rule-terminators
+    - include: illegal-blocks
+    - include: illegal-groups
+
+  at-font-face-property-names:
+    - match: \b(?i:font-family){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: font-property-value
+    - match: '{{font_face_property_names}}'
+      scope: meta.property-name.css support.type.property-name.css
+
+  # @import
+  # https://www.w3.org/TR/css-cascade-4/#at-ruledef-import
+  at-import:
+    - match: (@)(?i:import){{break}}
       captures:
-        1: keyword.control.at-rule.media.css
-        2: punctuation.definition.keyword.css
-        3: support.constant.media.css
-      push:
-        - meta_scope: meta.at-rule.media.css
-        - include: media-query
-        - match: '(?=$)'
-          pop: true
-    - match: '\s*((@)namespace)\s+({{ident}}(?!{{nmchar}}|\())?'
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-import-content
+
+  at-import-content:
+    - meta_scope: meta.at-rule.import.css
+    - include: quoted-strings
+    - include: url-functions
+    - include: media-queries
+    - include: at-rule-end
+
+  # @keyframes
+  # https://www.w3.org/TR/css3-animations/#at-ruledef-keyframes
+  at-keyframes:
+    - match: (@)(?i:keyframes){{break}}
       captures:
-        1: keyword.control.at-rule.namespace.css
-        2: punctuation.definition.keyword.css
-        3: entity.other.namespace-prefix.css
-      push:
-        - meta_scope: meta.at-rule.namespace.css
-        - match: '(?=$)'
-          pop: true
-        - include: literal-string
-        - include: url-function
-        - include: comment-block
-        - include: comment-line
-    - match: '\s*((@)page)\s*(?:(:)(first|left|right))?\s*'
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-keyframe-content
+
+  at-keyframe-content:
+    - meta_scope: meta.at-rule.keyframe.css
+    - include: comma-delimiters
+    - include: at-keyframe-block
+    - include: at-keyframe-names
+    - include: at-rule-end
+
+  at-keyframe-names:
+    - include: sass-interpolation
+    - match: '{{illegal_custom_ident}}'
+      scope: invalid.illegal.identifier.css
+    - match: '{{ident}}'
+      scope: entity.other.animation-name.css
+    - include: quoted-strings
+
+  at-keyframe-block:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-keyframe-block-content
+
+  at-keyframe-block-content:
+    - meta_scope: meta.block.css
+    - include: block-end2
+    - include: comments
+    - include: property-lists
+    - include: at-keyframe-selectors
+
+  at-keyframe-selectors:
+    - match: (?=[[:alnum:].,%])
+      push: at-keyframe-selector-content
+
+  at-keyframe-selector-content:
+    - meta_scope: meta.selector.css
+    - include: comma-delimiters
+    - include: percentage-constants
+    - match: \b(?i:from|to){{break}}
+      scope: keyword.other.selector.css
+    - include: selector-end
+
+  # @media
+  # https://drafts.csswg.org/css-conditional-3/#at-ruledef-media
+  at-media:
+    - match: (@)(?i:media){{break}}
       captures:
-        1: keyword.control.at-rule.page.css
-        2: punctuation.definition.keyword.css
-        3: punctuation.definition.entity.css
-        4: entity.other.pseudo-class.css
-      push:
-        - meta_scope: meta.at-rule.page.css
-        - include: comment-block
-        - include: comment-line
-        - match: '\s*(?=$)'
-          pop: true
-    - match: '((@)supports){{break}}'
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-media-content
+
+  at-media-content:
+    - meta_scope: meta.at-rule.media.css
+    - include: media-queries
+    - include: at-rule-block
+    - include: at-rule-end
+
+  # @namespace
+  # https://www.w3.org/TR/css3-namespace/
+  at-namespace:
+    - match: (@)(?i:namespace){{break}}
       captures:
-        1: keyword.control.at-rule.supports.css
-        2: punctuation.definition.keyword.css
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
       push:
-        - meta_scope: meta.at-rule.supports.css
-        - match: '(?=$)'
-          pop: true
-        - include: at-supports-operators
-        - include: at-supports-parens
-    - match: '((@)content){{break}}'
+        - at-namespace-content
+        - at-namespace-identifier
+
+  at-namespace-identifier:
+    - match: '{{ident}}(?!{{nmchar}}|\()'
+      scope: entity.other.namespace-prefix.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+  at-namespace-content:
+    - meta_scope: meta.at-rule.namespace.css
+    - include: var-functions
+    - include: url-functions
+    - include: quoted-urls
+    - include: at-rule-end
+
+  # @page
+  # https://www.w3.org/TR/css3-page/#at-ruledef-page
+  at-page:
+    - match: (@)(?i:page){{break}}
       captures:
-        1: keyword.control.at-rule.content.sass
-        2: punctuation.definition.keyword.sass
-      push:
-        - match: '(?=$)'
-          pop: true
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-page-content
+
+  at-page-content:
+    - meta_scope: meta.at-rule.page.css
+    - include: comma-delimiters
+    - include: at-page-block
+    - include: at-page-names
+    - include: at-rule-end
+
+  at-page-names:
+    - match: (:)(?i:blank|first|left|right){{break}}
+      captures:
+        0: entity.other.pseudo-class.css
+        1: punctuation.definition.entity.css
+    - match: (:){{nmchar}}*
+      captures:
+        # 0: invalid.illegal.pseudo-class.css
+        1: punctuation.definition.entity.css
+    - match: '{{ident}}'
+      scope: entity.other.page-name.css
+
+  at-page-block:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-page-block-content
+
+  at-page-block-content:
+    - meta_scope: meta.property-list.css meta.block.css
+    - include: block-end2
+    - include: at-page-margin
+    - include: at-other
+    - include: property-lists
+    - include: rule-list-body
+
+  # @top-center, ...
+  # https://www.w3.org/TR/css-page-3/#margin-at-rule
+  at-page-margin:
+    - match: (@){{page_margin_property_names}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-page-margin-content
+
+  at-page-margin-content:
+    - meta_scope: meta.at-rule.margin.css
+    - include: at-page-block
+    - include: at-rule-end
+
+  # @supports
+  # https://drafts.csswg.org/css-conditional-3/#at-supports
+  at-supports:
+    - match: (@)(?i:supports){{break}}
+      captures:
+        0: keyword.control.directive.css
+        1: punctuation.definition.keyword.css
+      push: at-supports-content
+
+  at-supports-content:
+    - meta_scope: meta.at-rule.supports.css
+    - include: at-supports-groups
+    - include: at-supports-operators
+    - include: at-rule-block
+    - include: at-rule-end
 
   at-supports-operators:
-    - match: '\b(?i:and|or|not)\b'
+    - match: \b(?i:and|or|not){{break}}
+      scope: keyword.operator.logical.css
+
+  at-supports-groups:
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      push: at-supports-group-content
+
+  at-supports-group-content:
+    - meta_scope: meta.group.css
+    - include: group-end
+    - include: at-rule-end
+    - include: at-supports-groups
+    - include: at-supports-operators
+    - include: rule-list-body
+
+  # @<ident>
+  # Fallback context for incomplete or unknown at-rules.
+  # https://www.w3.org/TR/css-syntax-3/#at-rule
+  # https://www.w3.org/TR/CSS22/syndata.html#parsing-errors
+  at-other:
+    - match: (@){{ident}}
+      push: at-other-content
+
+  at-other-content:
+    - meta_scope: meta.at-rule.other.css
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-other-block-content
+    - include: at-rule-end
+
+  at-other-block-content:
+    - meta_scope: meta.block.css
+    - include: block-end2
+
+  at-rule-block:
+    - match: \{
+      scope: punctuation.section.block.begin.css
+      push: at-rule-block-content
+
+  at-rule-block-content:
+    - meta_scope: meta.block.css
+    - include: block-end2
+    - include: main
+
+  at-rule-end:
+    - match: (?=[;{}])
+      pop: 1
+    - include: comments
+
+
+###[ MEDIA QUERIES ]###########################################################
+
+  media-queries:
+    - include: comma-delimiters
+    - include: media-query-conditions
+    - include: media-query-media-types
+
+  media-query-conditions:
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      push: media-query-group-content
+    - match: '[<>]=?|='
+      scope: keyword.operator.comparison.css
+    - match: \b(?i:and|or|not|only){{break}}
       scope: keyword.operator.logic.css
 
-  at-supports-parens:
-    - match: '\('
-      scope: punctuation.definition.group.begin.css
-      push:
-        - meta_scope: meta.group.css
-        - match: '\)'
-          scope: punctuation.definition.group.end.css
-          pop: true
-        - include: at-supports-operators
-        - include: at-supports-parens
-        - include: comment-block
-        - include: comment-line
-        - include: properties
+  media-query-group-content:
+    - meta_scope: meta.group.css
+    - match: (?=[,;{}])
+      pop: 1
+    - include: group-end
+    - include: comments
+    - include: media-query-conditions
+    - include: media-query-property-names
+    - include: media-query-property-values
+    - include: sass-value-expression
+    - include: var-functions
+    - include: calc-functions
+    - include: scalar-rational-constants
+    - include: numeric-constants
 
-  keyframe-operators:
-    - match: \b(from|to)\b
-      scope: keyword.keyframe-selector.css
-    - include: comma-delimiter
-    - include: numeric-values
+  media-query-property-names:
+    - match: |-
+        (?xi:
+          ({{vendor_prefix}})?
+          (
+            (?: min- | max- )?
+            (?:
+              color (?: -gamut | -index )?
+            | monochrome | resolution | update
+            | (?: device- )? (?: height | width | aspect-ratio | pixel-ratio )
+            )
+          | (?:any-)?(?: pointer | hover )
+          | display-mode | grid | orientation | scan | scripting
+          | overflow-(?: block | inline )
+          )
+        ){{break}}
+      captures:
+        1: support.type.vendor-prefix.css
+        2: support.type.property-name.css
 
-  media-query:
-    - include: comment-block
-    - include: comment-line
-    - match: '\b(?i:all|aural|braille|embossed|handheld|print|projection|screen|speech|tty|tv)\b'
+  media-query-property-values:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      push: media-query-property-value-content
+
+  media-query-property-value-content:
+    - match: |-
+        \b(?xi:
+        # global css constants
+          all | inherit | initial | none | unset
+        # color-gamut / color-index:
+        | srgb | p3 | rec2020
+        # display-mode:
+        | browser | fullscreen | standalone | minimal-ui
+        # hover:
+        | hover
+        # orientation:
+        | landscape | portrait
+        # overflow:
+        | optional-paged | paged | scroll
+        # pointer:
+        | coarse | fine
+        # scan:
+        | interlace | progressive
+        # scripting:
+        | enabled | initial-only
+        # update:
+        | fast | normal | slow
+        ){{break}}
+      scope: support.constant.property-value.css
+      pop: 1
+    - include: else-pop
+
+  media-query-media-types:
+    # Media Types:
+    # https://www.w3.org/TR/CSS21/media.html
+    # https://drafts.csswg.org/mediaqueries-5/#media-types
+    - match: |-
+        \b(?xi:
+        # global css constants
+          all | inherit | initial | none | unset
+        # specs
+        | print | screen | speech
+        # deprecated
+        | aural | braille | embossed | handheld | projection | tty | tv
+        ){{break}}
       scope: support.constant.media.css
-    - match: \b(?i:and|or|not|only)\b
-      scope: keyword.operator.logic.media.css
-    - match: ','
-      scope: punctuation.definition.arbitrary-repetition.css
-    - match: '\('
-      scope: punctuation.definition.group.begin.css
-      push:
-        - match: '\)'
-          scope: punctuation.definition.group.end.css
-          pop: true
-        - include: comment-block
-        - include: comment-line
-        - match: |-
-            (?x)
-            (
-              (?:
-                (-webkit-|-o-)?
-                (?:min-|max-)?
-                (-moz-)?
-                (?:
-                  (?:device-)?(?:height|width|aspect-ratio|pixel-ratio)
-                  |color(?:-index)?|monochrome|resolution
-                )
-              )
-              |grid|scan|orientation
-            )\s*(:)?
-          captures:
-            1: support.type.property-name.media.css
-            2: support.type.vendor-prefix.css
-            3: support.type.vendor-prefix.css
-            4: punctuation.separator.key-value.css
-        - match: \b(portrait|landscape|progressive|interlace)
-          scope: support.constant.property-value.css
-        - match: '\s*(\d+)(/)(\d+)'
-          captures:
-            1: meta.number.integer.decimal.css constant.numeric.value.css
-            2: keyword.operator.arithmetic.css
-            3: meta.number.integer.decimal.css constant.numeric.value.css
-        - include: sass-value-expression
-        - include: numeric-values
 
+
+###[ SELECTORS ]###############################################################
+
+  # The original Sass syntax needs lookaheads for specific pseudo-classes
+  # and pseudo-elements, to understand if you're writing a selector
+  # or a property
+
+  selectors:
+    - match: (?=[:.*#[:alpha:]\[]|{{combinators}})
+      push: selector-content
+
+  selector-content:
+    - meta_scope: meta.selector.css
+    - include: selector-end
+    - include: comma-delimiters
+    # ampersand
+    - match: '\s*(&)'
+      captures:
+        1: keyword.operator.ampersand.sass
+      push:
+        - meta_scope: meta.selector.css
+        - match: '[-_]+'
+          scope: entity.other.attribute-name.css
+          push:
+            - match: '{{ident}}'
+              scope: entity.other.attribute-name.css
+            - include: sass-interpolation
+            - include: selector-parts
+        - include: selector-content
+    # # standard elements + pseudo elements
+    # - match: '\s*({{element_names}})(?={{pseudo_elements}})'
+    #   captures:
+    #     1: entity.name.tag.css
+    #   push:
+    #     - meta_scope: meta.selector.css
+    #     - include: selector-parts
+    # # standard elements + pseudoclasses
+    # - match: '\s*({{element_names}})(?=:{{regular_pseudo_classes}})'
+    #   captures:
+    #     1: entity.name.tag.css
+    #   push:
+    #     - meta_scope: meta.selector.css
+    #     - include: selector-parts
+    # - match: '\s*({{element_names}})(?=:({{functional_pseudo_classes}})\()'
+    #   captures:
+    #     1: entity.name.tag.css
+    #   push:
+    #     - meta_scope: meta.selector.css
+    #     - include: selector-parts
+    # - match: '\s*({{element_names}})(?=:(-(moz|ms|webkit)-){{ident}})'
+    #   captures:
+    #     1: entity.name.tag.css
+    #   push:
+    #     - meta_scope: meta.selector.css
+    #     - include: selector-parts
+
+    # Html Tags
+    - match: '{{html_tags}}'
+      scope: entity.name.tag.html.css
+    - match: '{{svg_tags}}'
+      scope: entity.name.tag.svg.css
+    # Custom Elements
+    # http://w3c.github.io/webcomponents/spec/custom/#custom-elements-core-concepts
+    - match: '{{custom_element_tags}}'
+      scope: entity.name.tag.custom.css
+    - match: \*
+      scope: variable.language.wildcard.asterisk.css
+    # Class and Id Selectors
+    # https://drafts.csswg.org/selectors-4/#class-html
+    - match: \.
+      scope: punctuation.definition.entity.css
+      push:
+        - meta_scope: entity.other.attribute-name.class.css
+        - include: sass-interpolation
+        - match: '{{generic_ident}}'
+          pop: 1
+        - include: immediately-pop
+    # https://drafts.csswg.org/selectors-4/#id-selectors
+    - match: \#
+      scope: punctuation.definition.entity.css
+      push:
+        - meta_scope: entity.other.attribute-name.id.css
+        - include: sass-interpolation
+        - match: '{{generic_ident}}'
+          pop: 1
+        - include: immediately-pop
+    # sass extend-only selectors
+    - match: \%
+      scope: punctuation.definition.entity.sass
+      push:
+        - meta_scope: entity.other.attribute-name.placeholder.sass
+        - include: sass-interpolation
+        - match: '{{generic_ident}}'
+          pop: 1
+        - include: immediately-pop
+    # Attribute Selectors
+    # https://drafts.csswg.org/selectors-4/#attribute-selectors
+    - match: \[
+      scope: punctuation.section.brackets.begin.css
+      push:
+        - attribute-selector-meta
+        - attribute-selector-key
+    # Pseudo Elements
+    # https://drafts.csswg.org/selectors-4/#pseudo-elements
+    - match: '::'
+      scope: punctuation.definition.pseudo-element.css
+      push:
+        - meta_include_prototype: false
+        - include: vendor-prefixes
+        - include: pseudo-element-function
+        - include: pseudo-element-regular
+        - include: immediately-pop
+    # Pseudo Classes
+    # https://drafts.csswg.org/selectors-4/#pseudo-classes
+    - match: ':'
+      scope: punctuation.definition.pseudo-class.css
+      push:
+        - meta_include_prototype: false
+        - include: vendor-prefixes
+        - include: pseudo-element-css2
+        - include: pseudo-class-function
+        - include: pseudo-class-regular
+        - include: immediately-pop
+    # Combinators
+    # https://drafts.csswg.org/selectors-4/#combinators
+    # https://drafts.csswg.org/css-scoping/#deep-combinator
+    - match: '{{combinators}}(?![>~+|])'
+      scope: keyword.operator.combinator.css
+    - match: '{{combinators}}{2,}|\|{3,}'
+      scope: invalid.illegal.combinator.css
+
+  selector-end:
+    - match: (?=\s*[;@(){}])
+      pop: 1
+    - include: comments
+
+  # Qualified Names
+  # https://drafts.csswg.org/css-namespaces-3/#css-qnames
+  namespace-prefixes:
+    - match: (?:({{ident}})|(\*))?(\|)(?!=)
+      captures:
+        1: entity.other.namespace-prefix.css
+        2: variable.language.wildcard.asterisk.css
+        3: punctuation.separator.namespace.css
+
+  vendor-prefixes:
+    - match: '{{vendor_prefix}}'
+      scope: support.type.vendor-prefix.css
+
+###[ SASS INTERPOLATED SELECTORS ]#########################################
+
+  interpolated-selector-body:
+    - match: '({)'
+      scope: punctuation.definition.group.begin.sass
+      push:
+        - match: '(})'
+          scope: punctuation.definition.group.end.sass
+          pop: true
+        - include: sass-script-expression
+    - include: selector-parts
+
+  interpolated-selectors:
+    # - match: '\s*(#)(?={.*}{{pseudo_elements}})'
+    #   captures:
+    #     1: punctuation.definition.variable.sass
+    #   push:
+    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
+    #     - include: interpolated-selector-body
+    # - match: '\s*(#)(?={.*}:{{regular_pseudo_classes}})'
+    #   captures:
+    #     1: punctuation.definition.variable.sass
+    #   push:
+    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
+    #     - include: interpolated-selector-body
+    # - match: '\s*(#)(?={.*}:({{functional_pseudo_classes}})\()'
+    #   captures:
+    #     1: punctuation.definition.variable.sass
+    #   push:
+    #     - meta_scope: meta.selector.css meta.group.interpolation.sass
+    #     - include: interpolated-selector-body
+    - match: '\s*(#)(?={.*}:(-(moz|ms|webkit)-){{ident}})'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: interpolated-selector-body
+    - match: '\s*(#)(?={.*}(?![-:]))'
+      captures:
+        1: punctuation.definition.variable.sass
+      push:
+        - meta_scope: meta.selector.css meta.group.interpolation.sass
+        - include: interpolated-selector-body
+
+###[ SELECTORS / ATTRIBUTE SELECTORS ]#########################################
+
+  attribute-selector-meta:
+    - meta_scope: meta.attribute-selector.css meta.brackets.css
+    - include: immediately-pop
+
+  attribute-selector-key:
+    - include: namespace-prefixes
+    - match: '{{ident}}'
+      scope: entity.other.attribute-name.css
+      set: attribute-selector-operator
+    - match: \*
+      scope: variable.language.wildcard.asterisk.css
+      set: attribute-selector-operator
+    - include: attribute-selector-operator
+
+  attribute-selector-operator:
+    - match: '[~*|^$]?='
+      scope: keyword.operator.logical.css
+      set:
+        - attribute-selector-flag
+        - attribute-selector-value
+    - include: attribute-selector-flag
+
+  attribute-selector-value:
+    - include: comments
+    - include: quoted-string
+    - match: '[^\s\]\[''"]+'
+      scope: meta.string.css string.unquoted.css
+      pop: 1
+    - include: else-pop
+
+  attribute-selector-flag:
+    - match: \b[iI]{{break}}
+      scope: keyword.other.flag.css
+      set: attribute-selector-end
+    - include: attribute-selector-end
+
+  attribute-selector-end:
+    - match: \]
+      scope: punctuation.section.brackets.end.css
+      pop: 1
+    - include: selector-end
+    - match: \S
+      scope: invalid.illegal.css
+
+###[ SELECTORS / PSEUDO CLASSES ]##############################################
+
+  # Functional Pseudo Classes
+  # https://drafts.csswg.org/selectors-4/#functional-pseudo-class
+  pseudo-class-function:
+    - include: pseudo-class-function-dir
+    - include: pseudo-class-function-lang
+    - include: pseudo-class-function-with-anb-args
+    - include: pseudo-class-function-with-selector-args
+    - include: pseudo-class-function-with-generic-args
+
+  # Special :dir() pseudo-class
+  # https://drafts.csswg.org/selectors-4/#the-dir-pseudo
+  pseudo-class-function-dir:
+    - match: (?i:dir)(?=\()
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: direction-constants
+
+  # Special :lang() pseudo-class
+  # https://drafts.csswg.org/selectors-4/#the-lang-pseudo
+  pseudo-class-function-lang:
+    - match: (?i:lang)(?=\()
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: quoted-strings
+            - include: language-ranges
+
+  # Functional Pseudo Classes with `An+B` param
+  # An+B Notation: https://drafts.csswg.org/css-syntax/#anb
+  pseudo-class-function-with-anb-args:
+    - match: |-
+        (?xi:
+        # https://drafts.csswg.org/selectors-4/#table-pseudos
+          nth-last-col
+        | nth-col
+        # https://drafts.csswg.org/selectors-4/#typed-child-index
+        | nth-last-child
+        | nth-child
+        | nth-last-of-type
+        | nth-of-type
+        )(?=\()
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: anb-notation-values
+            - include: scalar-integer-constants
+
+  anb-notation-values:
+    - match: \b(even|odd){{break}}
+      scope: support.constant.property-value.css
+    - match: (([-+]?)(\d*)(n))\s*(([-+])(\s*\d+))?
+      captures:
+        1: meta.number.integer.decimal.css
+        2: keyword.operator.arithmetic.css
+        3: constant.numeric.value.css
+        4: constant.numeric.suffix.css
+        5: meta.number.integer.decimal.css
+        6: keyword.operator.arithmetic.css
+        7: constant.numeric.value.css
+    - match: '[-+]\s+\d+n?|[-+]?\d+\s+n'
+      scope: invalid.illegal.numeric.css
+
+  # Functional Pseudo Classes with selector list
+  pseudo-class-function-with-selector-args:
+    - match: (?i:matches|is|where|not|has)(?=\()
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: selectors
+
+  # Functional Pseudo Classes with generic arguments
+  pseudo-class-function-with-generic-args:
+    - match: '{{ident}}(?=\()'
+      scope: meta.function-call.identifier.css entity.other.pseudo-class.css
+      set: other-functions-arguments
+
+  # Regular Pseudo Classes
+  # https://drafts.csswg.org/selectors-4/#pseudo-classes
+  pseudo-class-regular:
+    - match: '{{ident}}'
+      scope: entity.other.pseudo-class.css
+      pop: 1
+
+  # Legacy Pseudo Elements
+  # https://drafts.csswg.org/selectors-4/#pseudo-elements
+  pseudo-element-css2:
+    # Note: CSS1 & CSS2 compatibility requires those to be matched after `:`
+    - match: (?i:before|after|first-line|first-letter){{break}}
+      scope: entity.other.pseudo-element.css
+      pop: 1
+
+  # Functional Pseudo Elements
+  # https://drafts.csswg.org/selectors-4/#pseudo-elements
+  pseudo-element-function:
+    - match: '{{ident}}(?=\()'
+      scope: meta.function-call.identifier.css entity.other.pseudo-element.css
+      set: other-functions-arguments
+
+  # Pseudo Elements
+  # https://drafts.csswg.org/selectors-4/#pseudo-elements
+  pseudo-element-regular:
+    - match: '{{ident}}'
+      scope: entity.other.pseudo-element.css
+      pop: 1
+
+###[ PROPERTY LISTS ]##########################################################
+
+  # Highly modified from CSS because there is no strict separation
+  # between selectors and properties in Sass,
+  # ie. there is no 'property list'
+
+  properties:
+    - include: comments
+    - include: property-identifiers
+    - include: property-values
+    - include: rule-terminators
+    - include: illegal-blocks
+    - include: illegal-groups
+
+###[ PROPERTY IDENTIFIERS ]####################################################
+
+  property-identifiers:
+    - match: (?=[-[:alpha:]])
+      push: property-identifier-content
+
+  property-identifier-content:
+    - meta_scope: meta.property-name.css
+    - include: vendor-prefixes
+    # specific properties with special treatment
+    - include: counter-property
+    - include: font-property
+    # common properties
+    - include: builtin-property
+    - include: custom-property
+    - include: deprecated-property
+    - include: other-property
+    # bailout
+    - include: immediately-pop
+
+  builtin-property:
+    - match: '{{property_names}}'
+      scope: support.type.property-name.css
+      pop: 1
+
+  # Custom Properties
+  # https://drafts.csswg.org/css-variables/#typedef-custom-property
+  custom-property:
+    # custom property definition
+    - match: '{{custom_ident}}'
+      scope: entity.other.custom-property.css
+      pop: 1
+
+  deprecated-property:
+    - match: \b(var-)({{ident}})
+      scope: invalid.deprecated.custom-property.css
+      captures:
+        1: entity.other.custom-property.prefix.css
+        2: entity.other.custom-property.name.css
+      pop: 1
+
+  other-property:
+    # Note: Consume unknown identifiers to maintain word boundaries.
+    - match: '{{generic_ident}}'
+      pop: 1
+
+###[ PROPERTY VALUES ]#########################################################
+
+  property-values:
+    - match: ';'
+      scope: invalid.illegal.sass
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      push: property-value-content
+
+  property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: comma-delimiters
+    - include: common-operators
+    - include: builtin-values
+    - include: other-functions
+    - include: other-constants
+    - include: sass-maps
+
+  builtin-values:
+    - include: sass-value-expression
+    - include: quoted-strings
+    - include: builtin-functions
+    - include: color-values
+    - include: line-names
+    - include: unicode-ranges
+    - include: numeric-constants
+    - include: common-constants
+    - include: generic-font-names
+    - include: vendor-prefixes
+
+  # When including `color-values` and `color-adjuster-functions`, make sure it is
+  # included after the color adjustors to prevent `color-values` from consuming
+  # conflicting function names & color constants such as `red`, `green`, or `blue`.
+  color-values:
+    - include: color-functions
+    - include: color-constants
+
+  # Counter Symbol Values
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-system
+  # https://drafts.csswg.org/css-counter-styles-3/#symbols-function
+  counter-symbol-values:
+    - include: image-values
+    - include: counter-system-constants
+    - include: scalar-integer-constants
+    - include: quoted-strings
+
+  # 2D Image Values
+  # https://drafts.csswg.org/css-images-4/#image-values
+  image-values:
+    - include: cross-fade-functions
+    - include: gradient-functions
+    - include: image-functions
+    - include: image-set-functions
+    - include: url-functions
+
+###[ COUNTER PROPERTY ]########################################################
+
+  counter-property:
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters
+    - match: \b(?i:counter-(increment|reset|set)){{break}}
+      scope: support.type.property-name.css
+      set: counter-property-value
+
+  counter-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set:
+        - property-value-content
+        - counter-identifier
+    - include: else-pop
+
+  counter-identifier:
+    - match: '{{ident}}'
+      scope: entity.other.counter-name.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+###[ COUNTER STYLE FALLBACK PROPERTY ]#########################################
+
+  # Counter Style Fallback
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-fallback
+  counter-style-fallback-properties:
+    - match: \b(?i:fallback){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-fallback-property-value
+
+  counter-style-fallback-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set: counter-style-fallback-property-value-content
+    - include: else-pop
+
+  counter-style-fallback-property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: var-functions
+    - include: counter-style-identifiers
+
+  counter-style-identifiers:
+    - match: '{{counter_style_names}}'
+      scope: support.constant.counter-style-name.css
+    - match: '{{ident}}'
+      scope: entity.other.counter-style-name.css
+
+###[ COUNTER STYLE SYSTEM PROPERTY ]###########################################
+
+  # Counter Style System
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-system
+  counter-style-system-properties:
+    - match: \b(?i:system){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-system-property-value
+
+  counter-style-system-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set: counter-style-system-property-value-content
+    - include: else-pop
+
+  counter-style-system-property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: var-functions
+    - include: counter-symbol-values
+    - match: \b(?i:extends){{break}}
+      scope: keyword.declaration.extends.css
+      push: counter-style-identifier
+
+  counter-style-identifier:
+    - match: '{{counter_style_names}}'
+      scope: support.constant.counter-style-name.css
+      pop: 1
+    - match: '{{ident}}'
+      scope: entity.other.counter-style-name.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+###[ COUNTER STYLE SPEAK AS PROPERTY ]#########################################
+
+  # Counter Style Speak As
+  # https://drafts.csswg.org/css-counter-styles-3/#counter-style-speak-as
+  counter-style-speak-as-properties:
+    - match: \b(?i:speak-as){{break}}
+      scope: meta.property-name.css support.type.property-name.css
+      push: counter-style-speak-as-property-value
+
+  counter-style-speak-as-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set: counter-style-speak-as-property-value-content
+    - include: else-pop
+
+  counter-style-speak-as-property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: var-functions
+    - include: quoted-strings
+    - include: counter-speak-as-constants
+    - include: counter-style-identifiers
+
+###[ FONT PROPERTY ]###########################################################
+
+  # Font and Font-Family Property
+  # https://drafts.csswg.org/css-fonts-3/#font-family-prop
+  # https://drafts.csswg.org/css-fonts-3/#font-prop
+  font-property:
+    - match: \b(?i:font(-family)?){{break}}
+      scope: support.type.property-name.css
+      set: font-property-value
+
+  font-property-value:
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      set: font-property-value-content
+    - include: else-pop
+
+  font-property-value-content:
+    - meta_content_scope: meta.property-value.css
+    - include: terminator-pop
+    - include: comments
+    - include: comma-delimiters
+    - include: common-operators
+    - include: builtin-values
+    - include: font-family-names
+
+###[ BUILTIN FUNCTIONS ]#######################################################
+
+  builtin-functions:
+    - include: at-counter-functions
+    - include: at-font-functions
+    - include: attr-functions
+    - include: calc-functions
+    - include: color-adjuster-functions
+    - include: cross-fade-functions
+    - include: filter-functions
+    - include: filters-functions
+    - include: gradient-functions
+    - include: image-functions
+    - include: image-set-functions
+    - include: minmax-functions
+    - include: repeat-functions
+    - include: shape-functions
+    - include: timing-functions
+    - include: toggle-functions
+    - include: transform-functions
+    - include: url-functions
+    - include: var-functions
+    - include: sass-value-expression
+
+  function-arguments-common:
+    - include: group-end
+    - include: terminator-pop
+    - include: comments
+    - include: var-functions
+    - include: sass-value-expression
+
+###[ BUILTIN AT RULE FUNCTIONS ]###############################################
+
+  at-counter-functions:
+    # counter()
+    # https://drafts.csswg.org/css-lists-3/#funcdef-counter
+    # counters()
+    # https://drafts.csswg.org/css-lists-3/#funcdef-counters
+    - match: \b(?i:counters?)(?=\()
+      scope: meta.function-call.identifier.css support.function.counter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - - meta_scope: meta.function-call.arguments.css meta.group.css
+              - include: function-arguments-common
+              - include: comma-delimiters
+              - include: counter-style-identifiers
+              - include: quoted-strings
+            - counter-identifier
+
+    # symbols()
+    # https://drafts.csswg.org/css-counter-styles-3/#symbols-function
+    - match: \b(?i:symbols)(?=\()
+      scope: meta.function-call.identifier.css support.function.counter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: counter-symbol-values
+
+  at-document-functions:
+    # url-prefix()
+    # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-prefix
+    - match: \b(?i:url-prefix)(?=\()
+      scope: meta.function-call.identifier.css support.function.url-prefix.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-urls
+            - include: unquoted-urls
+
+    # domain()
+    # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-domain
+    - match: \b(?i:domain)(?=\()
+      scope: meta.function-call.identifier.css support.function.domain.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-urls
+            - include: unquoted-urls
+
+    # regexp()
+    # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-regexp
+    - match: \b(?i:regexp)(?=\()
+      scope: meta.function-call.identifier.css support.function.regexp.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-strings
+
+  at-font-functions:
+    # format()
+    # https://drafts.csswg.org/css-fonts-3/#descdef-src
+    # format() is also mentioned in `issue 2` at https://drafts.csswg.org/css-images-3/#issues-index
+    # but does not seem to be implemented in any manner
+    - match: \b(?i:format)(?=\()
+      scope: meta.function-call.identifier.css support.function.font-face.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-strings
+
+    # local()
+    # https://drafts.csswg.org/css-fonts-3/#descdef-src
+    - match: \b(?i:local)(?=\()
+      scope: meta.function-call.identifier.css support.function.font-face.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-strings
+            - include: generic-font-names
+            - include: font-family-names
+
+###[ BUILTIN COLOR FUNCTIONS ]#################################################
+
+  # Color Functions
+  # https://drafts.csswg.org/css-color
+  color-functions:
+    # rgb(), rgba()
+    # https://drafts.csswg.org/css-color/#rgb-functions
+    - match: \b(?i:rgba?)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # hsl(), hsla()
+    # https://drafts.csswg.org/css-color/#the-hsl-notation
+    # hwb() - Not yet implemented by browsers
+    # https://drafts.csswg.org/css-color/#funcdef-hwb
+    - match: \b(?i:hsla?|hwb)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: angle-constants
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # gray() - Not yet implemented by browsers
+    # https://drafts.csswg.org/css-color/#funcdef-gray
+    - match: \b(?i:gray)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # device-cmyk() - Not yet implemented by browsers
+    # https://drafts.csswg.org/css-color/#funcdef-device-cmyk
+    - match: \b(?i:device-cmyk)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: color-adjuster-functions # must be included before `color-values`
+            - include: color-values
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # color-mod() - Not yet implemented by browsers
+    # https://drafts.csswg.org/css-color/#funcdef-color-mod
+    - match: \b(?i:color)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: color-adjuster-functions # must be included before `color-values`
+            - include: color-values
+            - include: angle-constants
+            - include: scalar-constants
+
+  # Color Adjuster Functions - Not yet implemented by browsers
+  # https://drafts.csswg.org/css-color/#typedef-color-adjuster
+  color-adjuster-functions:
+    # red(), green(), blue(), alpha() - Not yet implemented by browsers
+    - match: \b(?i:red|green|blue|alpha|a)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-adjuster-operators
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # hue() - Not yet implemented by browsers
+    - match: \b(?i:hue|h)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-adjuster-operators
+            - include: angle-constants
+
+    # saturation(), lightness(), whiteness(), blackness() - Not yet implemented by browsers
+    - match: \b(?i:saturation|lightness|whiteness|blackness|[slwb])(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-adjuster-operators
+            - include: percentage-constants
+
+    # tint(), shade(), contrast() - Not yet implemented by browsers
+    # contrast() interferes with the contrast() filter function;
+    # therefore, it is not yet implemented here
+    - match: \b(?i:tint|shade)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: percentage-constants
+
+    # blend(), blenda() - Not yet implemented by browsers
+    - match: \b(?i:blenda|blend)(?=\()
+      scope: meta.function-call.identifier.css support.function.color.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-values
+            - include: percentage-constants
+            - match: \b(?i:rgb|hsl|hwb){{break}}
+              scope: keyword.other.color-space.css
+
+###[ BUILTIN FILTER FUNCTIONS ]################################################
+
+  filter-functions:
+    # filter()
+    # https://drafts.fxtf.org/filters/#funcdef-filter
+    - match: \b(?i:filter)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: filters-functions
+            - include: image-values
+            - include: quoted-strings
+
+  # Filter Functions
+  # https://drafts.fxtf.org/filters/#typedef-filter-function
+  filters-functions:
+    # blur()
+    # https://drafts.fxtf.org/filters/#funcdef-filter-blur
+    - match: \b(?i:blur)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: length-constants
+
+    # brightness(), contrast(), grayscale(), invert(), opacity(), saturate(), sepia()
+    # https://drafts.fxtf.org/filters/#funcdef-filter-brightness
+    - match: \b(?i:brightness|contrast|grayscale|invert|opacity|saturate|sepia)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: percentage-constants
+            - include: scalar-constants
+
+    # drop-shadow()
+    # https://drafts.fxtf.org/filters/#funcdef-filter-drop-shadow
+    - match: \b(?i:drop-shadow)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: color-values
+            - include: length-constants
+
+    # hue-rotate()
+    # https://drafts.fxtf.org/filters/#funcdef-filter-hue-rotate
+    - match: \b(?i:hue-rotate)(?=\()
+      scope: meta.function-call.identifier.css support.function.filter.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: angle-constants
+
+###[ BUILTIN GRID FUNCTIONS ]##################################################
+
+  # minmax()
+  # https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-minmax
+  minmax-functions:
+    - match: \b(?i:minmax)(?=\()
+      scope: meta.function-call.identifier.css support.function.grid.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: grid-constants
+            - include: length-constants
+            - include: percentage-constants
+
+  # repeat()
+  # https://drafts.csswg.org/css-grid/#funcdef-repeat
+  repeat-functions:
+    - match: \b(?i:repeat)(?=\()
+      scope: meta.function-call.identifier.css support.function.grid.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:auto-fill|auto-fit){{break}}
+              scope: keyword.other.grid.css
+            - include: calc-functions
+            - include: minmax-functions
+            - include: grid-constants
+            - include: length-constants
+            - include: percentage-constants
+            - include: scalar-integer-constants
+            - include: line-names
+
+###[ BUILTIN IMAGE FUNCTIONS ]#################################################
+
+  # cross-fade()
+  # https://drafts.csswg.org/css-images-4/#funcdef-cross-fade
+  cross-fade-functions:
+    - match: \b(?i:cross-fade)(?=\()
+      scope: meta.function-call.identifier.css support.function.image.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: color-values
+            - include: image-values
+            - include: percentage-constants
+            - include: quoted-urls
+
+  # image()
+  # https://drafts.csswg.org/css-images-4/#funcdef-image
+  image-functions:
+    - match: \b(?i:image)(?=\()
+      scope: meta.function-call.identifier.css support.function.image.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: color-values
+            - include: image-values
+            - include: quoted-urls
+            - include: direction-constants
+
+  # image-set()
+  # https://drafts.csswg.org/css-images-4/#funcdef-image-set
+  image-set-functions:
+    - match: \b(?i:image-set)(?=\()
+      scope: meta.function-call.identifier.css support.function.image.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: color-values
+            - include: image-values
+            - include: quoted-urls
+            - include: resolution-constants
+            - match: ([0-9]+)(x)
+              scope: meta.number.integer.decimal.css
+              captures:
+                1: constant.numeric.value.css
+                2: constant.numeric.suffix.css
+
+  # Gradient Functions
+  # https://drafts.csswg.org/css-images-3/#gradients
+  gradient-functions:
+    # conic-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/conic-gradient()
+    # repeating-conic-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-conic-gradient()
+    - match: \b((?:repeating-)?conic-gradient)(?=\()
+      scope: meta.function-call.identifier.css support.function.gradient.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:at|from){{break}}
+              scope: keyword.other.gradient.css
+            - match: \b(?i:bottom|center|left|right|top){{break}}
+              scope: support.constant.property-value.css
+            - include: color-values
+            - include: angle-constants
+            - include: length-constants
+            - include: percentage-constants
+
+    # linear-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient()
+    # repeating-linear-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-linear-gradient()
+    - match: \b((?:repeating-)?linear-gradient)(?=\()
+      scope: meta.function-call.identifier.css support.function.gradient.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:to){{break}}
+              scope: keyword.other.gradient.css
+            - match: \b(?i:bottom|left|right|top){{break}}
+              scope: support.constant.property-value.css
+            - include: color-values
+            - include: angle-constants
+            - include: length-constants
+            - include: percentage-constants
+
+    # radial-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/radial-gradient()
+    # repeating-radial-gradient()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-radial-gradient()
+    - match: \b((?:repeating-)?radial-gradient)(?=\()
+      scope: meta.function-call.identifier.css support.function.gradient.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:at|circle|ellipse){{break}}
+              scope: keyword.other.gradient.css
+            - match: \b(?i:bottom|center|left|right|top|(closest|farthest)-(corner|side)){{break}}
+              scope: support.constant.property-value.css
+            - include: color-values
+            - include: length-constants
+            - include: percentage-constants
+
+###[ BUILTIN SHAPE FUNCTIONS ]#################################################
+
+  # Shape Functions
+  # https://www.w3.org/TR/css-shapes-1/#typedef-basic-shape
+  shape-functions:
+    # rect() - Deprecated
+    # https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect
+    - match: \b(?i:rect)(?=\()
+      scope: meta.function-call.identifier.css support.function.shape.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - match: \b(?i:auto){{break}}
+              scope: support.constant.property-value.css
+            - include: calc-functions
+            - include: length-constants
+
+    # inset()
+    # https://www.w3.org/TR/css-shapes-1/#funcdef-inset
+    - match: \b(?i:inset)(?=\()
+      scope: meta.function-call.identifier.css support.function.shape.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - match: \b(?i:round){{break}}
+              scope: keyword.other.shape.css
+            - include: calc-functions
+            - include: length-constants
+            - include: percentage-constants
+
+    # circle()
+    # https://www.w3.org/TR/css-shapes-1/#funcdef-circle
+    # ellipse()
+    # https://www.w3.org/TR/css-shapes-1/#funcdef-ellipse
+    - match: \b(?i:circle|ellipse)(?=\()
+      scope: meta.function-call.identifier.css support.function.shape.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - match: \b(?i:at){{break}}
+              scope: keyword.other.shape.css
+            - match: \b(?i:top|right|bottom|left|center|closest-side|farthest-side){{break}}
+              scope: support.constant.property-value.css
+            - include: calc-functions
+            - include: length-constants
+            - include: percentage-constants
+
+    # polygon()
+    # https://www.w3.org/TR/css-shapes-1/#funcdef-polygon
+    - match: \b(?i:polygon)(?=\()
+      scope: meta.function-call.identifier.css support.function.shape.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - match: \b(?i:nonzero|evenodd){{break}}
+              scope: support.constant.property-value.css
+            - include: calc-functions
+            - include: length-constants
+            - include: percentage-constants
+
+###[ BUILTIN TIMING FUNCTIONS ]################################################
+
+  # Timing Functions
+  # https://www.w3.org/TR/web-animations-1/#timing-functions
+  timing-functions:
+    # cubic-bezier()
+    # https://www.w3.org/TR/web-animations-1/#cubic-bzier-timing-function
+    - match: \b(?i:cubic-bezier)(?=\()
+      scope: meta.function-call.identifier.css support.function.timing.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: scalar-constants
+
+    # steps()
+    # https://www.w3.org/TR/web-animations-1/#step-timing-function
+    - match: \b(?i:steps)(?=\()
+      scope: meta.function-call.identifier.css support.function.timing.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - match: \b(?i:end|middle|start){{break}}
+              scope: keyword.other.timing.css
+            - include: scalar-integer-constants
+
+###[ BUILTIN TRANSFORM FUNCTIONS ]#############################################
+
+  # Transform Functions
+  # https://www.w3.org/TR/css-transforms-1/#transform-functions
+  transform-functions:
+    # transform functions with comma separated <number> types
+    # matrix(), scale(), matrix3d(), scale3d()
+    - match: \b(?i:matrix3d|scale3d|matrix|scale)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: scalar-constants
+
+    # transform functions with comma separated <number> or <length> types
+    # translate(), translate3d()
+    - match: \b(?i:translate(3d)?)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: percentage-constants
+            - include: length-constants
+            - include: scalar-constants
+
+    # transform functions with a single <number> or <length> type
+    # translateX(), translateY()
+    - match: \b(?i:translate[XY])(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: percentage-constants
+            - include: length-constants
+            - include: scalar-constants
+
+    # transform functions with a single <angle> type
+    # rotate(), skewX(), skewY(), rotateX(), rotateY(), rotateZ()
+    - match: \b(?i:rotate[XYZ]?|skew[XY])(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: angle-constants
+
+    # transform functions with comma separated <angle> types
+    # skew()
+    - match: \b(?i:skew)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: angle-constants
+
+    # transform functions with a single <length> type
+    # translateZ(), perspective()
+    - match: \b(?i:translateZ|perspective)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: calc-functions
+            - include: length-constants
+
+    # transform functions with a comma separated <number> or <angle> types
+    # rotate3d()
+    - match: \b(?i:rotate3d)(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: angle-constants
+            - include: scalar-constants
+
+    # transform functions with a single <number> type
+    # scaleX(), scaleY(), scaleZ()
+    - match: \b(?i:scale[XYZ])(?=\()
+      scope: meta.function-call.identifier.css support.function.transform.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: scalar-constants
+
+###[ BUILTIN VALUE FUNCTIONS ]#################################################
+
+  # attr()
+  # https://www.w3.org/TR/css3-values/#funcdef-attr
+  attr-functions:
+    - match: \b(?i:attr)(?=\()
+      scope: meta.function-call.identifier.css support.function.attr.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - attr-function-arguments-value
+            - attr-function-arguments-identifier
+
+  attr-function-arguments-identifier:
+    - include: namespace-prefixes
+    - include: quoted-string
+    - include: var-function
+    - match: '{{ident}}'
+      scope: entity.other.attribute-name.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+  attr-function-arguments-value:
+    - meta_scope: meta.function-call.arguments.css meta.group.css
+    - include: function-arguments-common
+    - include: comma-delimiters
+    - match: '{{units}}'
+      scope: keyword.other.unit.css
+    - include: color-values
+    - include: common-constants
+    - include: generic-font-names
+    - include: numeric-constants
+
+  calc-functions:
+    # calc()
+    # https://www.w3.org/TR/css3-values/#funcdef-calc
+    - match: \b(?i:calc)(?=\()
+      scope: meta.function-call.identifier.css support.function.calc.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: calc-function-arguments-content
+
+    # clamp()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/clamp()
+    # max()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/max()
+    # min()
+    # https://developer.mozilla.org/en-US/docs/Web/CSS/min()
+    - match: \b(?i:clamp|max|min)(?=\()
+      scope: meta.function-call.identifier.css support.function.calc.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: calc-function-arguments-content
+            - include: comma-delimiters
+
+  calc-function-arguments-content:
+    - meta_scope: meta.group.css
+    - match: \)
+      scope: punctuation.section.group.end.css
+      set: maybe-illegal-operator
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      push: calc-function-arguments-content
+    - include: terminator-pop
+    - include: comments
+    - include: attr-functions
+    - include: calc-functions
+    - include: var-functions
+    - match: '{{float}}({{units}})?'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+      push: maybe-illegal-operator
+    - match: '{{integer}}({{units}})?'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+      push: maybe-illegal-operator
+    - match: '[-+*/]'
+      scope: keyword.operator.arithmetic.css
+
+  toggle-functions:
+    # toggle()
+    # https://www.w3.org/TR/css3-values/#toggle-notation
+    - match: \b(?i:toggle)(?=\()
+      scope: meta.function-call.identifier.css support.function.toggle.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: comma-delimiters
+            - include: calc-functions
+            - include: vendor-prefixes
+            - include: color-values
+            - include: common-constants
+            - include: numeric-constants
+            - include: quoted-strings
+
+  # url()
+  # https://drafts.csswg.org/css-values-3/#urls
+  url-functions:
+    - match: \b(?i:url)(?=\()
+      scope: meta.function-call.identifier.css support.function.url.css
+      push:
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: function-arguments-common
+            - include: quoted-urls
+            - include: unquoted-urls
+
+  # var()
+  # https://drafts.csswg.org/css-variables/#funcdef-var
+  # Note: Match valid groups before `var-functions` context is included.
+  var-functions:
+    - match: \b(?i:var)(?=\()
+      scope: meta.function-call.identifier.css support.function.var.css
+      push: var-function-arguments
+    - include: illegal-groups
+
+  var-function:
+    - match: \b(?i:var)(?=\()
+      scope: meta.function-call.identifier.css support.function.var.css
+      set: var-function-arguments
+    - include: illegal-groups
+
+  var-function-arguments:
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      set:
+        - var-function-arguments-defaults
+        - var-function-arguments-identifier
+
+  var-function-arguments-defaults:
+    - meta_scope: meta.function-call.arguments.css meta.group.css
+    - include: group-end
+    - include: font-property-value-content
+
+  var-function-arguments-identifier:
+    - match: '{{custom_ident}}'
+      scope: variable.other.custom-property.css
+      pop: 1
+    - include: comments
+    - include: else-pop
+
+###[ OTHER FUNCTIONS ]#########################################################
+
+  other-functions:
+    - match: '{{ident}}(?=\()'
+      scope: meta.function-call.identifier.css variable.function.css
+      push: other-functions-arguments
+
+  other-functions-arguments:
+    - meta_include_prototype: false
+    - match: \(
+      scope: punctuation.section.group.begin.css
+      set:
+        - meta_scope: meta.function-call.arguments.css meta.group.css
+        - include: function-arguments-common
+        - include: comma-delimiters
+        - include: calc-functions
+        - include: quoted-strings
+        - include: numeric-constants
+        - include: other-constants
+
+###[ CONSTANTS ]###############################################################
+
+  color-constants:
+    # https://www.w3.org/TR/CSS22/syndata.html#color-units
+    - match: '{{standard_colors}}'
+      scope: support.constant.color.w3c.standard.css
+    # https://www.w3.org/TR/css3-color/#svg-color
+    - match: '{{extended_colors}}'
+      scope: support.constant.color.w3c.extended.css
+    # Special Color Keywords
+    # https://www.w3.org/TR/css3-color/#currentcolor
+    # https://www.w3.org/TR/css3-color/#transparent-def
+    - match: \b(?i:currentColor|transparent){{break}}
+      scope: support.constant.color.w3c.special.css
+    # Hex Color
+    - match: (#)(\h{3}|\h{6}){{break}}
+      scope: constant.other.color.rgb-value.css
+      captures:
+        1: punctuation.definition.constant.css
+    # RGBA Hexadecimal Colors
+    # https://en.wikipedia.org/wiki/RGBA_color_space#RGBA_hexadecimal_.28word-order.29
+    - match: (#)(\h{4}|\h{8}){{break}}
+      scope: constant.other.color.rgba-value.css
+      captures:
+        1: punctuation.definition.constant.css
+
+  common-constants:
+    - match: '{{property_value_constants}}'
+      scope: support.constant.property-value.css
+
+  counter-speak-as-constants:
+    - match: '{{counter_speak_as_constants}}'
+      scope: support.constant.property-value.css
+
+  counter-system-constants:
+    - match: '{{counter_system_constants}}'
+      scope: support.constant.symbol-type.css
+
+  direction-constants:
+    - match: \b(ltr|rtl){{break}}
+      scope: support.constant.property-value.css
+
+  # Generic Font Families
+  # https://drafts.csswg.org/css-fonts-3/#family-name-value
+  generic-font-names:
+    - match: '{{font_family_constants}}'
+      scope: support.constant.property-value.css
+
+  grid-constants:
+    - match: \b(?i:auto|max-content|min-content){{break}}
+      scope: support.constant.property-value.css
+
+  other-constants:
+    - match: '{{ident}}'
+      scope: constant.other.css
+
+###[ NUMERIC CONSTANTS ]#######################################################
+
+  # https://www.w3.org/TR/css3-values/#numeric-constantss
+  numeric-constants:
+    - match: '{{float}}({{units}})?'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{units}})?'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  # Make sure `scalar-constants` is included after any other numeric values
+  # as `scalar-constants` will consume all numeric values.
+  scalar-constants:
+    - include: scalar-float-constants
+    - include: scalar-integer-constants
+
+  scalar-float-constants:
+    - match: '{{float}}'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+
+  scalar-integer-constants:
+    - match: '{{integer}}'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+
+  scalar-rational-constants:
+    - match: \d+(/)\d+
+      scope: meta.number.rational.css constant.numeric.value.css
+      captures:
+        1: keyword.operator.arithmetic.css
+
+  angle-constants:
+    - match: '{{float}}({{angle_units}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{angle_units}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+    - match: \b0\b(?!%)
+      scope: meta.number.integer.decimal.css constant.numeric.value.css
+
+  frequency-constants:
+    - match: '{{float}}({{frequency_units}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{frequency_units}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  length-constants:
+    - match: '{{float}}({{font_relative_lengths}}|{{viewport_percentage_lengths}}|{{absolute_lengths}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{font_relative_lengths}}|{{viewport_percentage_lengths}}|{{absolute_lengths}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+    - match: \b0\b(?!%)
+      scope: meta.number.integer.decimal.css constant.numeric.value.css
+
+  resolution-constants:
+    - match: '{{float}}({{resolution_units}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{resolution_units}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  percentage-constants:
+    - match: '{{float}}(%)'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}(%)'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  time-constants:
+    - match: '{{float}}({{duration_units}})'
+      scope: meta.number.float.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.decimal.css
+        4: constant.numeric.suffix.css
+    - match: '{{integer}}({{duration_units}})'
+      scope: meta.number.integer.decimal.css
+      captures:
+        1: keyword.operator.arithmetic.css
+        2: constant.numeric.value.css
+        3: constant.numeric.suffix.css
+
+  # Unicode Ranges
+  # https://www.w3.org/TR/css-syntax-3/#urange
+  unicode-ranges:
+    - match: ([Uu]\+)([\h?]{1,6}(?:(-)\h{1,6})?)
+      scope: meta.number.unicode-range.css
+      captures:
+        1: constant.numeric.prefix.css
+        2: constant.numeric.value.css
+        3: punctuation.separator.range.css
+
+###[ STRING CONSTANTS ]########################################################
+
+  # Font Family Names
+  # https://drafts.csswg.org/css-fonts-3/#family-name-value
+  font-family-names:
+    - match: '{{ident}}(?:\s+{{ident}}(?!\())*'
+      scope: meta.string.css string.unquoted.css
+
+  # Language Ranges
+  # https://drafts.csswg.org/selectors-4/#language-range
+  language-ranges:
+    - match: (?={{nmstart}}|\*)
+      push:
+        - meta_include_prototype: false
+        - meta_scope: meta.string.css string.unquoted.css
+        - include: string-content
+        - match: \*
+          scope: variable.language.wildcard.asterisk.css
+        - match: (?!{{nmchar}})
+          pop: 1
+
+  # Named Grid Lines
+  # https://drafts.csswg.org/css-grid/#named-lines
+  line-names:
+    - match: \[
+      scope: punctuation.section.brackets.begin.css
+      push: line-names-content
+
+  line-names-content:
+    - meta_scope: meta.line-names.css meta.brackets.css
+    - match: \]
+      scope: punctuation.section.brackets.end.css
+      pop: 1
+    - match: '{{ident}}'
+      scope: meta.string.css string.unquoted.line-name.css
+    - include: terminator-pop
+
+  quoted-strings:
+    - match: \"
+      scope: punctuation.definition.string.begin.css
+      push: double-quoted-string-content
+    - match: \'
+      scope: punctuation.definition.string.begin.css
+      push: single-quoted-string-content
+
+  quoted-string:
+    - match: \"
+      scope: punctuation.definition.string.begin.css
+      set: double-quoted-string-content
+    - match: \'
+      scope: punctuation.definition.string.begin.css
+      set: single-quoted-string-content
+
+  double-quoted-string-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.css string.quoted.double.css
+    - match: \"
+      scope: punctuation.definition.string.end.css
+      pop: 1
+    - include: string-content
+
+  single-quoted-string-content:
+    - meta_include_prototype: false
+    - meta_scope: meta.string.css string.quoted.single.css
+    - match: \'
+      scope: punctuation.definition.string.end.css
+      pop: 1
+    - include: string-content
+
+  string-content:
+    - meta_include_prototype: false
+    - match: \n
+      scope: invalid.illegal.newline.css
+      pop: 1
+    - match: \\\s*\n
+      scope: constant.character.escape.newline.css
+    - match: \\(?:\h{1,6}|.)
+      scope: constant.character.escape.css
+
+###[ URL STRING CONSTANTS ]####################################################
+
+  quoted-urls:
+    - match: \"
+      scope:
+        meta.string.css string.quoted.double.css
+        punctuation.definition.string.begin.css
+      push: double-quoted-url-content
+    - match: \'
+      scope:
+        meta.string.css string.quoted.single.css
+        punctuation.definition.string.begin.css
+      push: single-quoted-url-content
+
+  double-quoted-url-content:
+    - meta_include_prototype: false
+    - meta_content_scope:
+        meta.path.url.css
+        meta.string.css string.quoted.double.css
+    - match: \"
+      scope:
+        meta.string.css string.quoted.double.css
+        punctuation.definition.string.end.css
+      pop: 1
+    - include: string-content
+    - include: url-content
+
+  single-quoted-url-content:
+    - meta_include_prototype: false
+    - meta_content_scope:
+        meta.path.url.css
+        meta.string.css string.quoted.single.css
+    - match: \'
+      scope:
+        meta.string.css string.quoted.single.css
+        punctuation.definition.string.end.css
+      pop: 1
+    - include: string-content
+    - include: url-content
+
+  # Unquoted URL token
+  # https://drafts.csswg.org/css-syntax-3/#consume-a-url-token
+  unquoted-urls:
+    - match: (?=[[:alnum:]/])
+      push: unquoted-url-content
+
+  unquoted-url-content:
+    - meta_include_prototype: false
+    - meta_content_scope:
+        meta.path.url.css
+        meta.string.css string.unquoted.css
+    - match: '["''(]'
+      scope: invalid.illegal.unexpected-token.css
+      set:
+        - meta_include_prototype: false
+        - match: (?=\))
+          pop: 1
+        - include: string-content
+    - match: (?=\))
+      pop: 1
+    - include: url-content
+
+  url-content:
+    - include: string-content
+    - match: (%)\h{2}
+      scope: constant.character.escape.url.css
+      captures:
+        1: punctuation.definition.escape.css
+    - match: '[/&?#]|://'
+      scope: punctuation.separator.path.css
+
+###[ OPERATORS ]###############################################################
+
+  common-operators:
+    - match: \!\s*(?i:important){{break}}
+      scope: keyword.other.important.css
+    - match: /
+      scope: keyword.operator.arithmetic.css
+
+  color-adjuster-operators:
+    - match: '[-+*](?=\s)'
+      scope: keyword.operator.arithmetic.css
+    - match: '[-+*/]'
+      scope: invalid.illegal.operator.css
+
+  maybe-illegal-operator:
+    - match: '[-+](?=\s*\d)'
+      scope: invalid.illegal.operator.css
+      pop: 1
+    - match: \s*([-+])(?=\d)
+      captures:
+        1: invalid.illegal.operator.css
+      pop: 1
+    - include: immediately-pop
+
+###[ PUNCTUATION ]#############################################################
+
+  comma-delimiters:
+    - match: ','
+      scope: punctuation.separator.sequence.css
+
+  block-end2:
+    - match: \}
+      scope: punctuation.section.block.end.css
+      pop: 2
+
+  group-end:
+    - match: \)
+      scope: punctuation.section.group.end.css
+      pop: 1
+
+  rule-terminators:
+    - match: ;
+      scope: punctuation.terminator.rule.css
+
+  illegal-blocks:
+    # https://www.w3.org/TR/CSS22/syndata.html#parsing-errors
+    - match: \{
+      scope: invalid.illegal.unexpected-token.css
+      push:
+        - match: \}
+          scope: invalid.illegal.unexpected-token.css
+          pop: 1
+    - match: \}
+      scope: invalid.illegal.unexpected-token.css
+
+  illegal-groups:
+    # https://www.w3.org/TR/CSS22/syndata.html#parsing-errors
+    - match: \(
+      scope: invalid.illegal.unexpected-token.css
+      push:
+        - match: \)
+          scope: invalid.illegal.unexpected-token.css
+          pop: 1
+    - match: \)
+      scope: invalid.illegal.unexpected-token.css
+
+###[ PROTOTYPES ]##############################################################
+
+  else-pop:
+    - match: (?=\S)
+      pop: 1
+
+  immediately-pop:
+    - match: ''
+      pop: 1
+
+  terminator-pop:
+    - match: (?=[;){}])
+      pop: 1
+
+
+###############################################################################
+###[ Sass ]####################################################################
+###############################################################################
 
   sass-custom-functions:
     - match: '\b(({{ident}})(\.))?([a-z_-]+)(?=\()'
@@ -1122,32 +3411,25 @@ contexts:
         - include: function-arguments
 
   sass-script-expression:
-    - include: comment-line
-    - include: comment-block
-    - include: comma-delimiter
-    - include: sass-maps
+    - include: sass-value-expression
     - include: color-values
     - include: numeric-values
-    - include: sass-variables
-    - include: sass-functions
-    - include: sass-custom-functions
-    - include: sass-operators
-    - include: sass-interpolation
     - match: '\b(false|true|null)\b'
       scope: constant.language.sass
     - include: literal-string
     - include: unquoted-string
 
   sass-value-expression:
-    - include: comment-line
-    - include: comment-block
+    - include: comments
     - include: comma-delimiter
-    - include: var-function
+    - include: sass-maps
     - include: sass-variables
     - include: sass-functions
     - include: sass-custom-functions
-    - include: sass-interpolation
     - include: sass-operators
+    - include: sass-interpolation
+    - match: \b(true|false|null)\b
+      scope: constant.language.sass
 
   sass-maps:
     - match: '\('
@@ -1263,1694 +3545,3 @@ contexts:
         - match: '(?=$)'
           pop: true
         - include: sass-mixin-call
-
-
-
-  property-value-constants:
-    - match: |-
-            (?x)\b(
-                absolute|active|add
-              | all(-(petite|small)-caps|-scroll)?
-              | alpha(betic)?
-              | alternate(-reverse)?
-              | always|annotation|antialiased|at
-              | auto(hiding-scrollbar|-flow)?
-              | avoid(-column|-page|-region)?
-              | background(-color|-image|-position|-size)?
-              | backwards|balance|baseline|below|bevel|bicubic|bidi-override|blink
-              | block(-line-height)?
-              | blur
-              | bold(er)?
-              | border(-bottom|-left|-right|-top)?-(color|radius|width|style)
-              | border-(bottom|top)-(left|right)-radius
-              | border-image(-outset|-repeat|-slice|-source|-width)?
-              | border(-bottom|-left|-right|-top|-collapse|-spacing|-box)?
-              | both|bottom
-              | box(-shadow)?
-              | break-(all|word)
-              | brightness
-              | butt(on)?
-              | capitalize
-              | cent(er|ral)
-              | char(acter-variant)?
-              | cjk-ideographic|clip|clone|close-quote
-              | closest-(corner|side)
-              | col-resize|collapse
-              | color(-stop|-burn|-dodge)?
-              | column((-count|-gap|-reverse|-rule(-color|-width)?|-width)|s)?
-              | common-ligatures|condensed|consider-shifts|contain
-              | content(-box|s)?
-              | contextual|contrast|cover
-              | crisp(-e|E)dges
-              | crop
-              | cross(hair)?
-              | da(rken|shed)
-              | default|dense|diagonal-fractions|difference|disabled
-              | discretionary-ligatures|disregard-shifts
-              | distribute(-all-lines|-letter|-space)?
-              | dotted|double|drop-shadow
-              | (nwse|nesw|ns|ew|sw|se|nw|ne|w|s|e|n)-resize
-              | ease(-in-out|-in|-out)?
-              | element|ellipsis|embed|end|EndColorStr|evenodd
-              | exclu(de(-ruby)?|sion)
-              | expanded
-              | (extra|semi|ultra)-(condensed|expanded)
-              | farthest-(corner|side)?
-              | fill(-box|-opacity)?
-              | filter|first|fixed|flat
-              | fit-content
-              | flex((-basis|-end|-grow|-shrink|-start)|box)?
-              | flip|flood-color
-              | font(-size(-adjust)?|-stretch|-weight)?
-              | forwards
-              | from(-image)?
-              | full-width|geometricPrecision|glyphs|gradient|grayscale
-              | grid(-height)?
-              | groove|hand|hanging|hard-light|height|help|hidden|hide
-              | historical-(forms|ligatures)
-              | horizontal(-tb)?
-              | hue
-              | ideograph(-alpha|-numeric|-parenthesis|-space|ic)
-              | inactive|include-ruby|infinite|inherit|initial
-              | inline(-block|-box|-flex(box)?|-line-height|-table)?
-              | inset|inside
-              | inter(-ideograph|-word|sect)
-              | invert|isolat(e|ion)|italic
-              | jis(04|78|83|90)
-              | justify(-all)?
-              | keep-all
-              | large[r]?
-              | last|left|letter-spacing
-              | light(e[nr]|ing-color)
-              | line(-edge|-height|-through)?
-              | linear(-gradient|RGB)?
-              | lining-nums|list-item|local|loose|lowercase|lr-tb|ltr
-              | lumin(osity|ance)|manual
-              | margin(-bottom|-box|-left|-right|-top)?
-              | marker(-offset|s)?
-              | mathematical
-              | max-(content|height|lines|size|width)
-              | medium|middle
-              | min-(content|height|width)
-              | miter|mixed|move|multiply|newspaper
-              | no-(change|clip|(close|open)-quote|(common|discretionary|historical)-ligatures|contextual|drop|repeat)
-              | none|nonzero|normal|not-allowed|nowrap|oblique
-              | offset(-after|-before|-end|-start)?
-              | oldstyle-nums|opacity|open-quote
-              | optimize(Legibility|Precision|Quality|Speed)
-              | order|ordinal|ornaments
-              | outline(-color|-offset|-width)?
-              | outset|outside|over(line|-edge|lay)
-              | padding(-bottom|-box|-left|-right|-top)?
-              | page|painted|paused
-              | perspective-origin
-              | petite-caps|pixelated|pointer
-              | pre(-line|-wrap)?
-              | preserve-3d
-              | progid:DXImageTransform.Microsoft.(Alpha|Blur|dropshadow|gradient|Shadow)
-              | progress
-              | proportional-(nums|width)
-              | radial-gradient|recto|region|relative
-              | repeat(-[xy])?
-              | repeating-(linear|radial)-gradient
-              | replaced|reset-size|reverse|ridge|right
-              | round
-              | row(-resize|-reverse)?
-              | run-in
-              | ruby(-base|-text)?(-container)?
-              | rtl|running|saturat(e|ion)|screen
-              | safe
-              | scroll(-position|bar)?
-              | separate|sepia
-              | scale-down
-              | shape-(image-threshold|margin|outside)
-              | show
-              | sideways(-lr|-rl)?
-              | simplified
-              | slashed-zero|slice
-              | small(-caps|er)?
-              | smooth|snap|solid|soft-light
-              | space(-around|-between|-evenly)?
-              | span|sRGB
-              | stack(ed-fractions)?
-              | start(ColorStr)?
-              | static
-              | step-(end|start)
-              | sticky
-              | stop-(color|opacity)
-              | stretch|strict
-              | stroke(-box|-dash(array|offset)|-miterlimit|-opacity|-width)?
-              | style(set)?
-              | stylistic
-              | sub(grid|pixel-antialiased|tract)?
-              | super|swash
-              | table(-caption|-cell|(-column|-footer|-header|-row)-group|-column|-row)?
-              | tabular-nums|tb-rl
-              | text((-bottom|-(decoration|emphasis)-color|-indent|-(over|under|after|before)-edge|-shadow|-size(-adjust)?|-top)|field)?
-              | thi(ck|n)
-              | titling-ca(ps|se)
-              | to[p]?
-              | touch|traditional
-              | transform(-origin)?
-              | under(-edge|line)?
-              | unicase|unsafe|unset|uppercase|upright
-              | use-(glyph-orientation|script)
-              | verso
-              | vertical(-align|-ideographic|-lr|-rl|-text)?
-              | view-box
-              | viewport-fill(-opacity)?
-              | visibility
-              | visible(Fill|Painted|Stroke)?
-              | wait|wavy|weight|whitespace|width|word-spacing
-              | wrap(-reverse)?
-              | x{1,2}-(large|small)
-              | z-index|zero
-              | zoom(-in|-out)?
-              | ({{counter_styles}})
-            ){{break}}(?=[\s;{),/])
-      scope: support.constant.property-value.css
-    - match: \b(?i:sans-serif|serif|monospace|fantasy|cursive|system-ui)\b(?=\s*[;,\n}{])
-      scope: support.constant.font-name.css
-    - match: \b(true|false|null)\b
-      scope: constant.language.sass
-
-
-  function-arguments:
-    - include: function-notation-terminator
-    - match: '\('
-      scope: punctuation.definition.group.begin.css
-      push:
-      - meta_scope: meta.group.css meta.function-call.arguments.css
-      - match: '(?=\))'
-        pop: true
-      - match: '\('
-        scope: punctuation.definition.group.begin.css
-        push:
-        - meta_scope: meta.group.css
-        - match: '\)'
-          scope: punctuation.definition.group.end.css
-          pop: true
-        - include: sass-script-expression
-      - include: comment-block
-      - include: comment-line
-      - include: comma-delimiter
-      - match: ':'
-        scope: punctuation.separator.css
-      - include: var-function
-      - include: minmax-function
-      - include: color-adjuster-operators
-      - include: color-adjuster-functions # must be included before `color-values`
-      - include: color-functions
-      - include: color-hex-values
-      - include: numeric-values
-      - include: integer-type
-      - include: image-type
-      - include: literal-string
-      - include: sass-variables
-      - include: sass-functions
-      - include: sass-custom-functions
-      - include: sass-interpolation
-      - include: sass-operators
-      - match: '\b[^\s''"\(\)]+\b'
-        scope: string.unquoted.css
-
-  builtin-functions:
-    - include: attr-function
-    - include: calc-function
-    - include: cross-fade-function
-    - include: filter-functions
-    - include: gradient-functions
-    - include: image-function
-    - include: image-set-function
-    - include: minmax-function
-    - include: url-function
-    - include: var-function
-    - include: color-adjuster-functions
-
-      # filter()
-      # https://drafts.fxtf.org/filters/#funcdef-filter
-    - match: '\b(filter)(?=\()'
-      scope: support.function.filter.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: image-type
-          - include: literal-string
-          - include: filter-functions
-          - include: sass-value-expression
-
-      # counter()
-      # https://drafts.csswg.org/css-lists-3/#funcdef-counter
-    - match: '\b(counter)(?=\()'
-      scope: support.function.counter.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - match: '({{ident}})'
-            scope: entity.other.counter-name.css string.unquoted.css
-          - match: '(?=,)'
-            push:
-              - match: '(?=\))'
-                pop: true
-              - include: comma-delimiter
-              - include: var-function
-              - match: '\b({{counter_styles}}|none)\b'
-                scope: support.constant.property-value.counter-style.css
-              - include: sass-value-expression
-          - include: var-function
-
-      # counters()
-      # https://drafts.csswg.org/css-lists-3/#funcdef-counters
-    - match: '\b(counters)(?=\()'
-      scope: support.function.counter.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - match: '({{ident}})'
-            scope: entity.other.counter-name.css string.unquoted.css
-          - match: '(?=,)'
-            push:
-              - match: '(?=\))'
-                pop: true
-              - include: comma-delimiter
-              - include: var-function
-              - include: literal-string
-              - match: '\b({{counter_styles}}|none)\b'
-                scope: support.constant.property-value.counter-style.css
-              - include: sass-value-expression
-          - include: var-function
-
-      # symbols()
-      # https://drafts.csswg.org/css-counter-styles-3/#symbols-function
-    - match: '\b(symbols)(?=\()'
-      scope: support.function.counter.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - match: '\b(cyclic|numeric|alphabetic|symbolic|fixed)\b'
-            scope: support.constant.symbol-type.css
-          - include: comma-delimiter
-          - include: var-function
-          - include: literal-string
-          - include: image-type
-          - include: sass-value-expression
-
-      # format()
-      # https://drafts.csswg.org/css-fonts-3/#descdef-src
-      # format() is also mentioned in `issue 2` at https://drafts.csswg.org/css-images-3/#issues-index
-      # but does not seem to be implemented in any manner
-    - match: '\b(format)(?=\()'
-      scope: support.function.font-face.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: literal-string
-          - include: sass-value-expression
-
-      # local()
-      # https://drafts.csswg.org/css-fonts-3/#descdef-src
-    - match: '\b(local)(?=\()'
-      scope: support.function.font-face.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: sass-value-expression
-          - include: literal-string
-          - include: unquoted-string
-
-      # Transform Functions
-      # https://www.w3.org/TR/css-transforms-1/#transform-functions
-
-      # transform functions with comma separated <number> types
-      # matrix(), scale(), matrix3d(), scale3d()
-    - match: '\b(matrix3d|scale3d|matrix|scale)(?=\()'
-      scope: support.function.transform.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: calc-function
-          - include: number-type
-          - include: var-function
-          - include: sass-value-expression
-
-      # transform functions with comma separated <number> or <length> types
-      # translate(), translate3d()
-    - match: '\b(translate(3d)?)(?=\()'
-      scope: support.function.transform.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: calc-function
-          - include: percentage-type
-          - include: length-type
-          - include: number-type
-          - include: sass-value-expression
-
-      # transform functions with a single <number> or <length> type
-      # translateX(), translateY()
-    - match: '\b(translate[XY])(?=\()'
-      scope: support.function.transform.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: percentage-type
-          - include: length-type
-          - include: number-type
-          - include: sass-value-expression
-
-      # transform functions with a single <angle> type
-      # rotate(), skewX(), skewY(), rotateX(), rotateY(), rotateZ()
-    - match: '\b(rotate[XYZ]?|skew[XY])(?=\()'
-      scope: support.function.transform.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: angle-type
-          - include: sass-value-expression
-
-      # transform functions with comma separated <angle> types
-      # skew()
-    - match: '\b(skew)(?=\()'
-      scope: support.function.transform.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: calc-function
-          - include: angle-type
-          - include: sass-value-expression
-
-      # transform functions with a single <length> type
-      # translateZ(), perspective()
-    - match: '\b(translateZ|perspective)(?=\()'
-      scope: support.function.transform.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: length-type
-          - include: sass-value-expression
-
-      # transform functions with a comma separated <number> or <angle> types
-      # rotate3d()
-    - match: '\b(rotate3d)(?=\()'
-      scope: support.function.transform.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: calc-function
-          - include: angle-type
-          - include: number-type
-          - include: sass-value-expression
-
-      # transform functions with a single <number> type
-      # scaleX(), scaleY(), scaleZ()
-    - match: '\b(scale[XYZ])(?=\()'
-      scope: support.function.transform.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: calc-function
-          - include: number-type
-          - include: sass-value-expression
-
-      # Timing Functions
-      # https://www.w3.org/TR/web-animations-1/#timing-functions
-
-      # cubic-bezier()
-      # https://www.w3.org/TR/web-animations-1/#cubic-bzier-timing-function
-    - match: '\b(cubic-bezier)(?=\()'
-      scope: support.function.timing.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: calc-function
-          - include: number-type
-          - include: sass-value-expression
-
-      # steps()
-      # https://www.w3.org/TR/web-animations-1/#step-timing-function
-    - match: '\b(steps)(?=\()'
-      scope: support.function.timing.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: calc-function
-          - include: integer-type
-          - match: \b(end|middle|start){{break}}
-            scope: support.keyword.timing-direction.css
-          - include: sass-value-expression
-
-      # Shape Functions
-      # https://www.w3.org/TR/css-shapes-1/#typedef-basic-shape
-
-      # rect() - Deprecated
-      # https://drafts.fxtf.org/css-masking-1/#funcdef-clip-rect
-    - match: '\b(rect)(?=\()'
-      scope: support.function.shape.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - match: \bauto{{break}}
-            scope: support.constant.property-value.css
-          - include: var-function
-          - include: calc-function
-          - include: length-type
-          - include: sass-value-expression
-
-      # inset()
-      # https://www.w3.org/TR/css-shapes-1/#funcdef-inset
-    - match: '\b(inset)(?=\()'
-      scope: support.function.shape.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - match: '\bround{{break}}'
-            scope: keyword.other.css
-          - include: var-function
-          - include: calc-function
-          - include: length-type
-          - include: percentage-type
-          - include: sass-value-expression
-
-      # circle()
-      # https://www.w3.org/TR/css-shapes-1/#funcdef-circle
-      # ellipse()
-      # https://www.w3.org/TR/css-shapes-1/#funcdef-ellipse
-    - match: '\b(circle|ellipse)(?=\()'
-      scope: support.function.shape.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - match: '\bat{{break}}'
-            scope: keyword.other.css
-          - match: '\b(top|right|bottom|left|center|closest-side|farthest-side){{break}}'
-            scope: support.constant.property-value.css
-          - include: var-function
-          - include: calc-function
-          - include: length-type
-          - include: percentage-type
-          - include: sass-value-expression
-
-      # polygon()
-      # https://www.w3.org/TR/css-shapes-1/#funcdef-polygon
-    - match: '\b(polygon)(?=\()'
-      scope: support.function.shape.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - include: comment-block
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: length-type
-          - include: percentage-type
-          - include: calc-function
-          - match: '\b(nonzero|evenodd){{break}}'
-            scope: support.constant.property-value.css
-          - include: sass-value-expression
-
-      # toggle()
-      # https://www.w3.org/TR/css3-values/#toggle-notation
-    - match: '\b(toggle)(?=\()'
-      scope: support.function.toggle.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: calc-function
-          - include: vendor-prefix
-          - include: property-value-constants
-          - include: numeric-values
-          - include: color-values
-          - include: literal-string
-          - include: sass-value-expression
-
-      # repeat()
-      # https://drafts.csswg.org/css-grid/#funcdef-repeat
-    - match: '\b(repeat)(?=\()'
-      scope: support.function.grid.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: calc-function
-          - include: var-function
-          - include: length-type
-          - include: percentage-type
-          - include: minmax-function
-          - include: integer-type
-          - include: line-names
-          - match: \b(auto-fill|auto-fit){{break}}
-            scope: support.keyword.repetitions.css
-          - match: \b(max-content|min-content|auto){{break}}
-            scope: support.constant.property-value.css
-          - include: sass-value-expression
-
-  # var()
-  # https://drafts.csswg.org/css-variables/#funcdef-var
-  var-function:
-    - match: '\b(var)(?=\()'
-      scope: support.function.var.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: custom-property-name
-          - match: '(?=,)'
-            push:
-              - match: '(?=\))'
-                pop: true
-              - include: property-values
-          - include: sass-value-expression
-
-  # Filter Functions
-  # https://drafts.fxtf.org/filters/#typedef-filter-function
-  filter-functions:
-      # blur()
-      # https://drafts.fxtf.org/filters/#funcdef-filter-blur
-    - match: '\b(blur)(?=\()'
-      scope: support.function.filter.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: length-type
-          - include: sass-value-expression
-
-      # brightness(), contrast(), grayscale(), invert(), opacity(), saturate(), sepia()
-      # https://drafts.fxtf.org/filters/#funcdef-filter-brightness
-    - match: '\b(brightness|contrast|grayscale|invert|opacity|saturate|sepia)(?=\()'
-      scope: support.function.filter.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: percentage-type
-          - include: number-type
-          - include: sass-value-expression
-
-      # drop-shadow()
-      # https://drafts.fxtf.org/filters/#funcdef-filter-drop-shadow
-    - match: '\b(drop-shadow)(?=\()'
-      scope: support.function.filter.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: length-type
-          - include: color-values
-          - include: sass-value-expression
-
-      # hue-rotate()
-      # https://drafts.fxtf.org/filters/#funcdef-filter-hue-rotate
-    - match: '\b(hue-rotate)(?=\()'
-      scope: support.function.filter.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: angle-type
-          - include: sass-value-expression
-
-  # calc()
-  # https://www.w3.org/TR/css3-values/#funcdef-calc
-  calc-function:
-    - match: '\b(calc)(?=\()'
-      scope: support.function.calc.css
-      push:
-        - meta_scope: meta.function-call.css
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push: inside-calc-parens
-        - match: ''
-          pop: true
-    - match: '\b(?i:clamp|max|min)(?=\()'
-      scope: support.function.calc.css
-      push:
-        - meta_scope: meta.function-call.css
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push: inside-calc-parens
-        - match: ''
-          pop: true
-
-  inside-calc-parens:
-    - meta_scope: meta.group.css
-    - match: '\)'
-      scope: punctuation.definition.group.end.css
-      set: maybe-illegal-operator
-    - include: comment-block
-    - include: attr-function
-    - include: calc-function
-    - include: var-function
-    - include: numeric-values
-    - match: '[-+*/]'
-      scope: keyword.operator.arithmetic.css
-    - include: sass-value-expression
-    - match: '\('
-      scope: punctuation.definition.group.begin.css
-      push: inside-calc-parens
-
-  # attr()
-  # https://www.w3.org/TR/css3-values/#funcdef-attr
-  attr-function:
-    - match: '\b(attr)(?=\()'
-      scope: support.function.attr.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: qualified-name
-          - include: literal-string
-          - include: sass-value-expression
-          - match: '({{ident}})'
-            scope: entity.other.attribute-name.css
-            push:
-            - match: |-
-                (?x)\b(
-                    {{font_relative_lengths}}
-                  | {{viewport_percentage_lengths}}
-                  | {{absolute_lengths}}
-                  | {{angle_units}}
-                  | {{duration_units}}
-                  | {{frequency_units}}
-                  | {{resolution_units}}
-                )\b
-              scope: constant.numeric.suffix.css
-            - match: '(?=\))'
-              pop: true
-            - include: comma-delimiter
-            - include: var-function
-            - include: property-value-constants
-            - include: numeric-values
-            - include: color-values
-            - include: sass-value-expression
-
-  # url()
-  # https://drafts.csswg.org/css-images-3/#url-notation
-  url-function:
-    - match: '\b(url)(?=\()'
-      scope: support.function.url.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: literal-string
-          - match: '(https?|ftp)://'
-            scope: string.unquoted.css
-          - include: sass-value-expression
-          - include: unquoted-string
-
-  # url-prefix()
-  # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-prefix
-  url-prefix-function:
-    - match: '\b(url-prefix)(?=\()'
-      scope: support.function.url-prefix.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: literal-string
-          - match: '(https?|ftp)://'
-            scope: string.unquoted.css
-          - include: sass-value-expression
-          - include: unquoted-string
-
-  # domain()
-  # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-domain
-  domain-function:
-    - match: '\b(domain)(?=\()'
-      scope: support.function.domain.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: literal-string
-          - match: '(https?|ftp)://'
-            scope: string.unquoted.css
-          - include: sass-value-expression
-          - include: unquoted-string
-
-  # regexp()
-  # https://www.w3.org/TR/2012/WD-css3-conditional-20120911/#url-regexp
-  regexp-function:
-    - match: '\b(regexp)(?=\()'
-      scope: support.function.regexp.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: literal-string
-          - include: sass-value-expression
-
-  # image()
-  # https://drafts.csswg.org/css-images-3/#funcdef-image
-  image-function:
-    - match: '\b(image)(?=\()'
-      scope: support.function.image.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: color-values
-          - include: image-type
-          - include: literal-string
-          - include: sass-value-expression
-          - include: unquoted-string
-
-  # image-set()
-  # https://drafts.csswg.org/css-images-3/#funcdef-image-set
-  image-set-function:
-    - match: '\b(image-set)(?=\()'
-      scope: support.function.image.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: color-values
-          - include: image-type
-          - include: resolution-type
-          - match: '([0-9]+)(x)'
-            scope: meta.number.integer.decimal.css
-            captures:
-              1: constant.numeric.value.css
-              2: constant.numeric.suffix.css
-          - include: sass-value-expression
-          - include: literal-string
-          - include: unquoted-string
-
-  # Gradient Functions
-  # https://drafts.csswg.org/css-images-3/#gradients
-  gradient-functions:
-    # conic-gradient()
-    # https://developer.mozilla.org/en-US/docs/Web/CSS/conic-gradient()
-    # repeating-conic-gradient()
-    # https://developer.mozilla.org/en-US/docs/Web/CSS/repeating-conic-gradient()
-    - match: \b((?:repeating-)?conic-gradient)(?=\()
-      scope: support.function.gradient.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: \(
-          scope: punctuation.section.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '(?=\))'
-              pop: true
-            - include: comma-delimiter
-            - match: \b(?i:at|from){{break}}
-              scope: keyword.other.gradient.css
-            - match: \b(?i:bottom|center|left|right|top){{break}}
-              scope: support.constant.property-value.css
-            - include: color-values
-            - include: angle-type
-            - include: length-type
-            - include: percentage-type
-            - include: sass-value-expression
-
-      # linear-gradient()
-      # https://drafts.csswg.org/css-images-3/#linear-gradients
-      # repeating-linear-gradient()
-      # https://drafts.csswg.org/css-images-3/#funcdef-repeating-linear-gradient
-    - match: '\b((?:repeating-)?linear-gradient)(?=\()'
-      scope: support.function.gradient.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: color-values
-          - include: angle-type
-          - include: length-type
-          - include: percentage-type
-          - match: '\bto{{break}}'
-            scope: keyword.other.css
-          - match: \b(bottom|left|right|top){{break}}
-            scope: support.constant.property-value.css
-          - include: sass-value-expression
-
-      # radial-gradient()
-      # https://drafts.csswg.org/css-images-3/#radial-gradients
-      # repeating-radial-gradient()
-      # https://drafts.csswg.org/css-images-3/#funcdef-repeating-radial-gradient
-    - match: '\b((?:repeating-)?radial-gradient)(?=\()'
-      scope: support.function.gradient.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: color-values
-          - include: angle-type
-          - include: length-type
-          - include: percentage-type
-          - match: '\b(at|circle|ellipse){{break}}'
-            scope: keyword.other.css
-          - match: |-
-              (?x)\b(
-                  left
-                | center
-                | right
-                | top
-                | bottom
-                | closest-corner
-                | closest-side
-                | farthest-corner
-                | farthest-side
-              ){{break}}
-            scope: support.constant.property-value.css
-          - include: sass-value-expression
-
-  # cross-fade()
-  # https://drafts.csswg.org/css-images-3/#cross-fade-function
-  cross-fade-function:
-    - match: '\b(cross-fade)(?=\()'
-      scope: support.function.image.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: var-function
-          - include: color-values
-          - include: image-type
-          - include: percentage-type
-          - include: literal-string
-          - include: sass-value-expression
-          - include: unquoted-string
-
-  # minmax()
-  # https://drafts.csswg.org/css-grid/#valdef-grid-template-columns-minmax
-  minmax-function:
-    - match: '\b(minmax)(?=\()'
-      scope: support.function.grid.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: calc-function
-          - include: var-function
-          - include: percentage-type
-          - include: length-type
-          - match: \b(auto|max-content|min-content){{break}}
-            scope: support.constant.property-value.css
-          - include: sass-value-expression
-
-  # Color Functions
-  # https://drafts.csswg.org/css-color
-  color-functions:
-      # rgb(), rgba()
-      # https://drafts.csswg.org/css-color/#rgb-functions
-    - match: '\b(rgba?)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: calc-function
-          - include: var-function
-          - include: percentage-type
-          - include: number-type
-          # scss add overloads:
-          # https://sass-lang.com/documentation/Sass/Script/Functions.html#rgba-instance_method
-          - include: color-values
-          - include: sass-value-expression
-
-      # hsl(), hsla()
-      # https://drafts.csswg.org/css-color/#the-hsl-notation
-      # hwb() - Not yet implemented by browsers
-      # https://drafts.csswg.org/css-color/#funcdef-hwb
-    - match: '\b(hsla?|hwb)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: calc-function
-          - include: var-function
-          - include: angle-type
-          - include: percentage-type
-          - include: number-type
-          - include: sass-value-expression
-
-      # gray() - Not yet implemented by browsers
-      # https://drafts.csswg.org/css-color/#funcdef-gray
-    - match: '\b(gray)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: calc-function
-          - include: var-function
-          - include: percentage-type
-          - include: number-type
-          - include: sass-value-expression
-
-      # device-cmyk() - Not yet implemented by browsers
-      # https://drafts.csswg.org/css-color/#funcdef-device-cmyk
-    - match: '\b(device-cmyk)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: calc-function
-          - include: color-adjuster-functions # must be included before `color-values`
-          - include: var-function
-          - include: color-values
-          - include: percentage-type
-          - include: number-type
-          - include: sass-value-expression
-
-      # color-mod() - Not yet implemented by browsers
-      # https://drafts.csswg.org/css-color/#funcdef-color-mod
-    - match: '\b(color)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: comma-delimiter
-          - include: calc-function
-          - include: color-adjuster-functions # must be included before `color-values`
-          - include: var-function
-          - include: color-values
-          - include: angle-type
-          - include: number-type
-          - include: sass-value-expression
-
-  # Color Adjuster Functions - Not yet implemented by browsers
-  # https://www.w3.org/TR/css-color-4/#typedef-color-adjuster
-  color-adjuster-functions:
-      # red(), green(), blue(), alpha() - Not yet implemented by browsers
-    - match: '\b(red|green|blue|alpha|a)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: color-adjuster-operators
-          - include: percentage-type
-          - include: number-type
-          - include: sass-value-expression
-
-      # hue() - Not yet implemented by browsers
-    - match: '\b(hue|h)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: color-adjuster-operators
-          - include: angle-type
-          - include: sass-value-expression
-
-      # saturation(), lightness(), whiteness(), blackness() - Not yet implemented by browsers
-    - match: '\b(saturation|lightness|whiteness|blackness|[slwb])(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: color-adjuster-operators
-          - include: percentage-type
-          - include: sass-value-expression
-
-      # tint(), shade(), contrast() - Not yet implemented by browsers
-      # contrast() interferes with the contrast() filter function;
-      # therefore, it is not yet implemented here
-    - match: '\b(tint|shade)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: percentage-type
-          - include: sass-value-expression
-
-      # blend(), blenda() - Not yet implemented by browsers
-    - match: '\b(blenda|blend)(?=\()'
-      scope: support.function.color.css
-      push:
-        - meta_scope: meta.function-call.css
-        - include: function-notation-terminator
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-          - meta_scope: meta.group.css
-          - match: '(?=\))'
-            pop: true
-          - include: var-function
-          - include: calc-function
-          - include: color-values
-          - include: percentage-type
-          - match: \b(?i:rgb|hsl|hwb){{break}}
-            scope: keyword.other.color-space.css
-          - include: sass-value-expression
-
-
-  color-adjuster-operators:
-    - match: '[-+*](?=\s)'
-      scope: keyword.operator.arithmetic.css
-    - match: '[-+*/]'
-      scope: invalid.illegal.operator.css
-
-  maybe-illegal-operator:
-    - match: '[-+](?=\s*\d)'
-      scope: invalid.illegal.operator.css
-      pop: true
-    - match: '\s*([-+])(?=\d)'
-      captures:
-        1: invalid.illegal.operator.css
-      pop: true
-    - match: ''
-      pop: true
-
-  comma-delimiter:
-    - match: '\s*(,)\s*'
-      captures:
-        1: punctuation.separator.sequence.css
-
-  color-hex-values:
-    - match: '(#)(\h{3}|\h{6})\b'
-      scope: constant.other.color.rgb-value.css
-      captures:
-        1: punctuation.definition.constant.css
-    - match: '(#)(\h{4}|\h{8})\b'
-      scope: constant.other.color.rgba-value.css
-      captures:
-        1: punctuation.definition.constant.css
-
-  function-notation-terminator:
-    - match: '\)'
-      scope: meta.group.css punctuation.definition.group.end.css
-      pop: true
-
-  vendor-prefix:
-    - match: "-(?:webkit|moz|ms|o)-"
-      scope: support.type.vendor-prefix.css
-
-  unicode-range:
-    - match: |-
-        (?xi)
-            (u\+)
-            ([0-9a-f?]{1,6}
-            (?:(-)[0-9a-f]{1,6})?)
-      scope: support.unicode-range.css
-      captures:
-        1: support.constant.unicode-range.prefix.css
-        2: constant.codepoint-range.css
-        3: punctuation.section.range.css
-
-  qualified-name:
-    - match: '(?:({{ident}})|(\*))?([|])(?!=)'
-      captures:
-        1: entity.other.namespace-prefix.css
-        2: entity.name.namespace.wildcard.css
-        3: punctuation.separator.namespace.css
-
-  # Custom Properties
-  # https://drafts.csswg.org/css-variables/#typedef-custom-property-name
-  custom-property-name:
-    - match: '(--)({{nmchar}}+)'
-      scope: support.type.custom-property.css
-      captures:
-        1: punctuation.definition.custom-property.css
-        2: support.type.custom-property.name.css
-
-  color-values:
-    - include: color-functions
-    - include: color-hex-values
-    - match: \b(?i:aqua|black|blue|fuchsia|gray|green|lime|maroon|navy|olive|orange|purple|red|silver|teal|white|yellow){{break}}
-      scope: support.constant.color.w3c-standard-color-name.css
-    - match: \b(?i:aliceblue|antiquewhite|aquamarine|azure|beige|bisque|blanchedalmond|blueviolet|brown|burlywood|cadetblue|chartreuse|chocolate|coral|cornflowerblue|cornsilk|crimson|cyan|darkblue|darkcyan|darkgoldenrod|darkgray|darkgreen|darkgrey|darkkhaki|darkmagenta|darkolivegreen|darkorange|darkorchid|darkred|darksalmon|darkseagreen|darkslateblue|darkslategray|darkslategrey|darkturquoise|darkviolet|deeppink|deepskyblue|dimgray|dimgrey|dodgerblue|firebrick|floralwhite|forestgreen|gainsboro|ghostwhite|gold|goldenrod|greenyellow|grey|honeydew|hotpink|indianred|indigo|ivory|khaki|lavender|lavenderblush|lawngreen|lemonchiffon|lightblue|lightcoral|lightcyan|lightgoldenrodyellow|lightgray|lightgreen|lightgrey|lightpink|lightsalmon|lightseagreen|lightskyblue|lightslategray|lightslategrey|lightsteelblue|lightyellow|limegreen|linen|magenta|mediumaquamarine|mediumblue|mediumorchid|mediumpurple|mediumseagreen|mediumslateblue|mediumspringgreen|mediumturquoise|mediumvioletred|midnightblue|mintcream|mistyrose|moccasin|navajowhite|oldlace|olivedrab|orangered|orchid|palegoldenrod|palegreen|paleturquoise|palevioletred|papayawhip|peachpuff|peru|pink|plum|powderblue|rebeccapurple|rosybrown|royalblue|saddlebrown|salmon|sandybrown|seagreen|seashell|sienna|skyblue|slateblue|slategray|slategrey|snow|springgreen|steelblue|tan|thistle|tomato|turquoise|violet|wheat|whitesmoke|yellowgreen){{break}}
-      scope: support.constant.color.w3c-extended-color-keywords.css
-    - match: \b(?i:currentColor|transparent){{break}}
-      scope: support.constant.color.w3c-special-color-keyword.css
-
-  numeric-values:
-    - include: angle-type
-    - include: frequency-type
-    - include: length-type
-    - include: resolution-type
-    - include: time-type
-    - include: percentage-type
-    - include: number-type
-
-  float-type:
-    - match: '{{float}}'
-      scope: meta.number.float.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: punctuation.separator.decimal.css
-      push: maybe-illegal-operator
-
-  integer-type:
-    - match: '{{integer}}'
-      scope: meta.number.integer.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-      push: maybe-illegal-operator
-
-  number-type:
-    - include: float-type
-    - include: integer-type
-
-  percentage-type:
-    - match: '{{float}}(%)'
-      scope: meta.number.float.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: punctuation.separator.decimal.css
-        4: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-    - match: '{{integer}}(%)'
-      scope: meta.number.integer.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-
-  dimensions:
-    - include: angle-type
-    - include: frequency-type
-    - include: length-type
-    - include: resolution-type
-    - include: time-type
-
-  angle-type:
-    - match: '{{float}}({{angle_units}})\b'
-      scope: meta.number.float.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: punctuation.separator.decimal.css
-        4: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-    - match: '{{integer}}({{angle_units}})\b'
-      scope: meta.number.integer.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-    - match: '0\b(?!%)'
-      scope: meta.number.integer.decimal.css constant.numeric.value.css
-      push: maybe-illegal-operator
-
-  frequency-type:
-    - match: '{{float}}({{frequency_units}})\b'
-      scope: meta.number.float.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: punctuation.separator.decimal.css
-        4: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-    - match: '{{integer}}({{frequency_units}})\b'
-      scope: meta.number.integer.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-
-  length-type:
-    - match: '{{float}}({{font_relative_lengths}}|{{viewport_percentage_lengths}}|{{absolute_lengths}})\b'
-      scope: meta.number.float.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: punctuation.separator.decimal.css
-        4: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-    - match: '{{integer}}({{font_relative_lengths}}|{{viewport_percentage_lengths}}|{{absolute_lengths}})\b'
-      scope: meta.number.integer.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-    - match: '0\b(?!%)'
-      scope: meta.number.integer.decimal.css constant.numeric.value.css
-      push: maybe-illegal-operator
-
-  resolution-type:
-    - match: '{{float}}({{resolution_units}})\b'
-      scope: meta.number.float.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: punctuation.separator.decimal.css
-        4: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-    - match: '{{integer}}({{resolution_units}})\b'
-      scope: meta.number.integer.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-
-  time-type:
-    - match: '{{float}}({{duration_units}})\b'
-      scope: meta.number.float.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: punctuation.separator.decimal.css
-        4: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-    - match: '{{integer}}({{duration_units}})\b'
-      scope: meta.number.integer.decimal.css
-      captures:
-        1: keyword.operator.arithmetic.css
-        2: constant.numeric.value.css
-        3: constant.numeric.suffix.css
-      push: maybe-illegal-operator
-
-  image-type:
-    - include: cross-fade-function
-    - include: gradient-functions
-    - include: image-function
-    - include: image-set-function
-    - include: url-function
-
-
-  # Named Grid Lines
-  # https://drafts.csswg.org/css-grid/#named-lines
-  line-names:
-    - match: '\['
-      scope: punctuation.section.begin.css
-      push:
-        - match: '{{ident}}'
-          scope: string.unquoted.line-name.css
-        - match: '\]'
-          scope: punctuation.section.end.css
-          pop: true
-
-
-  unquoted-string:
-    - match: '\b[^\s''"]+\b'
-      scope: string.unquoted.css
-
-  unquoted-concatenated-string:
-    # cases:
-    # unquoted string +
-    # + unquoted string
-    # unquoted string + unquoted string
-    - match: '([a-zA-Z_-]+)\s+(\+)\s+([a-zA-Z_-]+(?=\s|$|;))|(\+)\s+([a-zA-Z_-]+(?=\s|$|;))|([a-zA-Z_-]+)\s+(\+)'
-      captures:
-        1: string.unquoted.css
-        2: keyword.operator.sass
-        3: string.unquoted.css
-        4: keyword.operator.sass
-        5: string.unquoted.css
-        6: string.unquoted.css
-        7: keyword.operator.sass
-
-  literal-string:
-    - match: \'
-      scope: punctuation.definition.string.begin.css
-      push:
-        - meta_scope: string.quoted.single.css
-        - match: \'
-          scope: punctuation.definition.string.end.css
-          pop: true
-        - include: string-content
-    - match: \"
-      scope: punctuation.definition.string.begin.css
-      push:
-        - meta_scope: string.quoted.double.css
-        - match: \"
-          scope: punctuation.definition.string.end.css
-          pop: true
-        - include: string-content
-
-  string-content:
-    - match: \n
-      scope: invalid.illegal.newline.css
-      pop: true
-    - match: \\\s*\n
-      scope: constant.character.escape.newline.css
-    - match: \\(?:\h{1,6}|.)
-      scope: constant.character.escape.css
-    - include: sass-interpolation
-
-
-
-  comment-block:
-    - match: /\*
-      scope: punctuation.definition.comment.css
-      push:
-        - meta_scope: comment.block.css
-        - match: \*/
-          scope: punctuation.definition.comment.css
-          pop: true
-        - match: ^\s*(\*)(?!/)
-          captures:
-            1: punctuation.definition.comment.css
-
-  comment-line:
-    - match: //
-      scope: punctuation.definition.comment.css
-      push:
-        - meta_scope: comment.line.double-slash.sass
-        - match: \n
-          pop: true
-
-  css-modules:
-    - match: '\s*(:)(import|export)'
-      scope: meta.selector.css entity.other.pseudo-class.css-modules.css
-      captures:
-        1: punctuation.definition.entity.css
-      push:
-        - meta_scope: meta.selector.css meta.function-call.css
-        - match: '\('
-          scope: punctuation.definition.group.begin.css
-          push:
-            - meta_scope: meta.group.css
-            - match: '\)'
-              scope: punctuation.definition.group.end.css
-              pop: true
-            - include: literal-string
-        - match: '\s*(?=$)'
-          scope: punctuation.terminator.rule.sass
-          pop: true

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -675,7 +675,7 @@ contexts:
       push:
         - include: push-to-value
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
 
     # Sass content at-rule
     - match: '((@)content){{break}}'
@@ -684,7 +684,7 @@ contexts:
         2: punctuation.definition.keyword.sass
       push:
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
 
     # CSS modules
     - match: '\b(composes)\b'
@@ -692,7 +692,7 @@ contexts:
       push:
         - include: push-to-value
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
     - match: '\s*(:)(import|export)'
       scope: meta.selector.css entity.other.pseudo-class.css-modules.css
       captures:
@@ -705,11 +705,11 @@ contexts:
             - meta_scope: meta.group.css
             - match: '\)'
               scope: punctuation.section.group.end.css
-              pop: true
+              pop: 1
             - include: quoted-strings
         - match: '\s*(?=$)'
           scope: punctuation.terminator.rule.sass
-          pop: true
+          pop: 1
 
     - include: comments
     - include: sass-mixins
@@ -751,7 +751,7 @@ contexts:
       push:
         - meta_scope: comment.line.double-slash.sass
         - match: \n
-          pop: true
+          pop: 1
 
 ###[ AT RULES ]################################################################
 
@@ -1380,10 +1380,10 @@ contexts:
             - meta_scope: meta.group.css
             - match: '\)'
               scope: punctuation.section.group.end.css
-              pop: true
+              pop: 1
             - include: quoted-strings
         - match: ''
-          pop: true
+          pop: 1
     - match: '\s*(:)(local|global)'
       scope: meta.selector.css entity.other.pseudo-class.css-modules.css
       captures:
@@ -1619,7 +1619,7 @@ contexts:
             0: support.type.property-name
         - include: push-to-value
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
     - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
       push: property-identifier-content
     - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
@@ -1627,7 +1627,7 @@ contexts:
       push:
         - include: push-to-value
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
 
   property-identifier-content:
     - meta_scope: meta.property-name.css
@@ -1642,7 +1642,7 @@ contexts:
 
     - include: push-to-value
     - match: '\s*(?=$)'
-      pop: true
+      pop: 1
 
   builtin-property:
     - match: '{{property_names}}'
@@ -3283,7 +3283,7 @@ contexts:
         - match: '\)'
           captures:
             0: punctuation.section.group.end.sass
-          pop: true
+          pop: 1
         - match: '(\$)([a-zA-Z0-9_-][\w-]*)\s*(:)'
           captures:
             0: variable.other.sass
@@ -3324,7 +3324,7 @@ contexts:
                   scope: punctuation.separator.key-value.css
                 - include: property-value-content
                 - match: (?=\()
-                  pop: true
+                  pop: 1
             - include: function-arguments-common
             - include: color-values
             - include: percentage-constants
@@ -3371,7 +3371,7 @@ contexts:
         - meta_scope: meta.group.interpolation.sass
         - match: '(})'
           scope: punctuation.section.group.end.sass
-          pop: true
+          pop: 1
         - include: sass-script-expression
 
   sass-operators:
@@ -3391,14 +3391,14 @@ contexts:
       push:
         - meta_scope: meta.function.declaration.sass
         - match: '(?=$)'
-          pop: true
+          pop: 1
         - match: '\('
           scope: punctuation.section.group.begin.sass
           push:
             - meta_scope: meta.function.parameters.sass
             - match: '\)'
               scope: punctuation.section.group.end.sass
-              pop: true
+              pop: 1
             - include: comma-delimiters
             - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
               scope: variable.parameter.sass
@@ -3406,7 +3406,7 @@ contexts:
                 1: punctuation.definition.variable.sass
               push:
                 - match: '(?=[,\)])'
-                  pop: true
+                  pop: 1
                 - match: ':'
                   scope: punctuation.separator.key-value.css
                 - include: property-value-content
@@ -3417,14 +3417,14 @@ contexts:
       push:
         - meta_scope: meta.function-call.sass
         - match: '(?=$)'
-          pop: true
+          pop: 1
         - match: '\('
           scope: punctuation.section.group.begin.sass
           push:
             - meta_scope: meta.function-call.arguments.sass
             - match: '\)'
               scope: punctuation.section.group.end.sass
-              pop: true
+              pop: 1
             - include: sass-value-expression
             - include: comma-delimiters
             - include: property-value-content
@@ -3451,7 +3451,7 @@ contexts:
             - include: selectors
             - include: comments
             - match: '(?=$)'
-              pop: true
+              pop: 1
         - include: selector-content
 
 ###[ SASS AT-RULE FUNCTIONS ]#########################################
@@ -3466,12 +3466,12 @@ contexts:
         - include: sass-variables
         - include: comma-delimiters
         - match: '(?=$)'
-          pop: true
+          pop: 1
         - match: \b(in){{break}}
           scope: keyword.operator.sass
           push:
             - match: '(?=$)'
-              pop: true
+              pop: 1
             - include: comments
             - include: comma-delimiters
             - include: var-function
@@ -3483,7 +3483,7 @@ contexts:
       push:
         - meta_scope: meta.at-rule.sass
         - match: '(?=$)'
-          pop: true
+          pop: 1
         - include: sass-script-expression
     - match: '(@)(if|else if|else){{break}}'
       captures:
@@ -3492,7 +3492,7 @@ contexts:
       push:
         - meta_scope: meta.at-rule.sass
         - match: '(?=$)'
-          pop: true
+          pop: 1
         - include: sass-script-expression
     - match: '(@)(warn|error){{break}}'
       captures:
@@ -3501,7 +3501,7 @@ contexts:
       push:
         - meta_scope: meta.at-rule.sass
         - match: '(?=$)'
-          pop: true
+          pop: 1
         - include: sass-script-expression
     - match: '(@)(debug){{break}}'
       captures:
@@ -3510,7 +3510,7 @@ contexts:
       push:
         - meta_scope: meta.at-rule.sass
         - match: '(?=$)'
-          pop: true
+          pop: 1
         - include: sass-script-expression
     - match: '(@)(at-root){{break}}'
       captures:
@@ -3523,7 +3523,7 @@ contexts:
       push:
         - meta_scope: meta.at-rule.extend.sass
         - match: '(?=$)'
-          pop: true
+          pop: 1
         - match: \!\s*(default|global|optional){{break}}
           scope: keyword.other.sass
         - include: selectors
@@ -3535,14 +3535,14 @@ contexts:
       push:
         - meta_scope: meta.function.declaration.sass
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
         - match: '\('
           scope: punctuation.section.group.begin.sass
           push:
             - meta_scope: meta.function.parameters.sass
             - match: '\)'
               scope: punctuation.section.group.end.sass
-              pop: true
+              pop: 1
             - include: comma-delimiters
             - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
               scope: variable.parameter.sass
@@ -3550,7 +3550,7 @@ contexts:
                 1: punctuation.definition.variable.sass
               push:
                 - match: '(?=[,\)])'
-                  pop: true
+                  pop: 1
                 - match: ':'
                   scope: punctuation.separator.key-value.css
                 - match: '\b(false|true|null)\b'
@@ -3566,14 +3566,14 @@ contexts:
       push:
         - meta_scope: meta.function-call.sass
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
         - match: '\('
           scope: punctuation.section.group.begin.sass
           push:
             - meta_scope: meta.function-call.arguments.sass
             - match: '\)'
               scope: punctuation.section.group.end.sass
-              pop: true
+              pop: 1
             - include: comments
             - include: sass-variables
             - include: sass-functions
@@ -3592,7 +3592,7 @@ contexts:
       push:
         - meta_scope: meta.at-rule.sass
         - match: '\s*(?=$)'
-          pop: true
+          pop: 1
         - include: property-value-content
     - match: '\s*((@)(use|forward){{break}})\s*'
       captures:
@@ -3602,7 +3602,7 @@ contexts:
         - meta_scope: meta.at-rule.module.sass
         - match: '\s*(?=$)'
           scope: punctuation.terminator.rule.sass
-          pop: true
+          pop: 1
         - match: '\b(as)\b\s+([a-zA-Z0-9_-]*(\*)?)'
           captures:
             1: keyword.control.as.sass
@@ -3612,7 +3612,7 @@ contexts:
           scope: keyword.control.show-hide.sass
           push:
             - match: '(?=$)'
-              pop: true
+              pop: 1
             - include: comment-block
             - include: sass-variables
             - include: sass-functions
@@ -3627,7 +3627,7 @@ contexts:
           push:
             - match: '\)(?=$)'
               scope: punctuation.section.group.end.sass
-              pop: true
+              pop: 1
             - match: ':'
               scope: punctuation.separator.key-value.css
             - include: comments

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -3601,7 +3601,7 @@ contexts:
           scope: keyword.control.show-hide.sass
           push:
             - include: terminator-pop
-            - include: comment-block
+            - include: comments
             - include: sass-variables
             - include: sass-functions
             - include: sass-operators

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -683,6 +683,7 @@ contexts:
         1: keyword.control.at-rule.content.sass
         2: punctuation.definition.keyword.sass
       push:
+        - include: terminator-pop
         - match: '\s*(?=$)'
           pop: 1
 
@@ -708,7 +709,6 @@ contexts:
               pop: 1
             - include: quoted-strings
         - match: '\s*(?=$)'
-          scope: punctuation.terminator.rule.sass
           pop: 1
 
     - include: comments
@@ -3441,17 +3441,18 @@ contexts:
       captures:
         1: keyword.operator.ampersand.sass
       push:
-        - meta_scope: meta.selector.css
+        # - meta_scope: meta.selector.css
         - match: '[-_]+'
           scope: entity.other.attribute-name.css
+
           push:
             - match: '{{ident}}'
               scope: entity.other.attribute-name.css
             - include: sass-interpolation
             - include: selectors
             - include: comments
-            - match: '(?=$)'
-              pop: 1
+            - match: '(?=$|{)'
+              pop: 2
         - include: selector-content
 
 ###[ SASS AT-RULE FUNCTIONS ]#########################################
@@ -3465,13 +3466,11 @@ contexts:
         - meta_scope: meta.at-rule.each.sass
         - include: sass-variables
         - include: comma-delimiters
-        - match: '(?=$)'
-          pop: 1
+        - include: terminator-pop
         - match: \b(in){{break}}
           scope: keyword.operator.sass
           push:
-            - match: '(?=$)'
-              pop: 1
+            - include: terminator-pop
             - include: comments
             - include: comma-delimiters
             - include: var-function
@@ -3482,8 +3481,7 @@ contexts:
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
-        - match: '(?=$)'
-          pop: 1
+        - include: terminator-pop
         - include: sass-script-expression
     - match: '(@)(if|else if|else){{break}}'
       captures:
@@ -3491,8 +3489,7 @@ contexts:
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
-        - match: '(?=$)'
-          pop: 1
+        - include: terminator-pop
         - include: sass-script-expression
     - match: '(@)(warn|error){{break}}'
       captures:
@@ -3500,8 +3497,7 @@ contexts:
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
-        - match: '(?=$)'
-          pop: 1
+        - include: terminator-pop
         - include: sass-script-expression
     - match: '(@)(debug){{break}}'
       captures:
@@ -3509,8 +3505,7 @@ contexts:
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
-        - match: '(?=$)'
-          pop: 1
+        - include: terminator-pop
         - include: sass-script-expression
     - match: '(@)(at-root){{break}}'
       captures:
@@ -3522,8 +3517,7 @@ contexts:
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.extend.sass
-        - match: '(?=$)'
-          pop: 1
+        - include: terminator-pop
         - match: \!\s*(default|global|optional){{break}}
           scope: keyword.other.sass
         - include: selectors
@@ -3534,8 +3528,7 @@ contexts:
         4: entity.name.function.sass
       push:
         - meta_scope: meta.function.declaration.sass
-        - match: '\s*(?=$)'
-          pop: 1
+        - include: terminator-pop
         - match: '\('
           scope: punctuation.section.group.begin.sass
           push:
@@ -3565,8 +3558,7 @@ contexts:
         7: variable.function.sass
       push:
         - meta_scope: meta.function-call.sass
-        - match: '\s*(?=$)'
-          pop: 1
+        - include: terminator-pop
         - match: '\('
           scope: punctuation.section.group.begin.sass
           push:
@@ -3591,8 +3583,7 @@ contexts:
         1: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.sass
-        - match: '\s*(?=$)'
-          pop: 1
+        - include: terminator-pop
         - include: property-value-content
     - match: '\s*((@)(use|forward){{break}})\s*'
       captures:
@@ -3600,9 +3591,7 @@ contexts:
         2: punctuation.definition.keyword.sass
       push:
         - meta_scope: meta.at-rule.module.sass
-        - match: '\s*(?=$)'
-          scope: punctuation.terminator.rule.sass
-          pop: 1
+        - include: terminator-pop
         - match: '\b(as)\b\s+([a-zA-Z0-9_-]*(\*)?)'
           captures:
             1: keyword.control.as.sass
@@ -3611,8 +3600,7 @@ contexts:
         - match: '\b(show|hide)\b'
           scope: keyword.control.show-hide.sass
           push:
-            - match: '(?=$)'
-              pop: 1
+            - include: terminator-pop
             - include: comment-block
             - include: sass-variables
             - include: sass-functions

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -708,10 +708,9 @@ contexts:
     - include: comments
     - include: sass-mixins
     - include: selectors
-    - include: interpolated-selectors
+    - include: sass-interpolated-selectors
     - include: at-rules
     - include: rule-list-body
-    - include: illegal-groups
 
 ###[ COMMENTS ]################################################################
 
@@ -796,8 +795,6 @@ contexts:
     - include: at-counter-style-property-names
     - include: property-values
     - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
 
   at-counter-style-names:
     - match: '{{counter_style_illegal_names}}'
@@ -875,8 +872,6 @@ contexts:
     - include: at-font-face-property-names
     - include: property-values
     - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
 
   at-font-face-property-names:
     - match: \b(?i:font-family){{break}}
@@ -1562,12 +1557,10 @@ contexts:
     - include: property-identifiers
     - include: property-values
     - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
 
   push-to-value:
     - match: ';'
-      scope: invalid.illegal.sass
+      scope: punctuation.terminator.rule.css
     - match: ':'
       scope: punctuation.separator.key-value.css
       push: property-value-content
@@ -1588,8 +1581,6 @@ contexts:
     # common properties
     - include: builtin-property
     - include: custom-property
-    # - include: deprecated-property
-    # - include: other-property
     - include: push-to-value
     - match: '\s*(?=$)'
       pop: true
@@ -1604,17 +1595,6 @@ contexts:
     # custom property definition
     - match: '{{custom_ident}}'
       scope: meta.property-name.css entity.other.custom-property.css
-
-  deprecated-property:
-    - match: \b(var-)({{ident}})
-      scope: invalid.deprecated.custom-property.css
-      captures:
-        1: entity.other.custom-property.prefix.css
-        2: entity.other.custom-property.name.css
-
-  # other-property:
-  #   # Note: Consume unknown identifiers to maintain word boundaries.
-  #   - match: '{{generic_ident}}'
 
 ###[ PROPERTY VALUES ]#########################################################
 
@@ -2774,13 +2754,11 @@ contexts:
     - match: \b(?i:var)(?=\()
       scope: meta.function-call.identifier.css support.function.var.css
       push: var-function-arguments
-    - include: illegal-groups
 
   var-function:
     - match: \b(?i:var)(?=\()
       scope: meta.function-call.identifier.css support.function.var.css
       set: var-function-arguments
-    - include: illegal-groups
 
   var-function-arguments:
     - match: \(
@@ -3220,17 +3198,6 @@ contexts:
   rule-terminators:
     - match: ;
       scope: punctuation.terminator.rule.css
-
-  illegal-blocks:
-    # https://www.w3.org/TR/CSS22/syndata.html#parsing-errors
-    - match: \{
-      scope: invalid.illegal.unexpected-token.css
-      push:
-        - match: \}
-          scope: invalid.illegal.unexpected-token.css
-          pop: 1
-    - match: \}
-      scope: invalid.illegal.unexpected-token.css
 
 ###[ PROTOTYPES ]##############################################################
 

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -3079,6 +3079,7 @@ contexts:
       scope: constant.character.escape.newline.css
     - match: \\(?:\h{1,6}|.)
       scope: constant.character.escape.css
+    - include: sass-interpolation
 
 ###[ URL STRING CONSTANTS ]####################################################
 

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -943,7 +943,6 @@ contexts:
     - meta_scope: meta.block.css
     - include: block-end2
     - include: comments
-    - include: property-lists
     - include: at-keyframe-selectors
 
   at-keyframe-selectors:

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1492,14 +1492,22 @@ contexts:
     - include: illegal-blocks
     - include: illegal-groups
 
+  push-to-value:
+    - match: ';'
+      scope: invalid.illegal.sass
+    - match: ':'
+      scope: punctuation.separator.key-value.css
+      push: property-value-content
+
 ###[ PROPERTY IDENTIFIERS ]####################################################
 
   property-identifiers:
-    - match: (?=[-[:alpha:]])
+    - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
       push: property-identifier-content
 
   property-identifier-content:
-    - meta_scope: meta.property-name.css
+    - meta_scope: meta.property-list.css
+    - include: comments
     - include: vendor-prefixes
     # specific properties with special treatment
     - include: counter-property
@@ -1507,23 +1515,22 @@ contexts:
     # common properties
     - include: builtin-property
     - include: custom-property
-    - include: deprecated-property
-    - include: other-property
-    # bailout
-    - include: immediately-pop
+    # - include: deprecated-property
+    # - include: other-property
+    - include: push-to-value
+    - match: '\s*(?=$)'
+      pop: true
 
   builtin-property:
     - match: '{{property_names}}'
-      scope: support.type.property-name.css
-      pop: 1
+      scope: meta.property-name.css support.type.property-name.css
 
   # Custom Properties
   # https://drafts.csswg.org/css-variables/#typedef-custom-property
   custom-property:
     # custom property definition
     - match: '{{custom_ident}}'
-      scope: entity.other.custom-property.css
-      pop: 1
+      scope: meta.property-name.css entity.other.custom-property.css
 
   deprecated-property:
     - match: \b(var-)({{ident}})
@@ -1531,12 +1538,10 @@ contexts:
       captures:
         1: entity.other.custom-property.prefix.css
         2: entity.other.custom-property.name.css
-      pop: 1
 
-  other-property:
-    # Note: Consume unknown identifiers to maintain word boundaries.
-    - match: '{{generic_ident}}'
-      pop: 1
+  # other-property:
+  #   # Note: Consume unknown identifiers to maintain word boundaries.
+  #   - match: '{{generic_ident}}'
 
 ###[ PROPERTY VALUES ]#########################################################
 
@@ -1600,7 +1605,7 @@ contexts:
   counter-property:
     # https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Lists_and_Counters/Using_CSS_counters
     - match: \b(?i:counter-(increment|reset|set)){{break}}
-      scope: support.type.property-name.css
+      scope: meta.property-name.css support.type.property-name.css
       set: counter-property-value
 
   counter-property-value:
@@ -1614,7 +1619,7 @@ contexts:
   counter-identifier:
     - match: '{{ident}}'
       scope: entity.other.counter-name.css
-      pop: 1
+    - include: push-to-value
     - include: comments
     - include: else-pop
 
@@ -1712,7 +1717,7 @@ contexts:
   # https://drafts.csswg.org/css-fonts-3/#font-prop
   font-property:
     - match: \b(?i:font(-family)?){{break}}
-      scope: support.type.property-name.css
+      scope: meta.property-name.css support.type.property-name.css
       set: font-property-value
 
   font-property-value:
@@ -1752,14 +1757,12 @@ contexts:
     - include: transform-functions
     - include: url-functions
     - include: var-functions
-    - include: sass-value-expression
 
   function-arguments-common:
     - include: group-end
     - include: terminator-pop
     - include: comments
     - include: var-functions
-    - include: sass-value-expression
 
 ###[ BUILTIN AT RULE FUNCTIONS ]###############################################
 
@@ -3152,6 +3155,8 @@ contexts:
       pop: 1
 
   terminator-pop:
+    - match: '\s*(?=$)'
+      pop: 1
     - match: (?=[;){}]|$)
       pop: 1
 
@@ -3194,7 +3199,7 @@ contexts:
           captures:
             1: variable.parameter.sass
             2: punctuation.separator.key-value.css
-        - include: property-values
+        - include: property-value-content
 
   sass-variables:
     - match: '(({{ident}})(\.))?(\$)([a-zA-Z0-9_-][\w-]*)'
@@ -3210,18 +3215,38 @@ contexts:
       captures:
         1: support.function.sass
       push:
-        - meta_scope: meta.function-call.sass
-        - include: function-arguments-common
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - match: (\$)([a-zA-Z0-9_-][\w-]*)(?=:)
+              scope: variable.other.sass
+              captures:
+                1: punctuation.definition.variable.sass
+              push:
+                - match: ':'
+                  scope: punctuation.separator.key-value.css
+                - include: property-value-content
+                - match: (?=\()
+                  pop: true
+            - include: sass-value-expression
+            - include: function-arguments-common
 
   sass-custom-functions:
     - match: '\b(({{ident}})(\.))?([a-z_-]+)(?=\()'
-      scope: support.function.sass
+      scope: support.function.custom.sass
       captures:
         2: entity.name.namespace.sass
         3: punctuation.separator.namespace.sass
       push:
-        - meta_scope: meta.function-call.css
-        - include: function-arguments-common
+        - meta_include_prototype: false
+        - match: \(
+          scope: punctuation.section.group.begin.css
+          set:
+            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - include: sass-value-expression
+            - include: function-arguments-common
 
   sass-interpolation:
     - match: '(#)({)'
@@ -3270,7 +3295,7 @@ contexts:
                   pop: true
                 - match: ':'
                   scope: punctuation.separator.key-value.css
-                - include: property-values
+                - include: property-value-content
     - match: '\s*((\+)([\w-]+))'
       captures:
         1: variable.function.sass
@@ -3285,7 +3310,7 @@ contexts:
             - meta_scope: meta.function-call.arguments.sass
             - include: sass-value-expression
             - include: comma-delimiters
-            - include: property-values
+            - include: property-value-content
             - include: quoted-strings
             - match: '{{ident}}'
               scope: string.unquoted.sass
@@ -3418,7 +3443,7 @@ contexts:
                   scope: punctuation.separator.key-value.css
                 - match: '\b(false|true|null)\b'
                   scope: constant.language.sass
-                - include: property-values
+                - include: property-value-content
     - match: '((@)(include))\s+(([a-z]+)(\.))?([\w-]+)'
       captures:
         0: variable.function.sass
@@ -3440,7 +3465,7 @@ contexts:
             - include: sass-functions
             - include: sass-operators
             - include: comma-delimiters
-            - include: property-values
+            - include: property-value-content
             - include: quoted-strings
             - match: '{{ident}}'
               scope: string.unquoted.sass
@@ -3456,7 +3481,7 @@ contexts:
         - meta_scope: meta.at-rule.sass
         - match: '\s*(?=$)'
           pop: true
-        - include: property-values
+        - include: property-value-content
     - match: '\s*((@)(use|forward){{break}})\s*'
       captures:
         1: keyword.control.directive.module.sass
@@ -3499,7 +3524,7 @@ contexts:
             - include: sass-functions
             - include: sass-operators
             - include: comma-delimiters
-            - include: property-values
+            - include: property-value-content
         - include: comment-block
         - include: comment-line
         - include: quoted-strings

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -2338,12 +2338,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:at|from){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|center|left|right|top){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: angle-constants
             - include: length-constants
@@ -2361,12 +2361,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:to){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|left|right|top){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: angle-constants
             - include: length-constants
@@ -2384,12 +2384,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:at|circle|ellipse){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|center|left|right|top|(closest|farthest)-(corner|side)){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: length-constants
             - include: percentage-constants
@@ -3255,6 +3255,8 @@ contexts:
   sass-script-expression:
     - include: sass-value-expression
     - include: builtin-values
+    - match: '{{ident}}'
+      scope: constant.other.sass
 
   sass-value-expression:
     - include: comments

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -694,11 +694,11 @@ contexts:
       push:
         - meta_scope: meta.selector.css meta.function-call.css
         - match: '\('
-          scope: punctuation.definition.group.begin.css
+          scope: punctuation.section.group.begin.css
           push:
             - meta_scope: meta.group.css
             - match: '\)'
-              scope: punctuation.definition.group.end.css
+              scope: punctuation.section.group.end.css
               pop: true
             - include: quoted-strings
         - match: '\s*(?=$)'
@@ -1343,11 +1343,11 @@ contexts:
       push:
         - meta_scope: meta.selector.css meta.function-call.css
         - match: '\('
-          scope: punctuation.definition.group.begin.css
+          scope: punctuation.section.group.begin.css
           push:
             - meta_scope: meta.group.css
             - match: '\)'
-              scope: punctuation.definition.group.end.css
+              scope: punctuation.section.group.end.css
               pop: true
             - include: quoted-strings
         - match: ''
@@ -1638,10 +1638,10 @@ contexts:
         0: meta.property-name.css support.type.property-name
         1: meta.group.interpolation.sass
         2: punctuation.definition.variable.sass
-        3: punctuation.definition.group.begin.sass
+        3: punctuation.section.group.begin.sass
         4: variable.other.sass
         5: punctuation.definition.variable.sass
-        7: punctuation.definition.group.end.sass
+        7: punctuation.section.group.end.sass
       push:
         - include: push-to-value
         - match: '\s*(?=$)'
@@ -1658,7 +1658,7 @@ contexts:
     - include: builtin-values
     - include: other-functions
     - include: other-constants
-    - include: sass-maps
+    - include: sass-value-expression
 
   builtin-values:
     - include: quoted-strings
@@ -3232,17 +3232,6 @@ contexts:
     - match: \}
       scope: invalid.illegal.unexpected-token.css
 
-  illegal-groups:
-    # https://www.w3.org/TR/CSS22/syndata.html#parsing-errors
-    - match: \(
-      scope: invalid.illegal.unexpected-token.css
-      push:
-        - match: \)
-          scope: invalid.illegal.unexpected-token.css
-          pop: 1
-    - match: \)
-      scope: invalid.illegal.unexpected-token.css
-
 ###[ PROTOTYPES ]##############################################################
 
   else-pop:
@@ -3282,12 +3271,12 @@ contexts:
   sass-maps:
     - match: '\('
       captures:
-        0: punctuation.definition.group.begin.sass
+        0: punctuation.section.group.begin.sass
       push:
         - meta_scope: meta.group.css meta.map.arguments.css
         - match: '\)'
           captures:
-            0: punctuation.definition.group.end.sass
+            0: punctuation.section.group.end.sass
           pop: true
         - match: '(\$)([a-zA-Z0-9_-][\w-]*)\s*(:)'
           captures:
@@ -3314,11 +3303,12 @@ contexts:
       captures:
         1: support.function.sass
       push:
+        - meta_scope: meta.function-call.sass
         - meta_include_prototype: false
         - match: \(
           scope: punctuation.section.group.begin.css
           set:
-            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - meta_scope: meta.function-call.sass meta.function-call.arguments.css meta.group.css
             - match: (\$)([a-zA-Z0-9_-][\w-]*)(?=:)
               scope: variable.other.sass
               captures:
@@ -3338,6 +3328,8 @@ contexts:
             - include: scalar-integer-constants
             - include: generic-font-names
             - include: numeric-constants
+            - match: '{{ident}}'
+              scope: constant.other.sass
 
   sass-custom-functions:
     - match: '\b(?!var)(({{ident}})(\.))?([a-z_-]+)(?=\()'
@@ -3346,11 +3338,12 @@ contexts:
         2: entity.name.namespace.sass
         3: punctuation.separator.namespace.sass
       push:
+        - meta_scope: meta.function-call.sass
         - meta_include_prototype: false
         - match: \(
           scope: punctuation.section.group.begin.css
           set:
-            - meta_scope: meta.function-call.arguments.css meta.group.css
+            - meta_scope: meta.function-call.sass meta.function-call.arguments.css meta.group.css
             - include: function-arguments-common
             - include: color-values
             - include: percentage-constants
@@ -3360,16 +3353,18 @@ contexts:
             - include: scalar-integer-constants
             - include: generic-font-names
             - include: numeric-constants
+            - match: '{{ident}}'
+              scope: constant.other.sass
 
   sass-interpolation:
     - match: '(#)({)'
       captures:
         1: punctuation.definition.variable.sass
-        2: punctuation.definition.group.begin.sass
+        2: punctuation.section.group.begin.sass
       push:
         - meta_scope: meta.group.interpolation.sass
         - match: '(})'
-          scope: punctuation.definition.group.end.sass
+          scope: punctuation.section.group.end.sass
           pop: true
         - include: sass-script-expression
 
@@ -3392,11 +3387,11 @@ contexts:
         - match: '(?=$)'
           pop: true
         - match: '\('
-          scope: punctuation.definition.group.begin.sass
+          scope: punctuation.section.group.begin.sass
           push:
             - meta_scope: meta.function.parameters.sass
             - match: '\)'
-              scope: punctuation.definition.group.end.sass
+              scope: punctuation.section.group.end.sass
               pop: true
             - include: comma-delimiters
             - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
@@ -3418,11 +3413,11 @@ contexts:
         - match: '(?=$)'
           pop: true
         - match: '\('
-          scope: punctuation.definition.group.begin.sass
+          scope: punctuation.section.group.begin.sass
           push:
             - meta_scope: meta.function-call.arguments.sass
             - match: '\)'
-              scope: punctuation.definition.group.end.sass
+              scope: punctuation.section.group.end.sass
               pop: true
             - include: sass-value-expression
             - include: comma-delimiters
@@ -3474,12 +3469,7 @@ contexts:
             - include: comments
             - include: comma-delimiters
             - include: var-function
-            - include: sass-variables
-            - include: sass-functions
-            - include: sass-custom-functions
-            - include: sass-interpolation
-            - include: sass-maps
-            - include: sass-operators
+            - include: sass-value-expression
     - match: '(@)(for|while){{break}}'
       captures:
         0: keyword.control.flow.sass
@@ -3541,11 +3531,11 @@ contexts:
         - match: '\s*(?=$)'
           pop: true
         - match: '\('
-          scope: punctuation.definition.group.begin.sass
+          scope: punctuation.section.group.begin.sass
           push:
             - meta_scope: meta.function.parameters.sass
             - match: '\)'
-              scope: punctuation.definition.group.end.sass
+              scope: punctuation.section.group.end.sass
               pop: true
             - include: comma-delimiters
             - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
@@ -3572,11 +3562,11 @@ contexts:
         - match: '\s*(?=$)'
           pop: true
         - match: '\('
-          scope: punctuation.definition.group.begin.sass
+          scope: punctuation.section.group.begin.sass
           push:
             - meta_scope: meta.function-call.arguments.sass
             - match: '\)'
-              scope: punctuation.definition.group.end.sass
+              scope: punctuation.section.group.end.sass
               pop: true
             - include: comments
             - include: sass-variables
@@ -3627,10 +3617,10 @@ contexts:
         - match: '(with)\s+(\()'
           captures:
             1: keyword.control.with.sass
-            2: punctuation.definition.group.begin.sass
+            2: punctuation.section.group.begin.sass
           push:
             - match: '\)(?=$)'
-              scope: punctuation.definition.group.end.sass
+              scope: punctuation.section.group.end.sass
               pop: true
             - match: ':'
               scope: punctuation.separator.key-value.css
@@ -3647,10 +3637,10 @@ contexts:
 
   sass-interpolated-selector-body:
     - match: '({)'
-      scope: punctuation.definition.group.begin.sass
+      scope: punctuation.section.group.begin.sass
       push:
         - match: '(})'
-          scope: punctuation.definition.group.end.sass
+          scope: punctuation.section.group.end.sass
           pop: 2
         - include: sass-script-expression
 

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -665,6 +665,12 @@ contexts:
     - include: at-rules
     - include: rule-list-body
     - include: illegal-groups
+    - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
+      captures:
+        0: variable.declaration.sass
+        1: punctuation.definition.variable.sass
+      push:
+        - include: push-to-value
     # - include: css-modules # need to re-implement?
 
 ###[ COMMENTS ]################################################################
@@ -1060,7 +1066,7 @@ contexts:
     - include: main
 
   at-rule-end:
-    - match: (?=[;{}])
+    - match: (?=[;{}]|$)
       pop: 1
     - include: comments
 
@@ -1554,6 +1560,8 @@ contexts:
 
   property-value-content:
     - meta_content_scope: meta.property-value.css
+    - match: '\!\s*(default|global|optional)\b'
+      scope: keyword.other.sass
     - include: terminator-pop
     - include: comments
     - include: comma-delimiters

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -651,6 +651,8 @@ contexts:
   main:
     - match: '\{|\}|;'
       scope: invalid.illegal.sass
+
+    # Yekyll front matter
     - match: '^---$'
       scope: frontmatter.jekyll punctuation.section.frontmatter.begin.jekyll
       embed: scope:source.yaml
@@ -658,24 +660,7 @@ contexts:
       escape: '^---$'
       escape_captures:
         0: frontmatter.jekyll punctuation.section.frontmatter.end.jekyll
-    - include: comments
-    - include: sass-mixins
-    - include: selectors
-    - include: interpolated-selectors
-    - include: at-rules
-    - include: rule-list-body
-    - include: illegal-groups
 
-
-    # Sass nested property names
-    # Partial property names, split at "-"
-    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
-    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - include: push-to-value
-        - match: '\s*(?=$)'
-          pop: true
     # Sass variable declarations
     - match: '(\$)([a-zA-Z0-9_-][\w-]*)'
       captures:
@@ -685,7 +670,39 @@ contexts:
         - include: push-to-value
         - match: '\s*(?=$)'
           pop: true
-    # - include: css-modules # need to re-implement?
+
+    # CSS modules
+    - match: '\b(composes)\b'
+      scope: meta.property-name.css-modules.css support.type.property-name
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
+    - match: '\s*(:)(import|export)'
+      scope: meta.selector.css entity.other.pseudo-class.css-modules.css
+      captures:
+        1: punctuation.definition.entity.css
+      push:
+        - meta_scope: meta.selector.css meta.function-call.css
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+            - meta_scope: meta.group.css
+            - match: '\)'
+              scope: punctuation.definition.group.end.css
+              pop: true
+            - include: quoted-strings
+        - match: '\s*(?=$)'
+          scope: punctuation.terminator.rule.sass
+          pop: true
+
+    - include: comments
+    - include: sass-mixins
+    - include: selectors
+    - include: interpolated-selectors
+    - include: at-rules
+    - include: rule-list-body
+    - include: illegal-groups
 
 ###[ COMMENTS ]################################################################
 
@@ -1304,6 +1321,28 @@ contexts:
     - match: '{{combinators}}{2,}|\|{3,}'
       scope: invalid.illegal.combinator.css
 
+    # CSS modules
+    - match: '\s*(:)(local|global)(?=\()'
+      scope: meta.selector.css entity.other.pseudo-class.css-modules.css
+      captures:
+        1: punctuation.definition.entity.css
+      push:
+        - meta_scope: meta.selector.css meta.function-call.css
+        - match: '\('
+          scope: punctuation.definition.group.begin.css
+          push:
+            - meta_scope: meta.group.css
+            - match: '\)'
+              scope: punctuation.definition.group.end.css
+              pop: true
+            - include: quoted-strings
+        - match: ''
+          pop: true
+    - match: '\s*(:)(local|global)'
+      scope: meta.selector.css entity.other.pseudo-class.css-modules.css
+      captures:
+        1: punctuation.definition.entity.css
+
   selector-end:
     - match: (?=\s*[;@(){}]|$)
       pop: 1
@@ -1511,6 +1550,15 @@ contexts:
     - include: rule-terminators
     - include: illegal-blocks
     - include: illegal-groups
+    # Sass nested property names
+    # Partial property names, split at "-"
+    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
+    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
+      scope: meta.property-name.css support.type.property-name.css
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
 
   push-to-value:
     - match: ';'

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1606,17 +1606,18 @@ contexts:
     # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
     - match: '[a-zA-Z0-9_-]*(?=#{)'
       captures:
-        0: support.type.property-name
+        0: meta.property-name.css support.type.property-name.css
       push:
         - meta_scope: meta.property-name.css
         - include: sass-interpolation
         - match: '[a-zA-Z0-9_-]*'
           captures:
-            0: support.type.property-name
+            0: meta.property-name.css support.type.property-name.css
         - include: push-to-value
         - match: '\s*(?=$)'
           pop: 1
     - match: (?=({{vendor_prefix}})?{{property_names}}|{{custom_ident}}|\b(?i:counter-(increment|reset|set)){{break}}|\b(?i:font(-family)?){{break}})
+      scope: meta.property-name.css
       push: property-identifier-content
     - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
       scope: meta.property-name.css support.type.property-name.css
@@ -1626,6 +1627,7 @@ contexts:
           pop: 1
 
   property-identifier-content:
+    - meta_scope: meta.property-name.css
     - include: comments
     - include: vendor-prefixes
     # specific properties with special treatment

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1345,7 +1345,6 @@ contexts:
       scope: keyword.operator.combinator.css
 
   selector-content:
-    - meta_scope: meta.selector.css
     - include: selector-end
     - include: comma-delimiters
     - include: sass-ampersand

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1763,6 +1763,7 @@ contexts:
     - include: terminator-pop
     - include: comments
     - include: var-functions
+    - include: sass-value-expression
 
 ###[ BUILTIN AT RULE FUNCTIONS ]###############################################
 
@@ -3230,11 +3231,18 @@ contexts:
                 - include: property-value-content
                 - match: (?=\()
                   pop: true
-            - include: sass-value-expression
             - include: function-arguments-common
+            - include: color-values
+            - include: percentage-constants
+            - include: scalar-constants
+            - include: angle-constants
+            - include: length-constants
+            - include: scalar-integer-constants
+            - include: generic-font-names
+            - include: numeric-constants
 
   sass-custom-functions:
-    - match: '\b(({{ident}})(\.))?([a-z_-]+)(?=\()'
+    - match: '\b(?!var)(({{ident}})(\.))?([a-z_-]+)(?=\()'
       scope: support.function.custom.sass
       captures:
         2: entity.name.namespace.sass
@@ -3245,8 +3253,15 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: sass-value-expression
             - include: function-arguments-common
+            - include: color-values
+            - include: percentage-constants
+            - include: scalar-constants
+            - include: angle-constants
+            - include: length-constants
+            - include: scalar-integer-constants
+            - include: generic-font-names
+            - include: numeric-constants
 
   sass-interpolation:
     - match: '(#)({)'

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -2267,10 +2267,10 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:auto-fill|auto-fit){{break}}
               scope: keyword.other.grid.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: calc-functions
             - include: minmax-functions
             - include: grid-constants
@@ -2355,12 +2355,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:at|from){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|center|left|right|top){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: angle-constants
             - include: length-constants
@@ -2378,12 +2378,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:to){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|left|right|top){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: angle-constants
             - include: length-constants
@@ -2401,12 +2401,12 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:at|circle|ellipse){{break}}
               scope: keyword.other.gradient.css
             - match: \b(?i:bottom|center|left|right|top|(closest|farthest)-(corner|side)){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: color-values
             - include: length-constants
             - include: percentage-constants
@@ -2426,9 +2426,9 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - match: \b(?i:auto){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
             - include: calc-functions
             - include: length-constants
 
@@ -2442,9 +2442,9 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - match: \b(?i:round){{break}}
               scope: keyword.other.shape.css
+            - include: function-arguments-common
             - include: calc-functions
             - include: length-constants
             - include: percentage-constants
@@ -2461,11 +2461,11 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
             - match: \b(?i:at){{break}}
               scope: keyword.other.shape.css
             - match: \b(?i:top|right|bottom|left|center|closest-side|farthest-side){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
             - include: calc-functions
             - include: length-constants
             - include: percentage-constants
@@ -2480,10 +2480,10 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
-            - include: function-arguments-common
-            - include: comma-delimiters
             - match: \b(?i:nonzero|evenodd){{break}}
               scope: support.constant.property-value.css
+            - include: function-arguments-common
+            - include: comma-delimiters
             - include: calc-functions
             - include: length-constants
             - include: percentage-constants
@@ -2518,11 +2518,11 @@ contexts:
           scope: punctuation.section.group.begin.css
           set:
             - meta_scope: meta.function-call.arguments.css meta.group.css
+            - match: \b(?i:end|middle|start){{break}}
+              scope: keyword.other.timing.css
             - include: function-arguments-common
             - include: comma-delimiters
             - include: calc-functions
-            - match: \b(?i:end|middle|start){{break}}
-              scope: keyword.other.timing.css
             - include: scalar-integer-constants
 
 ###[ BUILTIN TRANSFORM FUNCTIONS ]#############################################

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1236,7 +1236,7 @@ contexts:
       push:
         - meta_scope: meta.selector.css
         - include: selector-content
-    - match: (?=\s*[#.:\[\*%>~+,&])
+    - match: (?=\s*[#.:\[\*%>~+,&](?!{))
       push:
         - meta_scope: meta.selector.css
         - include: selector-content
@@ -1555,15 +1555,6 @@ contexts:
     - include: rule-terminators
     - include: illegal-blocks
     - include: illegal-groups
-    # Sass nested property names
-    # Partial property names, split at "-"
-    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
-    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
-      scope: meta.property-name.css support.type.property-name.css
-      push:
-        - include: push-to-value
-        - match: '\s*(?=$)'
-          pop: true
 
   push-to-value:
     - match: ';'
@@ -1624,6 +1615,28 @@ contexts:
     - match: ':'
       scope: punctuation.separator.key-value.css
       push: property-value-content
+    # Sass nested property names
+    # Partial property names, split at "-"
+    # http://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
+    - match: '\b(z|y|x|writing|wrap|word|will|width|white|weight|visibility|vertical|variant-position|variant-numeric|variant-ligatures|variant-east-asian|variant-caps|variant-alternates|variant|user|unicode|underline-position|underline|type|transition|transform|touch|top-width|top-style|top-right-radius|top-left-radius|top-color|top|timing-function|timing|threshold|text|template-rows|template-columns|template-areas|template|tap|table|tab|synthesis|symbols|style-type|style-position|style-image|style|stroke|stretch|stop|state|start|speak|span|spacing|space|source|smoothing|slice|sizing|size-adjust|size|side|shrink|shift|shape|shadow|settings|self|select|scrolling|scroll|rule-width|rule-style|rule-color|rule|rows|row-start|row-gap|row-end|row|right-width|right-style|right-radius|right-color|right|resolution|reset|repeat-y|repeat-x|repeat|rendering|range|radius|property|profile|preferred-size|preferred|positive|position-y|position-x|position|pointer|play-state|play|pitch|perspective|pause|path|paint|page|padding|pack|override|overflow|outside|outset|outline|origin-y|origin-x|origin|orientation|orient|ordinal-group|ordinal|order|opacity|offset|object|numeric|negative|nbsp|name|mode|mix|miterlimit|min|mid|max|mask|marker|margin|list|linejoin|linecap|line-pack|line|lighting|ligatures|letter|left-width|left-style|left-radius|left-color|left|layout|last|language-override|language|kerning|justify|iteration-count|iteration|items|item-align|item|interpolation-filters|interpolation|inside|index|indent|increment|image-width|image-threshold|image-source|image-slice|image-repeat|image-outset|image|highlight-color|highlight|height|grow|group|grid|gap|function|font|flow|flood|flex|fit|filters|fill-mode|fill-color|fill|feature-settings|feature|family|events|end|empty|emphasis-style|emphasis-position|emphasis-color|emphasis|duration|drag|dominant|display|direction|delay|decoration-style|decoration-line|decoration-color|decoration-break|decoration|dashoffset|dasharray|counter|count|content|contain|composite|columns|column-start|column-gap|column-end|column|color|collapse|clip|clamp|change|cells|caption|caps|break-inside|break-before|break-after|break|box-contain|box|bottom-width|bottom-style|bottom-color|bottom|border|blend-mode|blend|bidi|behavior|before|basis|baseline|background|backface|auto-rows|auto-flow|auto-columns|auto|attachment|as|areas|area|animation|anchor|alternates|alignment|align-last|align|after|adjust|additive|action)\b'
+      scope: meta.property-name.css support.type.property-name.css
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
+    - match: '[a-zA-Z0-9_-]*((#)({)((\$)([a-zA-Z0-9_-][\w-]*))(}))[a-zA-Z0-9_-]*'
+      captures:
+        0: meta.property-name.css support.type.property-name
+        1: meta.group.interpolation.sass
+        2: punctuation.definition.variable.sass
+        3: punctuation.definition.group.begin.sass
+        4: variable.other.sass
+        5: punctuation.definition.variable.sass
+        7: punctuation.definition.group.end.sass
+      push:
+        - include: push-to-value
+        - match: '\s*(?=$)'
+          pop: true
 
   property-value-content:
     - meta_content_scope: meta.property-value.css

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1062,8 +1062,6 @@ contexts:
     - include: at-page-property-names
     - include: property-values
     - include: rule-terminators
-    - include: illegal-blocks
-    - include: illegal-groups
 
   at-page-property-names:
     - match: '{{page_property_names}}'

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -1627,7 +1627,6 @@ contexts:
           pop: 1
 
   property-identifier-content:
-    - meta_scope: meta.property-name.css
     - include: comments
     - include: vendor-prefixes
     # specific properties with special treatment

--- a/Syntaxes/Sass.sublime-syntax
+++ b/Syntaxes/Sass.sublime-syntax
@@ -2745,6 +2745,7 @@ contexts:
       push: maybe-illegal-operator
     - match: '[-+*/]'
       scope: keyword.operator.arithmetic.css
+    - include: sass-value-expression
 
   toggle-functions:
     # toggle()

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -1,3 +1,5 @@
+/* SYNTAX TEST "Packages/Sass/Syntaxes/Sass.sublime-syntax" */
+
 // https://sass-lang.com/documentation/file.INDENTED_SYNTAX.html
 
 // This comment will not appear in the CSS output.
@@ -709,7 +711,7 @@ p
 //           ^^^^ constant.numeric
 
   top: steps(1, var(--end))
-/*                ^^^ support.function.var.css */
+/*              ^^^ support.function.var.css */
 
   top: blenda(red 50% hsl)
 //     ^^^^^^             support.function.color.css

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -356,20 +356,20 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
     cursor: e + -resize
 //          ^ string.unquoted
 //           ^ - string
-//            ^ keyword.operator.sass
+//            ^ keyword.operator
 //             ^ - string
 //              ^^^^^ string.unquoted
 
     content: "Foo " + Bar
 //               ^ string.quoted.double
+//                  ^ keyword.operator
 //                    ^ string.unquoted
 //                       ^ - string
-//                  ^ keyword.operator.sass
 
     font-family: sans- + "serif"
 //               ^^^^^ string.unquoted
 //                              ^ - string
-//                     ^ keyword.operator.sass
+//                     ^ keyword.operator
 
     content: "I ate #{5 + 10} pies!"
 //           ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -221,7 +221,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
   block comment contains #{ $variable
   block comment contains #{ function($variable) + "escap\e" + -.5em
 */
-// <- comment.block.css punctuation.definition.comment.css
+// <- comment.block.css punctuation.definition.comment
 
 // line comment
 // line comment contains #{ $variable
@@ -421,7 +421,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 */
 
 +firefox-message(".header" + test + .class, #some-id:hover)
-// <- punctuation.definition.keyword.sass
+// <- keyword.control.directive.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
 // ^^^^^^^^^^^^^ variable.function.sass
 //              ^ punctuation.section.group.begin
@@ -432,9 +432,9 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //                               ^ - string
 
   +firefox-message($foo)
-//^ punctuation.definition.keyword.sass
+//^ keyword.control.directive.sass
 //^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
-//^^^^^^^^^^^^^^^^ variable.function.sass
+// ^^^^^^^^^^^^^^^ variable.function.sass
 //                 ^^^^ variable.other
 
 =large-text
@@ -622,7 +622,7 @@ $list: (top, bottom, right, position, height);
 .button
   @include corners.rounded
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
-//         ^^^^^^^^^^^^^^^ variable.function.sass
+//                 ^^^^^^^ variable.function.sass
 //         ^^^^^^^ entity.name.namespace.sass
 //                ^ punctuation
   padding: 5px + corners.$radius

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -353,19 +353,6 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
     background: url(data:image/gifbase64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)
 //                  ^^^^^ string.unquoted.css
 
-    cursor: e + -resize
-//          ^ string.unquoted
-//           ^ - string
-//            ^ keyword.operator
-//             ^ - string
-//              ^^^^^ string.unquoted
-
-    content: "Foo " + Bar
-//               ^ string.quoted.double
-//                  ^ keyword.operator
-//                    ^ string.unquoted
-//                       ^ - string
-
     font-family: sans- + "serif"
 //               ^^^^^ string.unquoted
 //                              ^ - string
@@ -388,10 +375,6 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
     content: "I ate #{$value} pies!"
 //                    ^^^^^^ variable.other.sass
 //                    ^ punctuation.definition.variable.sass
-
-    @include breathe(somestring)
-//                   ^ string.unquoted
-//                             ^ - string
 
     @include breathe(border-bottom-color)
 //                   ^^^^^^^^^^^^^^^^^^^ support.constant.property-value.css
@@ -430,22 +413,22 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 @include firefox-message(".header" + test)
 //                       ^^^^^^^^^ meta.function-call.sass meta.function-call.arguments.sass string.quoted.double.css
 //                                 ^ keyword.operator.arithmetic.sass
-//                                   ^ string.unquoted
 //                                       ^ - string
-
 
 /*
   Mixin Directives
   http://sass-lang.com/documentation/file.INDENTED_SYNTAX.html#Mixin_Directives
 */
 
-+firefox-message(".header" + test)
++firefox-message(".header" + test + .class, #some-id:hover)
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
 // ^^^^^^^^^^^^^ variable.function.sass
+//              ^ punctuation.definition.group.begin
+//                                                        ^ punctuation.definition.group.end
 //               ^^^^^^^^^ string.quoted.double.css
 //                         ^ keyword.operator.arithmetic.sass
-//                           ^ string.unquoted
+//                           ^ constant.other
 //                               ^ - string
 
   +firefox-message($foo)

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -62,28 +62,29 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //  ^ - comment.line
   animation: progress-fade-in-animation .15s ease-in
 //            ^ - meta.selector
+//            ^ constant.other
 //                   ^ - keyword.operator
 //                         ^ - keyword.operator
     background-color: color(var(--background, blue) blend(var(--foreground, change-color($var, $blue: 5)) 80%))
 //  ^^^^^^^^^^^^^^^^ support.type.property-name.css
 //                  ^ punctuation.separator.key-value.css
 //                    ^^^^^ support.function.color.css
-//                         ^ punctuation.definition.group.begin.css
+//                         ^ punctuation
 //                          ^^^ support.function.var.css
-//                             ^ punctuation.definition.group.begin.css
-//                              ^^^^^^^^^^^^ support.type.custom-property
+//                             ^ punctuation
+//                              ^^^^^^^^^^^^ variable.other.custom-property
 //                                          ^ punctuation.separator
-//                                                ^ punctuation.definition.group.end.css
+//                                                ^ punctuation
 //                                                  ^^^^^ support.function.color.css
-//                                                       ^ punctuation.definition.group.begin.css
+//                                                       ^ punctuation
 //                                                        ^^^ support.function.var.css
-//                                                           ^ punctuation.definition.group.begin.css
-//                                                            ^^^^^^^^^^^^ support.type.custom-property.css
+//                                                           ^ punctuation
+//                                                            ^^^^^^^^^^^^ variable.other.custom-property
 //                                                                                              ^ variable.other
 //                                                                                                  ^ punctuation.separator
-//                                                                                                      ^ punctuation.definition.group.end.css
+//                                                                                                      ^ punctuation
 //                                                                                                        ^^^ constant.numeric
-//                                                                                                           ^^ punctuation.definition.group.end.css
+//                                                                                                           ^^ punctuation
   @document url(http://www)
     background: url($blue)
     background-color: color($mark, custom-function(unthemed))

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -116,7 +116,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //       ^ punctuation.definition.variable.sass
 
   -ms-text-size-adjust: 100%;
-//^^^^^^^^^^^^^^^^^^^^ meta.property-name.css
+//    ^^^^^^^^^^^^^^^^ meta.property-name.css
 //^^^^ support.type.vendor-prefix.css
 
   .redbox:hover
@@ -124,61 +124,62 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
     color: #000000
 
   &
-//^^ meta.selector.css
+//^ meta.selector.css
 
   &:hover text-decoration: underline
 //^^^^^^^^ meta.selector.css
 //^ keyword.operator.ampersand.sass
-// ^ entity.other.pseudo-class.css punctuation.definition.entity.css
+// ^ punctuation
   main
     input:-webkit-autofill,
 //  ^^^^^ entity.name.tag
-//        ^^^^^^^^^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
+//                ^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
 //        ^^^^^^^^ support.type.vendor-prefix.css
-//       ^ punctuation.definition.entity.css
+//       ^ punctuation
     [type="submit"]:-moz-focusring,
-//                  ^^^^^^^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
+//                       ^^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
 //                  ^^^^^ support.type.vendor-prefix.css
     custom-input:-webkit-autofill:hover {}
 //  ^^^^^^^^^^^^ entity.name.tag
-//               ^^^^^^^^^^^^^^^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
+//                       ^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
+//                                ^^^^^ meta.selector.css entity.other.pseudo-class.css
 //               ^^^^^^^^ support.type.vendor-prefix.css
-//              ^ punctuation.definition.entity.css
-//                               ^ punctuation.definition.entity.css
+//              ^ punctuation
+//                               ^ punctuation
     -ms-text-size-adjust: 100%;
-//  ^^^^^^^^^^^^^^^^^^^^ meta.property-name.css
+//      ^^^^^^^^^^^^^^^^ meta.property-name.css
 //  ^^^^ support.type.vendor-prefix.css
 
   span:hover,
   +,
-//^ punctuation.separator.combinator
+//^ keyword.operator.combinator
   .test:first-child + &,
-//                  ^ punctuation.separator.combinator
+//                  ^ keyword.operator.combinator
 //                    ^ keyword.operator.ampersand
   .test:not(.class) &,
 //                  ^ keyword.operator.ampersand
 
   body.firefox ~ & font-weight: normal
 //^^^^^^^^^^^^^^^^^ meta.selector
-//             ^ punctuation.separator.combinator.css
+//             ^ keyword.operator.combinator.css
 //               ^ keyword.operator.ampersand.sass
   &:nth-child(even) a,
 //                  ^ entity.name.tag
   &-bemish
 //^ keyword.operator.ampersand.sass
 // ^^^^^^^ entity.other.attribute-name.css
-// ^^^^^^^^ meta.selector.css
+// ^^^^^^^ meta.selector.css
   &_bemish // test comment
 //^ keyword.operator.ampersand.sass
 // ^^^^^^^ entity.other.attribute-name.css
-// ^^^^^^^^ meta.selector.css
+// ^^^^^^^ meta.selector.css
 
 
 @media(max-width: $break-parent) // test comment
-// <- meta.at-rule.media.css keyword.control.at-rule.media.css punctuation.definition.keyword.css
+// <- meta.at-rule.media.css keyword.control.directive.css punctuation.definition.keyword.css
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
-//    ^ punctuation.definition.group.begin.css
-//     ^ support.type.property-name.media.css
+//    ^ punctuation.section.group.begin.css
+//     ^ support.type.property-name.css
 //              ^ punctuation.separator.key-value.css
 //                               ^ comment.line.double-slash
   will-change: transform, scroll-position
@@ -209,7 +210,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //  ^ meta.property-name.css support.type.property-name.css
 
     width: calc((100px - 20px) / 2)
-//              ^ punctuation.definition.group - string
+//              ^ punctuation.section.group - string
 
 
 
@@ -242,7 +243,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 @import url(foo)
 @import "rounded-corners", "text-shadow"
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.import
-//                       ^ punctuation.definition.arbitrary-repetition
+//                       ^ punctuation.separator.sequence
 #main
   @import "example"
 

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -20,7 +20,6 @@
 /*
 Sass indented syntax doesn't use { } or ;
 */
-
 div {
 //  ^ invalid.illegal.sass
   color: blue;
@@ -58,15 +57,15 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
   display: block
 // ^ meta.property-name.css support.type.property-name.css
 :root:hover
-// <- entity.other.pseudo-class.css punctuation.definition.entity.css
+// <- punctuation.definition
 // ^^ entity.other.pseudo-class.css
 #main h1+.sub:not(.class)
 //    ^^^^^^^^^^^^^^^^^^^ meta.selector.css
 //    ^^ entity.name.tag
 //     ^ - constant.numeric
 //      ^ keyword.operator.combinator.css
-//           ^ punctuation.definition.entity.css
-//               ^ punctuation.definition.group.begin
+//           ^ punctuation.definition
+//               ^ punctuation.section
 
   //color: #00ff00
 //  ^ comment.line

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -306,7 +306,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 @mixin firefox-message($selector: false)
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.sass
-// ^ keyword.control.at-rule.sass
+// ^ keyword.control.directive.sass
 //     ^^^^^^^^^^^^^^^ entity.name.function.sass
 //                    ^ meta.function.parameters.sass punctuation.definition.group.begin.sass
 //                     ^^ meta.function.parameters.sass variable.parameter.sass

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -257,7 +257,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
   */
   :import("path/to/dep.css")
   // ^^^^ entity.other.pseudo-class.css-modules.css
-  //     ^ punctuation.definition.group.begin.css
+  //     ^ punctuation.section.group.begin.css
   //      ^^^^ string
     localAlias: keyFromDep
 
@@ -283,9 +283,9 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
   .localA :global .global-b .global-c :local(.localD.localE::before) .global-d
   //      ^^^^^^^ entity.other.pseudo-class.css-modules
   //                                  ^^^^^^ entity.other.pseudo-class.css-modules
-  //                                        ^ meta.function-call.css meta.group.css punctuation.definition.group.begin.css
+  //                                        ^ meta.function-call.css meta.group.css punctuation.section.group.begin.css
   //                                         ^^^^^^^^^^^^^^^^^^^^^^ meta.selector
-  //                                                               ^ punctuation.definition.group.end.css
+  //                                                               ^ punctuation.section.group.end.css
   :global  // global blocks
   // ^^^^ entity.other.pseudo-class.css-modules
     .global-class-name
@@ -308,21 +308,21 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.sass
 // ^ keyword.control.directive.sass
 //     ^^^^^^^^^^^^^^^ entity.name.function.sass
-//                    ^ meta.function.parameters.sass punctuation.definition.group.begin.sass
+//                    ^ meta.function.parameters.sass punctuation.section.group.begin.sass
 //                     ^^ meta.function.parameters.sass variable.parameter.sass
 //                     ^ punctuation.definition.variable.sass
 //                                 ^ constant.language
-//                                     ^ meta.function.parameters.sass punctuation.definition.group.end.sass
+//                                     ^ meta.function.parameters.sass punctuation.section.group.end.sass
   #{$selector + "some string"}:not(.class),
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.interpolation.sass
 //^ punctuation.definition.variable.sass
-// ^ punctuation.definition.group.begin.sass
+// ^ punctuation.section.group.begin.sass
 //  ^^^^^^^^^ variable.other.sass
 //  ^ punctuation.definition.variable.sass
 //            ^ keyword.operator
 //              ^^^^^^^^^^^^^ string.quoted.double
-//                           ^ punctuation.definition.group.end.sass
+//                           ^ punctuation.section.group.end.sass
 //                            ^ punctuation.definition
 //                             ^ entity.other.pseudo-class.css
   &--#{$test}__123 a
@@ -333,10 +333,10 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
   body.firefox #{$selector}:before
 //             ^^^^^^^^^^^^ meta.group.interpolation.sass
 //             ^ punctuation.definition.variable.sass
-//              ^ punctuation.definition.group.begin.sass
+//              ^ punctuation.section.group.begin.sass
 //               ^^^^^^^^^ variable.other.sass
 //               ^ punctuation.definition.variable.sass
-//                        ^ punctuation.definition.group.end.sass
+//                        ^ punctuation.section.group.end.sass
 //                         ^ punctuation.definition
 //                          ^ entity.other.pseudo-element.css
 
@@ -362,11 +362,11 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //           ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
 //                  ^^^^^^^^^ meta.group.interpolation.sass
 //                  ^ punctuation.definition.variable.sass
-//                   ^ punctuation.definition.group.begin.sass
+//                   ^ punctuation.section.group.begin.sass
 //                    ^ constant.numeric.value.css
 //                      ^ keyword.operator.arithmetic.sass
 //                        ^ constant.numeric.value.css
-//                          ^ punctuation.definition.group.end.sass
+//                          ^ punctuation.section.group.end.sass
     transform: #{translate + $axis + '(' + $span * $aim + ')'}
 //                           ^^^^^ variable.other
 //                           ^ punctuation.definition.variable
@@ -382,10 +382,10 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
     #{$prop}: var(--#{$color}-primary, color(primary, unthemed))
 //  ^^^^^^^^ meta.group.interpolation.sass
 //  ^ punctuation.definition.variable.sass
-//   ^ punctuation.definition.group.begin.sass
+//   ^ punctuation.section.group.begin.sass
 //    ^^^^^ variable.other.sass
 //    ^ punctuation.definition.variable.sass
-//         ^ punctuation.definition.group.end.sass
+//         ^ punctuation.section.group.end.sass
 //          ^ punctuation.separator.key-value
     #{$prop}-color: blue
 //  ^^^^^^^^^^^^^^ meta.property-name
@@ -424,8 +424,8 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
 // ^^^^^^^^^^^^^ variable.function.sass
-//              ^ punctuation.definition.group.begin
-//                                                        ^ punctuation.definition.group.end
+//              ^ punctuation.section.group.begin
+//                                                        ^ punctuation.section.group.end
 //               ^^^^^^^^^ string.quoted.double.css
 //                         ^ keyword.operator.arithmetic.sass
 //                           ^ constant.other
@@ -492,7 +492,7 @@ $list: (top, bottom, right, position, height);
 //           ^^^ support.constant.property-value
 //                 ^ punctuation.separator.sequence.css
 //                   ^^^ support.constant.property-value
-//                          ^^^ string.unquoted
+//                          ^^^ meta.property-value
 //                                  ^ punctuation.separator.sequence.css
 
 @each $animal, $color, $cursor in (puma, black, default),(sea-slug, blue, pointer), (egret, white, move)
@@ -510,12 +510,12 @@ $list: (top, bottom, right, position, height);
   color: nth(map-merge($map, $map2), 3)
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.css meta.function-call.sass
 //       ^^^ support.function.sass
-//          ^ punctuation.definition.group.begin
+//          ^ punctuation.section.group.begin
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
 //           ^^^^^^^^^ support.function.sass
-//                    ^ punctuation.definition.group.begin
+//                    ^ punctuation.section.group.begin
 //                         ^ punctuation.separator.sequence.css
-//                                ^ punctuation.definition.group.end
+//                                ^ punctuation.section.group.end
 
 
 
@@ -614,8 +614,8 @@ $list: (top, bottom, right, position, height);
 //                                          ^^^^ constant
 //                                        ^ punctuation
 //                                              ^ punctuation
-//                                 ^ punctuation.definition.group.begin.sass
-//                                                                      ^ punctuation.definition.group.end.sass
+//                                 ^ punctuation.section.group.begin.sass
+//                                                                      ^ punctuation.section.group.end.sass
 
 
 
@@ -660,8 +660,8 @@ $translucent-red: rgba(255, 0, 0, 0.5)
 p
   color: opacify($translucent-red, 0.3)
 //       ^^^^^^^ support.function.sass
-//              ^ punctuation.definition.group.begin
-//                                    ^ punctuation.definition.group.end
+//              ^ punctuation.section.group.begin
+//                                    ^ punctuation.section.group.end
 
   background-color: transparentize($translucent-red, 0.25)
 //                  ^^^^^^^ support.function.sass
@@ -736,9 +736,9 @@ p
 //                    ^^^ keyword.other.color-space.css
   top: blend(hsl(219, 10%, 6%) 50%)
 //     ^^^^^ support.function.color.css
-//          ^ punctuation.definition.group.begin.css
+//          ^ punctuation.section.group.begin.css
 //           ^^^ support.function.color.css
-//              ^ punctuation.definition.group.begin.css
+//              ^ punctuation.section.group.begin.css
 //               ^^^ meta.number.integer.decimal.css constant.numeric.value.css
 //                  ^ punctuation.separator.sequence.css
 //                    ^^ meta.number.integer.decimal.css constant.numeric.value.css
@@ -746,10 +746,10 @@ p
 //                       ^ punctuation.separator.sequence.css
 //                         ^ meta.number.integer.decimal.css constant.numeric.value.css
 //                          ^ meta.number.integer.decimal.css constant.numeric.suffix.css
-//                           ^ punctuation.definition.group.end.css
+//                           ^ punctuation.section.group.end.css
 //                             ^^ meta.number.integer.decimal.css constant.numeric.value.css
 //                               ^ meta.number.integer.decimal.css constant.numeric.suffix.css
-//                                ^ punctuation.definition.group.end.css
+//                                ^ punctuation.section.group.end.css
   top: alpha(-1.5%)
 //     ^^^^^ support.function.color.css
 //           ^ invalid.illegal.operator.css
@@ -832,19 +832,19 @@ p
 //^^^^^^^^^^^^^^^^ support.type.property-name.css
 //                ^ punctuation.separator.key-value.css
 //                  ^^^^^ support.function.color.css
-//                       ^ punctuation.definition.group.begin.css
+//                       ^ punctuation.section.group.begin.css
 //                        ^^^ support.function.var.css
-//                           ^ punctuation.definition.group.begin.css
+//                           ^ punctuation.section.group.begin.css
 //                            ^^^^^^^^^^^^ support.type.custom-property
-//                                        ^ punctuation.definition.group.end.css
+//                                        ^ punctuation.section.group.end.css
 //                                          ^^^^^ support.function.color.css
-//                                               ^ punctuation.definition.group.begin.css
+//                                               ^ punctuation.section.group.begin.css
 //                                                ^^^ support.function.var.css
-//                                                   ^ punctuation.definition.group.begin.css
+//                                                   ^ punctuation.section.group.begin.css
 //                                                    ^^^^^^^^^^^^ support.type.custom-property.css
-//                                                                ^ punctuation.definition.group.end.css
+//                                                                ^ punctuation.section.group.end.css
 //                                                                  ^^^ constant.numeric
-//                                                                     ^^ punctuation.definition.group.end.css
+//                                                                     ^^ punctuation.section.group.end.css
 
     grid: [linename1] "a" 100px [linename2]
 //  ^^^^ meta.property-name.css

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -33,17 +33,6 @@ div {
 
 
 /*
-  Property syntax with the colon before the property name
-*/
-#main
-  :font-family sans
-  :color blue
-  :font-size 0.3em
-  // ^ support.type.property-name.css
-  // ^ - meta.selector
-  //   ^ - keyword.operator
-
-/*
   Nested selectors and &
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_rules
   Variables and !global etc

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -1,10 +1,3 @@
-// SYNTAX TEST "Packages/Sass/Syntaxes/Sass.sublime-syntax"
----
-# this ensures Jekyll reads the file to be transformed into CSS later
----
-//^ frontmatter.jekyll punctuation.section.frontmatter.end.jekyll
-
-
 // https://sass-lang.com/documentation/file.INDENTED_SYNTAX.html
 
 // This comment will not appear in the CSS output.

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -362,6 +362,8 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //                      ^ keyword.operator.arithmetic.sass
 //                        ^ constant.numeric.value.css
 //                          ^ punctuation.section.group.end.sass
+    padding: calc(#{spacer/2 - 5px})
+//                ^^^^^^^^^^^^^^^^^ meta.group.interpolation
     transform: #{translate + $axis + '(' + $span * $aim + ')'}
 //                           ^^^^^ variable.other
 //                           ^ punctuation.definition.variable

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -75,7 +75,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //                              ^^^^^^^^^^^^ variable.other.custom-property
 //                                          ^ punctuation.separator
 //                                                ^ punctuation
-//                                                  ^^^^^ support.function.color.css
+//                                                  ^^^^^ support.function
 //                                                       ^ punctuation
 //                                                        ^^^ support.function.var.css
 //                                                           ^ punctuation

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -193,7 +193,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //  ^ meta.property-name.css support.type.property-name.css
 
     family: fantasy
-//                ^ meta.property-value.css support.constant.font-name.css
+//                ^ meta.property-value.css support.constant
 //  ^ meta.property-name.css support.type.property-name.css
 
     size: 1rem*$ratio
@@ -203,7 +203,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //  ^ meta.property-name.css support.type.property-name.css
 
   font: 20px/24px fantasy
-//                ^ meta.property-value.css support.constant.font-name.css
+//                ^ meta.property-value.css support.constant
 //  ^ meta.property-name.css support.type.property-name.css
 
     weight: bold
@@ -323,7 +323,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //            ^ keyword.operator
 //              ^^^^^^^^^^^^^ string.quoted.double
 //                           ^ punctuation.definition.group.end.sass
-//                            ^ punctuation.definition.entity.css
+//                            ^ punctuation.definition
 //                             ^ entity.other.pseudo-class.css
   &--#{$test}__123 a
 //^^^^^^^^^^^^^^^^^^ meta.selector
@@ -337,7 +337,7 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //               ^^^^^^^^^ variable.other.sass
 //               ^ punctuation.definition.variable.sass
 //                        ^ punctuation.definition.group.end.sass
-//                         ^ punctuation.definition.entity.css
+//                         ^ punctuation.definition
 //                          ^ entity.other.pseudo-element.css
 
     content: "Hi, Firefox users!"

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -567,36 +567,36 @@ $list: (top, bottom, right, position, height);
 @use 'something else' as *
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^ keyword.control.at-rule.module.sass
+// ^ keyword.control
 //    ^^^^^^^^^^^^^^ string.quoted
 //                    ^^ keyword.control
 //                       ^ constant.language.import-all
 @use "src/corners"
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^ keyword.control.at-rule.module.sass
+// ^ keyword.control
 //    ^^^^^^^^^^^^ string.quoted
 @use /*import bootstrap*/ "bootstrap" as b
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
 //                                    ^^ keyword.control
-// ^ keyword.control.at-rule.module.sass
+// ^ keyword.control
 //                ^ comment
 @forward "functions"
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^^^^^ keyword.control.at-rule.module.sass
+// ^^^^^ keyword.control
 //       ^^^^^^^^^^^ string.quoted
 @forward "functions" show color-yiq
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^ keyword.control.at-rule.module.sass
+// ^ keyword.control
 //                   ^^^^ keyword.control
 //                        ^^^^^^^^^ meta.generic-name.sass
 @forward "functions" hide assert-ascending, $some_variable
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^ keyword.control.at-rule.module.sass
+// ^ keyword.control
 //                   ^^^^ keyword.control
 //                        ^^^^^^^^^^^^^^^ meta.generic-name.sass
 //                                        ^ punctuation.separator.sequence.css
@@ -698,28 +698,28 @@ p
 //                 ^^^          constant.numeric
 //                    ^         punctuation.separator.sequence.css
 //                      ^^      constant.numeric
-//                          ^^^ support.function.color.css
+//                          ^^^ support.function
 
   top: color(w(var()) s(var()))
 //     ^^^^^       support.function.color.css
-//           ^     support.function.color.css
+//           ^     support.function
 //             ^^^ support.function.var.css
-//                    ^ support.function.color.css
+//                    ^ support.function
 //                      ^^^ support.function.var.css
 
   top: alpha(- 1.5%)
 //     ^^^^^        support.function.color.css
-//           ^      keyword.operator.arithmetic.css
+//           ^      keyword.operator.arithmetic
 //             ^^^^ constant.numeric
 
   top: h(+ 1.5deg)
 //     ^          support.function.color.css
-//       ^        keyword.operator.arithmetic.css
+//       ^        keyword.operator.arithmetic
 //         ^^^^^^ constant.numeric
 
   top: w(* 1.5%)
 //     ^        support.function.color.css
-//       ^      keyword.operator.arithmetic.css
+//       ^      keyword.operator.arithmetic
 //         ^^^^ constant.numeric
 
   top: shade(1.5%)
@@ -731,13 +731,13 @@ p
 
   top: blenda(red 50% hsl)
 //     ^^^^^^             support.function.color.css
-//            ^^^         support.constant.color.w3c-standard-color-name.css
+//            ^^^         support.constant.color
 //                ^^^     constant.numeric
 //                    ^^^ keyword.other.color-space.css
   top: blend(hsl(219, 10%, 6%) 50%)
 //     ^^^^^ support.function.color.css
 //          ^ punctuation.section.group.begin.css
-//           ^^^ support.function.color.css
+//           ^^^ support.function
 //              ^ punctuation.section.group.begin.css
 //               ^^^ meta.number.integer.decimal.css constant.numeric.value.css
 //                  ^ punctuation.separator.sequence.css
@@ -752,12 +752,11 @@ p
 //                                ^ punctuation.section.group.end.css
   top: alpha(-1.5%)
 //     ^^^^^ support.function.color.css
-//           ^ invalid.illegal.operator.css
 //            ^^^ meta.number.float.decimal.css constant.numeric.value.css
 //               ^ meta.number.float.decimal.css constant.numeric.suffix.css
 
   top: calc(+1px+1px)
-//          ^ keyword.operator.arithmetic.css
+//          ^ keyword.operator.arithmetic
 //              ^ invalid.illegal.operator.css
   top: calc(1px+ 1px)
 //             ^ invalid.illegal.operator.
@@ -768,14 +767,14 @@ p
   top: calc((1px)+ 1px)
 //               ^ invalid.illegal.operator.css
   top: calc(+1px+(+1px)+1px)
-//          ^ keyword.operator.arithmetic.css
-//              ^ keyword.operator.arithmetic.css
-//                ^ keyword.operator.arithmetic.css
+//          ^ keyword.operator.arithmetic
+//              ^ keyword.operator.arithmetic
+//                ^ keyword.operator.arithmetic
 //                     ^ invalid.illegal.operator.css
   top: calc(1px / 1px)
-//              ^ keyword.operator.arithmetic.css
+//              ^ keyword.operator.arithmetic
   top: calc(-1px-1px)
-//          ^ keyword.operator.arithmetic.css
+//          ^ keyword.operator.arithmetic
 //              ^ invalid.illegal.operator.css
   top: calc(1px- 1px)
 //             ^ invalid.illegal.operator.css
@@ -786,20 +785,20 @@ p
   top: calc((1px)- 1px)
 //               ^ invalid.illegal.operator.css
   top: calc(-1px-(-1px)-1px)
-//          ^ keyword.operator.arithmetic.css
-//              ^ keyword.operator.arithmetic.css
-//                ^ keyword.operator.arithmetic.css
+//          ^ keyword.operator.arithmetic
+//              ^ keyword.operator.arithmetic
+//                ^ keyword.operator.arithmetic
 //                     ^ invalid.illegal.operator.css
   top: clamp(1*5pt, calc(12/5), 100rem)
 //     ^^^^^ support.function.calc.css
 //           ^ constant.numeric.value.css
-//            ^ keyword.operator.arithmetic.css
+//            ^ keyword.operator.arithmetic
 //             ^ constant.numeric.value.css
 //              ^^ constant.numeric.suffix.css
 //                ^ punctuation.separator.sequence.css
 //                  ^^^^ support.function.calc.css
 //                       ^^ constant.numeric.value.css
-//                         ^ keyword.operator.arithmetic.css
+//                         ^ keyword.operator.arithmetic
 //                          ^ constant.numeric.value.css
 //                            ^ punctuation.separator.sequence.css
 //                              ^^^ constant.numeric.value.css
@@ -808,17 +807,17 @@ p
    top: max(5*6, min(10 + 5, calc(var(--size) / 5)))
 //      ^^^ support.function.calc.css
 //          ^ constant.numeric.value.css
-//           ^ keyword.operator.arithmetic.css
+//           ^ keyword.operator.arithmetic
 //            ^ constant.numeric.value.css
 //             ^ punctuation.separator.sequence.css
 //               ^^^ support.function.calc.css
 //                   ^^ constant.numeric.value.css
-//                      ^ keyword.operator.arithmetic.css
+//                      ^ keyword.operator.arithmetic
 //                        ^ constant.numeric.value.css
 //                         ^ punctuation.separator.sequence.css
 //                           ^^^^ support.function.calc.css
 //                                ^^^ support.function.var.css
-//                                            ^ keyword.operator.arithmetic.css
+//                                            ^ keyword.operator.arithmetic
 //                                              ^ constant.numeric.value.css
 
   top: conic-gradient(from 0.25turn at 50% 30%, #f69d3c, 10deg, #3f87a6, 350deg, #ebf8e1)
@@ -835,13 +834,13 @@ p
 //                       ^ punctuation.section.group.begin.css
 //                        ^^^ support.function.var.css
 //                           ^ punctuation.section.group.begin.css
-//                            ^^^^^^^^^^^^ support.type.custom-property
+//                            ^^^^^^^^^^^^ variable.other.custom-property
 //                                        ^ punctuation.section.group.end.css
-//                                          ^^^^^ support.function.color.css
+//                                          ^^^^^ support.function
 //                                               ^ punctuation.section.group.begin.css
 //                                                ^^^ support.function.var.css
 //                                                   ^ punctuation.section.group.begin.css
-//                                                    ^^^^^^^^^^^^ support.type.custom-property.css
+//                                                    ^^^^^^^^^^^^ variable.other.custom-property.css
 //                                                                ^ punctuation.section.group.end.css
 //                                                                  ^^^ constant.numeric
 //                                                                     ^^ punctuation.section.group.end.css
@@ -851,25 +850,25 @@ p
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.css
 //  ^^^^ support.type.property-name.css
 //      ^ punctuation.separator.key-value.css
-//        ^ punctuation.section.begin.css
+//        ^ punctuation.section.brackets.begin.css
 //         ^^^^^^^^^ string.unquoted.line-name.css
-//                  ^ punctuation.section.end.css
+//                  ^ punctuation.section.brackets.end.css
 //                    ^^^ string.quoted.double.css
 //                        ^^^^^ meta.number.integer.decimal.css
-//                              ^ punctuation.section.begin.css
+//                              ^ punctuation.section.brackets.begin.css
 //                               ^^^^^^^^^ string.unquoted.line-name.css
-//                                        ^ punctuation.section.end.css
+//                                        ^ punctuation.section.brackets.end.css
 
 .test-pseudo-class-tag:not(*)
-//                    ^ punctuation.definition.entity.css
+//                    ^ punctuation.definition
 //                     ^^^ entity.other.pseudo-class.css
-//                         ^ entity.name.tag.wildcard.css
+//                         ^ variable.language.wildcard
 .test-pseudo-class-tag:is(*)
-//                    ^ punctuation.definition.entity.css
+//                    ^ punctuation.definition
 //                     ^^ entity.other.pseudo-class.css
-//                        ^ entity.name.tag.wildcard.css
+//                        ^ variable.language.wildcard
 
  .test-pseudo-class-tag:where(*)
-//                     ^ punctuation.definition.entity.css
+//                     ^ punctuation.definition
 //                      ^^^^^ entity.other.pseudo-class.css
-//                            ^ entity.name.tag.wildcard.css
+//                            ^ variable.language.wildcard

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -469,10 +469,6 @@ h1
 //                           ^^^ constant.numeric
 //                            ^^ constant.numeric.suffix
 
-
-@function grid-width($n)
-  @return $n * $grid-width + ($n - 1) * $gutter-width
-
 #sidebar
   width: grid-width(5)
 
@@ -550,15 +546,8 @@ $list: (top, bottom, right, position, height);
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives
 */
 @function size($size, $base: $base-font-size, $unit: null)
-  @return if (
-    $unit == 'px',
-    strip($size) * strip($base),
-//  ^ meta.function-call
-//                 ^ meta.function-call
-    strip($size) / strip($base) + 0.00001
-//  ^ meta.function-call
-  )
-
+@function grid-width($n)
+  @return $n * $grid-width + ($n - 1) * $gutter-width
 
 /*
   Module system

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -397,11 +397,11 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 //            ^ - meta.group.interpolation
 
 @keyframes beat, bounce
-//  ^^^^^^^^^^^^^^^^^^^ meta.at-rule.keyframe.css
+//  ^^^^^^^^^^^^^^^^^^^ meta.at-rule.keyframe
+//  ^^^^^^              keyword.control.directive
 // <-                       punctuation.definition.keyword.css
-//   ^^^^^              keyword.control.at-rule.keyframe.css
 //         ^^^^         entity.other.animation-name.css
-//             ^        punctuation.definition.arbitrary-repetition.css
+//             ^        punctuation.separator.sequence
 //               ^^^^^^ entity.other.animation-name.css
 
 @keyframes #{$animation + '-' + $direction}

--- a/Tests/syntax_test_sass.sass
+++ b/Tests/syntax_test_sass.sass
@@ -28,6 +28,11 @@ div {
 }
 // <- invalid.illegal.sass
 
+.test-strings
+    content: "double"
+    color: blue
+
+
 /*
   Property syntax with the colon before the property name
 */
@@ -46,7 +51,7 @@ div {
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#variables_
 */
 [data-type="text"]:hover,
-//                ^^^^^^ entity.other.pseudo-class.css
+//                 ^^^^^ entity.other.pseudo-class.css
 input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select, textarea
 //                                    ^^^^^^^^^^^^^^ entity.name.tag.custom.css
 //                                                        ^^^^^^^^^^^^ entity.other.attribute-name.placeholder.sass
@@ -57,9 +62,9 @@ input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder), select,
 // ^^ entity.other.pseudo-class.css
 #main h1+.sub:not(.class)
 //    ^^^^^^^^^^^^^^^^^^^ meta.selector.css
-//    ^^ entity.name.tag.css
+//    ^^ entity.name.tag
 //     ^ - constant.numeric
-//      ^ punctuation.separator.combinator.css
+//      ^ keyword.operator.combinator.css
 //           ^ punctuation.definition.entity.css
 //               ^ punctuation.definition.group.begin
 

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -56,14 +56,14 @@ selector-ish::before[data-type="text"]:not(:first-child),
   color: rgba(100, #aaa, 12deg, 95%);
   background: url($blue);
   testbackground-color: blue;
-//
+/*
 
 *
     *
 /*  ^ comment.block.css punctuation.definition.comment.css */
 //
 
-
+/*
   CSS grids
 */
   grid-template-columns:
@@ -77,8 +77,7 @@ selector-ish::before[data-type="text"]:not(:first-child),
                          repeat(auto-fit, [linename3 first nav-start] 300px)
                          100px;
 }
-//
-
+/*
   Var function arguments
 */
 .test {
@@ -88,8 +87,8 @@ selector-ish::before[data-type="text"]:not(:first-child),
   content: translateX(calc(var(--progress)));
   content: fn(height-$width);
 }
-//
 
+/*
   Nested selectors and &
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_rules
   Variables and !global etc
@@ -232,9 +231,9 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //                  ^ punctuation.definition.entity.css
 }
 // <- punctuation.section.property-list.end.css
-//
 
 
+/*
   Nested properties
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#nested_properties
 */
@@ -260,9 +259,9 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //              ^ punctuation.section.group - string
   }
 }
-//
 
 
+/*
 Support property values after a line break?
 */
 .grid {
@@ -295,9 +294,9 @@ color: format(
 @import "imports/somefile.sass"; // this should be a comment
 //                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash
 //                               ^^ punctuation.definition.comment
-//
 
 
+/*
   Import Statements
   http://sass-lang.com/documentation/file.SASS_REFERENCE.html#import
 */
@@ -318,8 +317,8 @@ color: format(
 #main {
   @import "example";
 }
-//
 
+/*
  CSS Modules
 
    Interoperable CSS: https://github.com/css-modules/icss#specification
@@ -351,8 +350,9 @@ color: format(
 //             ^^^^^^^^^^ string
 //                          ^ punctuation
 }
-/* CSS Modules
-   Composing selectors: https://github.com/css-modules/css-modules#css-modules
+/*
+  CSS Modules
+  Composing selectors: https://github.com/css-modules/css-modules#css-modules
 */
 .otherClassName {
   composes: className from "./style.css";  // from filename
@@ -363,8 +363,9 @@ color: format(
 //                          ^^^^ keyword.operator
 //                                     ^ punctuation
 }
-/* CSS Modules
-   Global vs. local scope: https://github.com/css-modules/css-modules#exceptions
+/*
+  CSS Modules
+  Global vs. local scope: https://github.com/css-modules/css-modules#exceptions
 */
 .localA :global .global-b .global-c :local(.localD.localE::before) .global-d
 //      ^^^^^^^ entity.other.pseudo-class.css-modules
@@ -384,9 +385,9 @@ color: format(
     color: green;
   }
 }
-//
 
 
+/*
   Strings, (un)quoted, operations and interpolation
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#sass-script-strings
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#interpolation_
@@ -534,10 +535,9 @@ color: format(
  test // this should also be a comment
    );
 // ^ punctuation.section.group.end.sass
-//
 
 
-
+/*
   Mixin Directives
   http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixins
   http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixin-arguments
@@ -575,8 +575,8 @@ h1 { @include sexy-border(blue, 2in); }
 //                              ^^^ constant.numeric
 //                               ^^ constant.numeric.suffix
 //                                  ^ punctuation.terminator.rule
-//
 
+/*
   Function Directives
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives
 */
@@ -602,9 +602,9 @@ h1 { @include sexy-border(blue, 2in); }
 //  ^ meta.function-call
   );
 }
-//
 
 
+/*
   Lists, Maps
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#maps
 */
@@ -747,9 +747,8 @@ $gutter-width: 10px;
 #sidebar { width: grid-width(5); }
 //                ^^^^^^^^^^^^^ meta.property-value.css meta.function-call.css
 //                ^^^^^^^^^^ support.function
-//
 
-
+/*
   Module system
   https://sass-lang.com/blog/the-module-system-is-launched
 */
@@ -842,9 +841,9 @@ $gutter-width: 10px;
 //                      ^ punctuation
 //                              ^ punctuation
 }
-//
 
 
+/*
   More @ features
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#if
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#debug
@@ -896,8 +895,8 @@ $gutter-width: 10px;
   @at-root (without: media) {
     color: red;
   }
-//
 
+/*
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#the_optional_flag
 */
   @extend .error !optional;
@@ -1185,7 +1184,7 @@ $gutter-width: 10px;
 //      ^^^^^ comment.block.css
 }
 
-    @supports not ( and ( top: 2px ) ) { }
+    @supports not ( and ( top: 2px ) ) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.supports.css
 //  ^ punctuation.definition.keyword.css
 //   ^^^^^^^^ keyword.control.at-rule.supports.css

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -372,7 +372,7 @@ color: format(
 .localA :global .global-b .global-c :local(.localD.localE::before) .global-d
 //      ^^^^^^^ entity.other.pseudo-class.css-modules
 //                                  ^^^^^^ entity.other.pseudo-class.css-modules
-//                                        ^ meta.function-callmeta.group.css punctuation.section.group.begin.css
+//                                        ^ meta.group.css punctuation.section.group.begin.css
 //                                         ^^^^^^^^^^^^^^^^^^^^^^ meta.selector
 //                                                               ^ punctuation.section.group.end.css
 :global {  // global blocks
@@ -528,7 +528,7 @@ color: format(
   ".header", /*a comment*/
  test // this should also be a comment
    );
-// ^ punctuation.section.group.end.sass
+// ^ punctuation.section.group.end
 
 
 /*

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -1,9 +1,3 @@
-// SYNTAX TEST "Packages/Sass/Syntaxes/SCSS.sublime-syntax"
----
-# this ensures Jekyll reads the file to be transformed into CSS later
----
-//^ frontmatter.jekyll punctuation.section.frontmatter.end.jekyll
-
 /*
 Correctly differentiate between properties and selectors,
 especially with pseudo-stuff because of the :

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -60,7 +60,7 @@ selector-ish::before[data-type="text"]:not(:first-child),
 
 *
     *
-/*  ^ comment.block.css punctuation.definition.comment.css */
+/*  ^ comment.block.css punctuation.definition.comment.
 //
 
 /*
@@ -99,17 +99,17 @@ selector-ish::before[data-type="text"]:not(:first-child),
 */
 *,
 :root,
-// <- entity.other.pseudo-class.css punctuation.definition.entity.css
+// <- punctuation.definition.pseudo-class.css
 // ^^ entity.other.pseudo-class.css
 ::before, :hover,
 #main h1+.sub:not(.class) {
-//    ^^^^^^^^^^^^^^^^^^^^ meta.selector.css
-//    ^^ entity.name.tag.css
+//    ^^^^^^^^^^^^^^^^^^^ meta.selector.css
+//    ^^ entity.name.tag
 //     ^ - constant.numeric
 //      ^ keyword.operator.combinator.css
-//           ^ punctuation.definition.entity.css
+//           ^ punctuation.definition
 //               ^ punctuation.section.group.begin
-//                        ^ punctuation.section.property-list.begin
+//                        ^ punctuation
   color: #00ff00;
   height: 97%;
   align-self : baseline;
@@ -145,7 +145,7 @@ selector-ish::before[data-type="text"]:not(:first-child),
   input:not([type="radio"]):not(h1):not(custom-element):not(%placeholder),
 //                                       ^ entity.name
   :root,
-//^ entity.other.pseudo-class.css punctuation.definition.entity.css
+//^ punctuation.definition
 // ^^ entity.other.pseudo-class.css
   ::before, :hover,
   &:nth-child(even) a,
@@ -161,18 +161,19 @@ selector-ish::before[data-type="text"]:not(:first-child),
   main {
     input:-webkit-autofill,
 //  ^^^^^ entity.name.tag
-//        ^^^^^^^^^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
 //        ^^^^^^^^ support.type.vendor-prefix.css
-//       ^ punctuation.definition.entity.css
+//                ^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
+//       ^ punctuation.definition
     custom-input:-webkit-autofill:hover {}
 //  ^^^^^^^^^^^^ entity.name.tag
-//               ^^^^^^^^^^^^^^^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
+//                       ^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
+//                                ^^^^^ meta.selector.css entity.other.pseudo-class.css
 //               ^^^^^^^^ support.type.vendor-prefix.css
-//              ^ punctuation.definition.entity.css
-//                               ^ punctuation.definition.entity.css
+//              ^ punctuation.definition
+//                               ^ punctuation.definition
 
 [type="submit"]:-moz-focusring {}
-//              ^^^^^^^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
+//                   ^^^^^^^^^ meta.selector.css entity.other.pseudo-class.css
 //              ^^^^^ support.type.vendor-prefix.css
 
     -ms-text-size-adjust: 100%;
@@ -180,21 +181,22 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //  ^^^^ support.type.vendor-prefix.css
   }
   span:hover { }
-// ^^^ entity.name.tag.css
+// ^^^ entity.name.tag
 
 
   & {}
-//^^ meta.selector.css
+//^ meta.selector.css
   &:hover { text-decoration: underline; }
-//^^^^^^^^ meta.selector.css
+//^^^^^^^ meta.selector.css
 //^ keyword.operator.ampersand.sass
-// ^ entity.other.pseudo-class.css punctuation.definition.entity.css
+// ^ punctuation.definition
+//  ^ entity.other.pseudo-class.css
   &:not(:first-child, :last-child) { text-decoration: underline; }
-//      ^^^^^^^^^^^^ entity.other.pseudo-class.css
-//      ^ punctuation.definition.entity.css
-//                  ^ punctuation.separator.css
-//                    ^^^^^^^^^^^ entity.other.pseudo-class.css
+//      ^ punctuation.definition
+//       ^^^^^^^^^^^ entity.other.pseudo-class.css
+//                  ^ punctuation.separator.sequence
 //                    ^ punctuation.definition
+//                     ^^^^^^^^^^ entity.other.pseudo-class.css
   +,
 //^ keyword.operator.combinator
   .test:first-child + & {}
@@ -207,7 +209,7 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //            ^^^ entity.other.pseudo-class.css
 //                ^^^^^^^ entity.other.attribute-name.class.css
   body.firefox ~ & { font-weight: normal; }
-//^^^^^^^^^^^^^^^^^ meta.selector
+//^^^^^^^^^^^^^^^^ meta.selector
 //             ^ keyword.operator.combinator.css
 //               ^ keyword.operator.ampersand.sass
   &-bemish {  }
@@ -222,15 +224,15 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //     ^ meta.selector.css
   [data-type="text"]:hover,
 //^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector
-//                  ^^^^^^ entity.other.pseudo-class.css
-//                  ^ punctuation.definition.entity.css
-//                        ^ punctuation.separator.css
+//                  ^ punctuation.definition
+//                   ^^^^^ entity.other.pseudo-class.css
+//                        ^ punctuation.separator.sequence
   [data-type="text"]:active {}
-//^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector
-//                  ^^^^^^^ entity.other.pseudo-class.css
-//                  ^ punctuation.definition.entity.css
+//^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector
+//                  ^ punctuation.definition
+//                   ^^^^^^ entity.other.pseudo-class.css
 }
-// <- punctuation.section.property-list.end.css
+// <- punctuation.section.block.end.css
 
 
 /*
@@ -284,12 +286,12 @@ color: format(
   block comment contains #{ $variable }
   block comment contains #{ function($variable) + "escap\e" + -.5em }
 */
-// <- comment.block.css punctuation.definition.comment.css
+// <- comment.block.css punctuation.definition.comment
 
 // line comment
 // line comment contains #{ $variable }
 // line comment contains #{ function($variable) + "escap\e" + -.5em }
-// <- comment.line.double-slash.sass punctuation.definition.comment.css
+// <- comment.line.double-slash.sass punctuation.definition.comment
 
 @import "imports/somefile.sass"; // this should be a comment
 //                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash
@@ -331,7 +333,7 @@ color: format(
 //     ^ punctuation.section.group.begin.css
 //      ^^^^ string
 //                       ^ punctuation.section.group.end.css
-//                         ^ punctuation.section.property-list.begin.css
+//                         ^ punctuation.section.block.begin.css
   localAlias: keyFromDep;
 // ^^^^^^^^^ meta.property-name.css-modules.css
 //            ^^^^^^^^^^ string
@@ -370,17 +372,17 @@ color: format(
 .localA :global .global-b .global-c :local(.localD.localE::before) .global-d
 //      ^^^^^^^ entity.other.pseudo-class.css-modules
 //                                  ^^^^^^ entity.other.pseudo-class.css-modules
-//                                        ^ meta.function-call.css meta.group.css punctuation.section.group.begin.css
+//                                        ^ meta.function-callmeta.group.css punctuation.section.group.begin.css
 //                                         ^^^^^^^^^^^^^^^^^^^^^^ meta.selector
 //                                                               ^ punctuation.section.group.end.css
 :global {  // global blocks
-// ^^^^ entity.other.pseudo-class.css-modules
+// ^^^^ entity.other.pseudo-class
   .global-class-name {
     color: green;
   }
 }
 :local {  // local blocks
-// ^^^ entity.other.pseudo-class.css-modules
+// ^^^ entity.other.pseudo-class
   .global-class-name {
     color: green;
   }
@@ -397,7 +399,6 @@ color: format(
 @mixin firefox-message($selector) {
 // <- meta.function.declaration.sass punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.sass
-// ^ keyword.control.at-rule.sass
 //     ^^^^^^^^^^^^^^^ entity.name.function.sass
 //                    ^ meta.function.parameters.sass punctuation.section.group.begin.sass
 //                              ^ meta.function.parameters.sass punctuation.section.group.end.sass
@@ -413,7 +414,7 @@ color: format(
 //            ^ keyword.operator
 //              ^^^^^^^^^^^^^ string.quoted.double
 //                           ^ punctuation.section.group.end.sass
-//                            ^ punctuation.definition.entity.css
+//                            ^ punctuation.definition
 //                             ^ entity.other.pseudo-class.css
   body.firefox #{$selector} + a:hover,
   body.firefox #{$selector} :active,
@@ -424,7 +425,7 @@ color: format(
 //               ^^^^^^^^^ variable.other.sass
 //               ^ punctuation.definition.variable.sass
 //                        ^ punctuation.section.group.end.sass
-//                         ^ punctuation.definition.entity.css
+//                         ^ punctuation.definition
 //                          ^ entity.other.pseudo-element.css
 
     content: "Hi, Firefox users!";
@@ -439,25 +440,19 @@ color: format(
 //                  ^^^^^ string.unquoted.css
   }
   p::before; {
-    cursor: e + -resize;
-//          ^ string.unquoted
-//           ^ - string
-//            ^ keyword.operator.sass
-//             ^ - string
-//              ^^^^^ string.unquoted
     content: "Foo " + Bar;
 //               ^ string.quoted.double
-//                    ^ string.unquoted
+//                    ^ constant.other
 //                       ^ - string
-//                  ^ keyword.operator.sass
+//                  ^ keyword.operator
     font-family: sans- + "serif";
 //               ^^^^^ string.unquoted
 //                              ^ - string
-//                     ^ keyword.operator.sass
+//                     ^ keyword.operator
     content: "I ate #{5 + 10} pies!";
 //           ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
 //                  ^^^^^^^^^ meta.group.interpolation.sass
-//                  ^ punctuation.section.variable.sass
+//                  ^ punctuation.definition.variable.sass
 //                   ^ punctuation.section.group.begin.sass
 //                    ^ constant.numeric.value.css
 //                      ^ keyword.operator.arithmetic.sass
@@ -479,8 +474,7 @@ color: format(
 //                  ^^^^^^^^^^^^ meta.function-call.arguments.sass
 //                  ^ punctuation.section.group.begin.sass
 //                             ^ punctuation.section.group.end.sass
-//                   ^^^^^^^^^^ string.unquoted.css
-//                   ^ string.unquoted
+//                   ^^^^^^^^^^ constant.other
 //                             ^ - string
     @include breathe(border-bottom-color);
 //           ^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
@@ -514,7 +508,7 @@ color: format(
   }
   &--#{$test}__123 a {}
 //^^^^^^^^^^^^^^^^^^ meta.selector
-//                   ^ punctuation.section.property-list.begin.css
+//                   ^ punctuation.section.block.begin.css
 }
 
 @include firefox-message(".header" + test);
@@ -524,11 +518,11 @@ color: format(
 //           ^^^^^^^ variable.function.sass
 //                       ^^^^^^^^^ meta.function-call.arguments.sass string.quoted.double.css
 //                                 ^ keyword.operator.arithmetic.sass
-//                                   ^ string.unquoted
+//                                   ^ constant.other
 //                                       ^ - string
 
 @include firefox-message(
-//           ^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
+//   ^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
 //           ^^^^^^^ variable.function.sass
 //                      ^ punctuation.section.group.begin.sass
   ".header", /*a comment*/
@@ -556,7 +550,7 @@ color: format(
 //                                        ^^^ constant.numeric
 //                                         ^^ constant.numeric.suffix
     @content;
-//  ^^^^^^^^ keyword.control.directive.content
+//  ^^^^^^^^ keyword.control.at-rule.content
 //  ^ punctuation.definition.keyword
 //          ^ punctuation.terminator.rule
 
@@ -625,7 +619,7 @@ $list: (top, bottom, right, position, height);
 //           ^^^ support.constant.property-value
 //                 ^ punctuation.separator.sequence.css
 //                   ^^^ support.constant.property-value
-//                          ^^^ string.unquoted
+//                          ^^^ constant.other
 //                                  ^ punctuation.separator.sequence.css
 @each $animal, $color, $cursor in (puma, black, default),
                                   (sea-slug, blue, pointer),
@@ -736,7 +730,7 @@ $gutter-width: 10px;
 //                               ^ keyword.operator.arithmetic.sass
 //                                    ^ keyword.operator.arithmetic.sass
   @return url("/images/#{$animal}.png");
-//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.css
+//        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 //            ^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.css
 //        ^^^ support.function.url.css
 //                     ^ punctuation.definition.variable.sass
@@ -745,7 +739,7 @@ $gutter-width: 10px;
   @return map.get(nth(map.get($config, 'radius'), 2), $namespace);
 }
 #sidebar { width: grid-width(5); }
-//                ^^^^^^^^^^^^^ meta.property-value.css meta.function-call.css
+//                ^^^^^^^^^^^^^ meta.property-value.css meta.function-call
 //                ^^^^^^^^^^ support.function
 
 /*
@@ -981,15 +975,15 @@ $gutter-width: 10px;
 
     .classname {}
 //  ^^^^^^^^^^^ meta.selector.css
-//  ^          punctuation.definition.entity.css
+//  ^          punctuation.definition
 //   ^^^^^^^^^ entity.other.attribute-name.class.css
 
     #id {}
-//  ^   punctuation.definition.entity.css
+//  ^   punctuation.definition
 //   ^^ entity.other.attribute-name.id.css
 
     html {}
-//  ^^^^ entity.name.tag.css
+//  ^^^^ entity.name.tag
 
     @charset "UTF-8";
 //  ^^^^^^^^^^^^^^^^ meta.at-rule.css
@@ -1011,7 +1005,7 @@ $gutter-width: 10px;
     @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"); /* only needed once */
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.namespace.css
 //             ^^^ support.function.url.css
-//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.css
+//             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 //                ^ meta.group.css punctuation.section.group.begin.css
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.css string.quoted.double.css
 //                                                                                ^ meta.group.css punctuation.section.group.end.css
@@ -1362,22 +1356,22 @@ $gutter-width: 10px;
 
 // Test Functional Pseudo Class Meta Scopes
 .test:nth-child(even) div .class {}
-//   ^^^^^^^^^^^^^^^^ meta.function-call.css
+//   ^^^^^^^^^^^^^^^^ meta.function-call
 //             ^^^^^^ meta.group.css
 //             ^      punctuation.section.group.begin.css
 //                  ^ punctuation.section.group.end.css
-//                    ^^^ entity.name.tag.css
+//                    ^^^ entity.name.tag
 //                        ^^^ entity.other.attribute-name.class.css
 
 .test-pseudo-classes:nth-child(2):hover {}
 //                   ^^^^^^^^^          entity.other.pseudo-class.css
 //                             ^        constant.numeric
-//                               ^      punctuation.definition.entity.css
+//                               ^      punctuation.definition
 //                                ^^^^^ entity.other.pseudo-class.css
 
 .test-pseudo-class-numerics:last-of-type div .class {}
 //                         ^^^^^^^^^^^^^ entity.other.pseudo-class.css
-//                                       ^^^ entity.name.tag.css
+//                                       ^^^ entity.name.tag
 //                                           ^^^ entity.other.attribute-name.class.css
 
 .test-pseudo-class-keywords:nth-of-type(odd) {}
@@ -1393,17 +1387,17 @@ $gutter-width: 10px;
 //                         ^ entity.name.tag.wildcard.css
 
 .test-pseudo-elements::before div .class {}
-//                   ^^ punctuation.definition.entity.css
+//                   ^^ punctuation.definition
 //                   ^^^^^^^^ entity.other.pseudo-element.css
-//                            ^^^ entity.name.tag.css
+//                            ^^^ entity.name.tag
 //                                ^^^ entity.other.attribute-name.class.css
 
 .test-pseudo-elements:after {}
-//                   ^ punctuation.definition.entity.css
+//                   ^ punctuation.definition
 //                   ^^^^^^ entity.other.pseudo-element.css
 
 .test-pseudo-elements::-webkit-slider-runnable-track
-//                   ^^ punctuation.definition.entity.css
+//                   ^^ punctuation.definition
 //                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.pseudo-element.css
 
 
@@ -1428,9 +1422,9 @@ $gutter-width: 10px;
 
 .test-attribute-selectors[disabled][type=button] {}
 //                       ^^^^^^^^^^ meta.attribute-selector.css
-//                       ^ punctuation.definition.entity.css
+//                       ^ punctuation.definition
 //                        ^^^^^^^^ entity.other.attribute-name.css
-//                                ^ punctuation.definition.entity.css
+//                                ^ punctuation.definition
 //                                  ^^^^ entity.other.attribute-name.css
 //                                       ^^^^^^ string.unquoted.css
 
@@ -1537,7 +1531,7 @@ $gutter-width: 10px;
 
 .test-function-meta {
     top: filter(param1, 20px);
-//       ^^^^^^^^^^^^^^^^^^^^ meta.function-call.css
+//       ^^^^^^^^^^^^^^^^^^^^ meta.function-call
 //             ^^^^^^^^^^^^^^ meta.group.css
 }
 
@@ -1762,7 +1756,7 @@ $gutter-width: 10px;
 //                   ^ keyword.operator
 //                     ^^^^ support.function.calc.css
     top: calc(100% - (1 * 10px) / 1 - (1 * 10px) / 1 - (1 * 10px) / 1);
-//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.css
+//       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 //       ^^^^ support.function.calc.css
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.css
 //           ^ punctuation.section.group.begin.css
@@ -2059,8 +2053,8 @@ $gutter-width: 10px;
 
 .test-custom-tags > div > span + cust·m-tÀg > div-cøstom-tag ~ form-Çust😀m-tag.classname:last-child:hover {}
 //                ^ -entity.name.tag.custom.css
-//                  ^^^ entity.name.tag.css
-//                        ^^^^ entity.name.tag.css
+//                  ^^^ entity.name.tag
+//                        ^^^^ entity.name.tag
 //                             ^ -entity.name.tag.custom.css
 //                               ^^^^^^^^^^ entity.name.tag.custom.css
 //                                            ^^^^^^^^^^^^^^ entity.name.tag.custom.css

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -107,9 +107,9 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //    ^^^^^^^^^^^^^^^^^^^^ meta.selector.css
 //    ^^ entity.name.tag.css
 //     ^ - constant.numeric
-//      ^ punctuation.separator.combinator.css
+//      ^ keyword.operator.combinator.css
 //           ^ punctuation.definition.entity.css
-//               ^ punctuation.definition.group.begin
+//               ^ punctuation.section.group.begin
 //                        ^ punctuation.section.property-list.begin
   color: #00ff00;
   height: 97%;
@@ -195,21 +195,21 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //      ^ punctuation.definition.entity.css
 //                  ^ punctuation.separator.css
 //                    ^^^^^^^^^^^ entity.other.pseudo-class.css
-//                    ^ punctuation.definition.entity.css
+//                    ^ punctuation.definition
   +,
-//^ punctuation.separator.combinator
+//^ keyword.operator.combinator
   .test:first-child + & {}
-//                  ^ punctuation.separator.combinator
+//                  ^ keyword.operator.combinator
 //                    ^ keyword.operator.ampersand
   .test:not(.class) & {}
 //                  ^ keyword.operator.ampersand
 
   strong:not(:not(.strong)) {}
-//           ^^^^ entity.other.pseudo-class.css
+//            ^^^ entity.other.pseudo-class.css
 //                ^^^^^^^ entity.other.attribute-name.class.css
   body.firefox ~ & { font-weight: normal; }
 //^^^^^^^^^^^^^^^^^ meta.selector
-//             ^ punctuation.separator.combinator.css
+//             ^ keyword.operator.combinator.css
 //               ^ keyword.operator.ampersand.sass
   &-bemish {  }
 //^ keyword.operator.ampersand.sass
@@ -242,7 +242,7 @@ selector-ish::before[data-type="text"]:not(:first-child),
   font: {
 //  ^ meta.property-name.css support.type.property-name.css
     family: fantasy;
-//                ^ meta.property-value.css support.constant.font-name.css
+//                ^ meta.property-value.css support.constant
 //  ^ meta.property-name.css support.type.property-name.css
     size: 1rem*$ratio;
 //  ^ meta.property-name.css support.type.property-name.css
@@ -250,14 +250,14 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //  ^ meta.property-name.css support.type.property-name.css
   }
   font: 20px/24px fantasy {
-//                ^ meta.property-value.css support.constant.font-name.css
+//                ^ meta.property-value.css support.constant
 //  ^ meta.property-name.css support.type.property-name.css
     weight : bold;
 //  ^ meta.property-name.css support.type.property-name.css
 //            ^ support.constant.property-value.css
     width: calc((100px - 20px) / 2);
 //  ^ meta.property-name.css support.type.property-name.css
-//              ^ punctuation.definition.group - string
+//              ^ punctuation.section.group - string
   }
 }
 //
@@ -308,10 +308,10 @@ color: format(
 @import url(foo);
 @import "rounded-corners", "text-shadow";
 //      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.import
-//                       ^ punctuation.definition.arbitrary-repetition
+//                       ^ punctuation.separator.sequence
 //                                      ^ punctuation.terminator.rule
 @import "rounded-corners", // this is a line comment
-//                       ^ punctuation.definition.arbitrary-repetition
+//                       ^ punctuation.separator.sequence
 //                         ^^ comment.line
         "functions/filter";
 //      ^ meta.at-rule.import
@@ -329,9 +329,9 @@ color: format(
 */
 :import("path/to/dep.css") {
 // ^^^^ entity.other.pseudo-class.css-modules.css
-//     ^ punctuation.definition.group.begin.css
+//     ^ punctuation.section.group.begin.css
 //      ^^^^ string
-//                       ^ punctuation.definition.group.end.css
+//                       ^ punctuation.section.group.end.css
 //                         ^ punctuation.section.property-list.begin.css
   localAlias: keyFromDep;
 // ^^^^^^^^^ meta.property-name.css-modules.css
@@ -369,9 +369,9 @@ color: format(
 .localA :global .global-b .global-c :local(.localD.localE::before) .global-d
 //      ^^^^^^^ entity.other.pseudo-class.css-modules
 //                                  ^^^^^^ entity.other.pseudo-class.css-modules
-//                                        ^ meta.function-call.css meta.group.css punctuation.definition.group.begin.css
+//                                        ^ meta.function-call.css meta.group.css punctuation.section.group.begin.css
 //                                         ^^^^^^^^^^^^^^^^^^^^^^ meta.selector
-//                                                               ^ punctuation.definition.group.end.css
+//                                                               ^ punctuation.section.group.end.css
 :global {  // global blocks
 // ^^^^ entity.other.pseudo-class.css-modules
   .global-class-name {
@@ -398,20 +398,20 @@ color: format(
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.sass
 // ^ keyword.control.at-rule.sass
 //     ^^^^^^^^^^^^^^^ entity.name.function.sass
-//                    ^ meta.function.parameters.sass punctuation.definition.group.begin.sass
-//                              ^ meta.function.parameters.sass punctuation.definition.group.end.sass
+//                    ^ meta.function.parameters.sass punctuation.section.group.begin.sass
+//                              ^ meta.function.parameters.sass punctuation.section.group.end.sass
 //                     ^^ meta.function.parameters.sass variable.parameter.sass
 //                     ^ punctuation.definition.variable.sass
   #{$selector + "some string"}:not(.class),
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.selector
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.interpolation.sass
 //^ punctuation.definition.variable.sass
-// ^ punctuation.definition.group.begin.sass
+// ^ punctuation.section.group.begin.sass
 //  ^^^^^^^^^ variable.other.sass
 //  ^ punctuation.definition.variable.sass
 //            ^ keyword.operator
 //              ^^^^^^^^^^^^^ string.quoted.double
-//                           ^ punctuation.definition.group.end.sass
+//                           ^ punctuation.section.group.end.sass
 //                            ^ punctuation.definition.entity.css
 //                             ^ entity.other.pseudo-class.css
   body.firefox #{$selector} + a:hover,
@@ -419,10 +419,10 @@ color: format(
   body.firefox #{$selector}:before {
 //             ^^^^^^^^^^^^ meta.group.interpolation.sass
 //             ^ punctuation.definition.variable.sass
-//              ^ punctuation.definition.group.begin.sass
+//              ^ punctuation.section.group.begin.sass
 //               ^^^^^^^^^ variable.other.sass
 //               ^ punctuation.definition.variable.sass
-//                        ^ punctuation.definition.group.end.sass
+//                        ^ punctuation.section.group.end.sass
 //                         ^ punctuation.definition.entity.css
 //                          ^ entity.other.pseudo-element.css
 
@@ -456,12 +456,12 @@ color: format(
     content: "I ate #{5 + 10} pies!";
 //           ^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double
 //                  ^^^^^^^^^ meta.group.interpolation.sass
-//                  ^ punctuation.definition.variable.sass
-//                   ^ punctuation.definition.group.begin.sass
+//                  ^ punctuation.section.variable.sass
+//                   ^ punctuation.section.group.begin.sass
 //                    ^ constant.numeric.value.css
 //                      ^ keyword.operator.arithmetic.sass
 //                        ^ constant.numeric.value.css
-//                          ^ punctuation.definition.group.end.sass
+//                          ^ punctuation.section.group.end.sass
     transform: #{translate + $axis + '(' + $span * $aim + ')'};
 //                           ^^^^^ variable.other
 //                           ^ punctuation.definition.variable
@@ -472,12 +472,12 @@ color: format(
 //                    ^ punctuation.definition.variable.sass
     @include breathe(somestring);
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
-//  ^^^^^^^^ keyword.control.at-rule.sass
+//  ^^^^^^^^ keyword.control.directive.sass
 //  ^ punctuation.definition.keyword.sass
 //           ^^^^^^^ variable.function.sass
 //                  ^^^^^^^^^^^^ meta.function-call.arguments.sass
-//                  ^ punctuation.definition.group.begin.sass
-//                             ^ punctuation.definition.group.end.sass
+//                  ^ punctuation.section.group.begin.sass
+//                             ^ punctuation.section.group.end.sass
 //                   ^^^^^^^^^^ string.unquoted.css
 //                   ^ string.unquoted
 //                             ^ - string
@@ -485,8 +485,8 @@ color: format(
 //           ^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
 //           ^^^^^^^ variable.function.sass
 //                  ^^^^^^^^^^^^ meta.function-call.arguments.sass
-//                  ^ punctuation.definition.group.begin.sass
-//                                      ^ punctuation.definition.group.end.sass
+//                  ^ punctuation.section.group.begin.sass
+//                                      ^ punctuation.section.group.end.sass
 //                   ^^^^^^^^^^^^^^^^^^^ support.constant.property-value
     animation: progress-fade-in-animation .15s ease-in;
 //              ^ - meta.selector
@@ -495,10 +495,10 @@ color: format(
     #{$prop}: var(--#{$color}-primary, color(primary, unthemed));
 //  ^^^^^^^^ meta.group.interpolation.sass
 //  ^ punctuation.definition.variable.sass
-//   ^ punctuation.definition.group.begin.sass
+//   ^ punctuation.section.group.begin.sass
 //    ^^^^^ variable.other.sass
 //    ^ punctuation.definition.variable.sass
-//         ^ punctuation.definition.group.end.sass
+//         ^ punctuation.section.group.end.sass
 //          ^ punctuation.separator.key-value
   }
   p.#{$name} {
@@ -517,7 +517,7 @@ color: format(
 }
 
 @include firefox-message(".header" + test);
-//  ^^^^ keyword.control.at-rule.sass
+//  ^^^^ keyword.control.directive.sass
 //<- punctuation.definition.keyword.sass
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
 //           ^^^^^^^ variable.function.sass
@@ -529,11 +529,11 @@ color: format(
 @include firefox-message(
 //           ^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
 //           ^^^^^^^ variable.function.sass
-//                      ^ punctuation.definition.group.begin.sass
+//                      ^ punctuation.section.group.begin.sass
   ".header", /*a comment*/
  test // this should also be a comment
    );
-// ^ punctuation.definition.group.end.sass
+// ^ punctuation.section.group.end.sass
 //
 
 
@@ -556,7 +556,7 @@ color: format(
 //                                        ^^^ constant.numeric
 //                                         ^^ constant.numeric.suffix
     @content;
-//  ^^^^^^^^ keyword.control.at-rule.content
+//  ^^^^^^^^ keyword.control.directive.content
 //  ^ punctuation.definition.keyword
 //          ^ punctuation.terminator.rule
 
@@ -609,7 +609,7 @@ h1 { @include sexy-border(blue, 2in); }
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#maps
 */
 $map: (
-//    ^ punctuation.definition.group.begin.sass
+//    ^ punctuation.section.group.begin.sass
   $key-1: #000,
 //      ^ punctuation.separator
 //            ^ punctuation.separator
@@ -651,18 +651,18 @@ $list: (top, bottom, right, position, height);
   color: nth(map.merge($map, $map2), 3);
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.css meta.function-call.sass
 //       ^^^ support.function.sass
-//          ^ punctuation.definition.group.begin
+//          ^ punctuation.section.group.begin
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
 //           ^^^^^^^^^ support.function.sass
 //           ^^^ entity.name.namespace
 //              ^ punctuation
-//                    ^ punctuation.definition.group.begin
+//                    ^ punctuation.section.group.begin
 //                         ^ punctuation.separator.sequence.css
-//                                ^ punctuation.definition.group.end
+//                                ^ punctuation.section.group.end
 }
 //
 
-
+/*
   Operators
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#operations
 */
@@ -680,7 +680,7 @@ p {
 }
 //
 
-
+/*
   Color Operations
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#color_operations
 */
@@ -701,9 +701,9 @@ $translucent-red: hsla(240deg 100% 50% / 5%);
 p {
   color: opacify($translucent-red, 0.3);
 //       ^^^^^^^ support.function.sass
-//              ^ punctuation.definition.group.begin
+//              ^ punctuation.section.group.begin
 //                               ^ punctuation.separator.sequence.css
-//                                    ^ punctuation.definition.group.end
+//                                    ^ punctuation.section.group.end
   background-color: transparentize(#E82C0C, 0.25);
 //                  ^^^^^^^ support.function.sass
 //                                 ^^^ constant.other.color.rgb-value.css
@@ -713,7 +713,7 @@ p {
 }
 //
 
-
+/*
   Function directives
   https://sass-lang.com/documentation/file.SASS_REFERENCE.html#function_directives
 */
@@ -724,7 +724,7 @@ $gutter-width: 10px;
 // ^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.sass
 // ^^^^^^ keyword.control.at-rule.sass
 //        ^^^^^^^^^^ entity.name.function.sass
-//                  ^ meta.function.parameters.sass punctuation.definition.group.begin.sass
+//                  ^ meta.function.parameters.sass punctuation.section.group.begin.sass
   @return $n * $grid-width + ($n - 1) * $gutter-width;
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.sass
 // ^^^^^^ keyword.control.at-rule.return.sass
@@ -805,15 +805,15 @@ $gutter-width: 10px;
 //                       ^^^^ variable
 //                               ^^^^ constant
 //                             ^ punctuation
-//                      ^ punctuation.definition.group.begin.sass
-//                                   ^ punctuation.definition.group.end.sass
+//                      ^ punctuation.section.group.begin.sass
+//                                   ^ punctuation.section.group.end.sass
 //                                    ^ punctuation.terminator.rule.sass
 @forward "sass:meta" as meta with (
 // ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
 //                   ^^ keyword.control.as.sass
 //                      ^^^^ meta.generic-name.sass
 //                           ^^^^ keyword.control.with.sass
-//                                ^ punctuation.definition.group.begin.sass
+//                                ^ punctuation.section.group.begin.sass
   // This sets bootstrap’s $paragraph-margin-bottom variable to 1.2rem before evaluating it.
   $paragraph-margin-bottom: 1.2rem,
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
@@ -975,8 +975,8 @@ $gutter-width: 10px;
 //                             ^ punctuation.separator.decimal.css
 
     top: url("image");
-//          ^         punctuation.definition.group.begin.css
-//                  ^ punctuation.definition.group.end.css
+//          ^         punctuation.section.group.begin.css
+//                  ^ punctuation.section.group.end.css
 }
 // < punctuation.section.property-list.css
 
@@ -1013,9 +1013,9 @@ $gutter-width: 10px;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.namespace.css
 //             ^^^ support.function.url.css
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.css
-//                ^ meta.group.css punctuation.definition.group.begin.css
+//                ^ meta.group.css punctuation.section.group.begin.css
 //                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.css string.quoted.double.css
-//                                                                                ^ meta.group.css punctuation.definition.group.end.css
+//                                                                                ^ meta.group.css punctuation.section.group.end.css
 
     @page :left {}
 //  ^^^^^^^^^^^^ meta.at-rule.page.css
@@ -1034,24 +1034,24 @@ $gutter-width: 10px;
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
 //  ^ punctuation.definition.keyword.css
 //   ^^^^^ keyword.control.at-rule.media.css
-//         ^ punctuation.definition.group.begin.css
+//         ^ punctuation.section.group.begin.css
 //          ^^^^^^^^^ support.type.property-name.media.css
 //                     ^^^^^ constant.numeric
-//                          ^ punctuation.definition.group.end.css
+//                          ^ punctuation.section.group.end.css
 
     @media (min-width: 700px) and (max-width: 2000px) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
 //  ^ punctuation.definition.keyword.css
 //   ^^^^^ keyword.control.at-rule.media.css
-//         ^ punctuation.definition.group.begin.css
+//         ^ punctuation.section.group.begin.css
 //          ^^^^^^^^^ support.type.property-name.media.css
 //                     ^^^^^ constant.numeric
-//                          ^ punctuation.definition.group.end.css
+//                          ^ punctuation.section.group.end.css
 //                            ^^^ keyword.operator.logic
-//                                ^ punctuation.definition.group.begin.css
+//                                ^ punctuation.section.group.begin.css
 //                                 ^^^^^^^^^ support.type.property-name.media.css
 //                                            ^^^^^^ constant.numeric
-//                                                  ^ punctuation.definition.group.end.css
+//                                                  ^ punctuation.section.group.end.css
 
    @media only screen and (-webkit-min-device-pixel-ratio: /* comment */ 1.3),
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
@@ -1060,36 +1060,36 @@ $gutter-width: 10px;
 //        ^^^^ keyword.operator.logic.media.css
 //             ^^^^^^ support.constant.media.css
 //                    ^^^ keyword.operator.logic.media.css
-//                        ^ punctuation.definition.group.begin.css
+//                        ^ punctuation.section.group.begin.css
 //                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.type.property-name.media.css
 //                                                       ^ punctuation.separator.key-value.css
 //                                                         ^^^^^^^^^^^^^ comment.block.css
 //                                                                       ^^^ constant.numeric
-//                                                                          ^ punctuation.definition.group.end.css
+//                                                                          ^ punctuation.section.group.end.css
 //                                                                           ^ punctuation.definition.arbitrary-repetition
     only screen and (-o-min-device-pixel-ratio: 13/10),
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
 //  ^^^^ keyword.operator.logic.media.css
 //       ^^^^^^ support.constant.media.css
 //              ^^^ keyword.operator.logic.media.css
-//                  ^ punctuation.definition.group.begin.css
+//                  ^ punctuation.section.group.begin.css
 //                   ^^^^^^^^^^^^^^^^^^^^^^^^^ support.type.property-name.media.css
 //                                            ^ punctuation.separator.key-value.css
 //                                              ^^ constant.numeric
 //                                                ^ keyword.operator
 //                                                 ^^ constant.numeric
-//                                                   ^ punctuation.definition.group.end.css
+//                                                   ^ punctuation.section.group.end.css
 //                                                    ^ punctuation.definition.arbitrary-repetition
     only screen and (min-resolution: 120dpi)
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
 //  ^^^^ keyword.operator.logic.media.css
 //       ^^^^^^ support.constant.media.css
 //              ^^^ keyword.operator.logic.media.css
-//                  ^ punctuation.definition.group.begin.css
+//                  ^ punctuation.section.group.begin.css
 //                   ^^^^^^^^^^^^^^ support.type.property-name.media.css
 //                                 ^ punctuation.separator.key-value.css
 //                                   ^^^^^^ constant.numeric
-//                                         ^ punctuation.definition.group.end.css
+//                                         ^ punctuation.section.group.end.css
 {}
 
     @custom-media --a-b (width: 1px);
@@ -1190,13 +1190,13 @@ $gutter-width: 10px;
 //  ^ punctuation.definition.keyword.css
 //   ^^^^^^^^ keyword.control.at-rule.supports.css
 //            ^^^ keyword.operator.logic.css
-//                ^ meta.group.css punctuation.definition.group.begin.css
+//                ^ meta.group.css punctuation.section.group.begin.css
 //                  ^^^ keyword.operator.logic.css
-//                      ^ meta.group.css punctuation.definition.group.begin.css
+//                      ^ meta.group.css punctuation.section.group.begin.css
 //                        ^^^ support.type.property-name.css
 //                           ^ punctuation.separator.key-value.css
 //                              ^^ constant.numeric
-//                                 ^ meta.group.css punctuation.definition.group.end.css
+//                                 ^ meta.group.css punctuation.section.group.end.css
 //                                     ^ punctuation
 //                                       ^ punctuation
 
@@ -1365,8 +1365,8 @@ $gutter-width: 10px;
 .test:nth-child(even) div .class {}
 //   ^^^^^^^^^^^^^^^^ meta.function-call.css
 //             ^^^^^^ meta.group.css
-//             ^      punctuation.definition.group.begin.css
-//                  ^ punctuation.definition.group.end.css
+//             ^      punctuation.section.group.begin.css
+//                  ^ punctuation.section.group.end.css
 //                    ^^^ entity.name.tag.css
 //                        ^^^ entity.other.attribute-name.class.css
 
@@ -1461,11 +1461,11 @@ $gutter-width: 10px;
 // ^ entity.name.tag.wildcard.css
 
 .test-combinators >>> a >> a > a + b ~ a {}
-//                ^^^                  punctuation.separator.combinator.css
-//                      ^^             punctuation.separator.combinator.css
-//                           ^         punctuation.separator.combinator.css
-//                               ^     punctuation.separator.combinator.css
-//                                   ^ punctuation.separator.combinator.css
+//                ^^^                  keyword.operator.combinator.css
+//                      ^^             keyword.operator.combinator.css
+//                           ^         keyword.operator.combinator.css
+//                               ^     keyword.operator.combinator.css
+//                                   ^ keyword.operator.combinator.css
 
 .test-generic-font-families {
     font: serif;
@@ -1618,19 +1618,19 @@ $gutter-width: 10px;
 //  ^^^^^^^^^^^^^^^^ support.type.property-name.css
 //                  ^ punctuation.separator.key-value.css
 //                    ^^^^^ support.function.color.css
-//                         ^ punctuation.definition.group.begin.css
+//                         ^ punctuation.section.group.begin.css
 //                          ^^^ support.function.var.css
-//                             ^ punctuation.definition.group.begin.css
+//                             ^ punctuation.section.group.begin.css
 //                              ^^^^^^^^^^^^ support.type.custom-property
-//                                          ^ punctuation.definition.group.end.css
+//                                          ^ punctuation.section.group.end.css
 //                                            ^^^^^ support.function.color.css
-//                                                 ^ punctuation.definition.group.begin.css
+//                                                 ^ punctuation.section.group.begin.css
 //                                                  ^^^ support.function.var.css
-//                                                     ^ punctuation.definition.group.begin.css
+//                                                     ^ punctuation.section.group.begin.css
 //                                                      ^^^^^^^^^^^^ support.type.custom-property.css
-//                                                                  ^ punctuation.definition.group.end.css
+//                                                                  ^ punctuation.section.group.end.css
 //                                                                    ^^^ constant.numeric
-//                                                                       ^^ punctuation.definition.group.end.css
+//                                                                       ^^ punctuation.section.group.end.css
 //                                                                         ^ punctuation.terminator.rule.css
 }
 
@@ -1766,27 +1766,27 @@ $gutter-width: 10px;
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.css
 //       ^^^^ support.function.calc.css
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group.css
-//           ^ punctuation.definition.group.begin.css
+//           ^ punctuation.section.group.begin.css
 //            ^^^ constant.numeric
 //                 ^ keyword.operator
-//                   ^ punctuation.definition.group.begin.css
+//                   ^ punctuation.section.group.begin.css
 //                   ^^^^^^^^^^ meta.group.css meta.group.css
-//                            ^ punctuation.definition.group.end.css
+//                            ^ punctuation.section.group.end.css
 //                              ^ keyword.operator
-//                                    ^ punctuation.definition.group.begin.css
+//                                    ^ punctuation.section.group.begin.css
 //                                         ^^ constant.numeric
 //                                           ^^ constant.numeric.suffix
-//                                             ^ punctuation.definition.group.end.css
+//                                             ^ punctuation.section.group.end.css
 //                                               ^ keyword.operator
 //                                                   ^ keyword.operator
-//                                                     ^ punctuation.definition.group.begin.css
+//                                                     ^ punctuation.section.group.begin.css
 //                                                      ^ constant.numeric
 //                                                        ^ keyword.operator
 //                                                          ^^ constant.numeric
-//                                                              ^ punctuation.definition.group.end.css
+//                                                              ^ punctuation.section.group.end.css
 //                                                                ^ keyword.operator
 //                                                                  ^ constant.numeric
-//                                                                   ^ punctuation.definition.group.end.css
+//                                                                   ^ punctuation.section.group.end.css
 //                                                                    ^ punctuation.terminator.rule.css - meta.group
 }
 
@@ -1977,7 +1977,7 @@ $gutter-width: 10px;
     grid-template: repeat(2, var(--size)) / repeat(2, 50%);
 //                           ^^^ support.function.var.css
 //                               ^^^^^^ support.type.custom-property.css
-//                                     ^^ punctuation.definition.group.end.css
+//                                     ^^ punctuation.section.group.end.css
 //                                          ^^^^^^ support.function.grid.css
     grid-template-columns:
       [a-line-name] auto

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -2090,6 +2090,10 @@ $gutter-width: 10px;
     grid-row: auto;
 //  ^^^^^^^^ support.type.property-name
 //          ^ punctuation.separator.key-value
+    place-items: center;
+//  ^^^^^^^^^^^ support.type.property-name
+//             ^ punctuation.separator.key-value
+//               ^^^^^^ support.constant.property-value.css
 }
 
 .test-meta-scopes-for-completions {

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -976,7 +976,7 @@ $gutter-width: 10px;
 // < punctuation.section.property-list.css
 
     .classname {}
-//  ^^^^^^^^^^^ meta.selector.css
+//  ^^^^^^^^^^ meta.selector.css
 //  ^          punctuation.definition
 //   ^^^^^^^^^ entity.other.attribute-name.class.css
 
@@ -988,24 +988,24 @@ $gutter-width: 10px;
 //  ^^^^ entity.name.tag
 
     @charset "UTF-8";
-//  ^^^^^^^^^^^^^^^^ meta.at-rule.css
+//  ^^^^^^^^^^^^^^^^ meta.at-rule
 //  ^        punctuation.definition.keyword.css
-//   ^^^^^^^ keyword.control.at-rule.css
+//   ^^^^^^^ keyword.control.directive
 
     @import "x" print;
 //  ^^^^^^^^^^^^^^^^^ meta.at-rule.import.css
 //  ^                 punctuation.definition.keyword.css
-//   ^^^^^^           keyword.control.at-rule.import.css
+//   ^^^^^^           keyword.control.directive
 //              ^^^^^ support.constant.media.css
 
     @namespace svg "http://www.w3.org/1999/xhtml";
 //  ^^^^^^^^^^^^^^^^^ meta.at-rule.namespace.css
 //  ^              punctuation.definition.keyword.css
-//   ^^^^^^^^^     keyword.control.at-rule.namespace.css
+//   ^^^^^^^^^     keyword.control.directive
 //             ^^^ entity.other.namespace-prefix.css
 
     @namespace url("http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"); /* only needed once */
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.namespace.css
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.namespace.css
 //             ^^^ support.function.url.css
 //             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call
 //                ^ meta.group.css punctuation.section.group.begin.css
@@ -1015,73 +1015,73 @@ $gutter-width: 10px;
     @page :left {}
 //  ^^^^^^^^^^^^ meta.at-rule.page.css
 //  ^     punctuation.definition.keyword.css
-//   ^^^^ keyword.control.at-rule.page.css
+//   ^^^^ keyword.control.directive
 
     @media only screen //test comment {}
 //  ^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
 //  ^                  punctuation.definition.keyword.css
-//   ^^^^^             keyword.control.at-rule.media.css
-//         ^^^^        keyword.operator.logic.media.css
+//   ^^^^^             keyword.control.directive
+//         ^^^^        keyword.operator.logic
 //              ^^^^^^ support.constant.media.css
 //                     ^ comment.line.double-slash
 {}
     @media (min-width: 700px) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
 //  ^ punctuation.definition.keyword.css
-//   ^^^^^ keyword.control.at-rule.media.css
+//   ^^^^^ keyword.control.directive
 //         ^ punctuation.section.group.begin.css
-//          ^^^^^^^^^ support.type.property-name.media.css
+//          ^^^^^^^^^ support.type.property-name
 //                     ^^^^^ constant.numeric
 //                          ^ punctuation.section.group.end.css
 
     @media (min-width: 700px) and (max-width: 2000px) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
 //  ^ punctuation.definition.keyword.css
-//   ^^^^^ keyword.control.at-rule.media.css
+//   ^^^^^ keyword.control.directive
 //         ^ punctuation.section.group.begin.css
-//          ^^^^^^^^^ support.type.property-name.media.css
+//          ^^^^^^^^^ support.type.property-name
 //                     ^^^^^ constant.numeric
 //                          ^ punctuation.section.group.end.css
 //                            ^^^ keyword.operator.logic
 //                                ^ punctuation.section.group.begin.css
-//                                 ^^^^^^^^^ support.type.property-name.media.css
+//                                 ^^^^^^^^^ support.type.property-name
 //                                            ^^^^^^ constant.numeric
 //                                                  ^ punctuation.section.group.end.css
 
    @media only screen and (-webkit-min-device-pixel-ratio: /* comment */ 1.3),
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
 // ^ punctuation.definition.keyword.css
-//  ^^^^^ keyword.control.at-rule.media.css
-//        ^^^^ keyword.operator.logic.media.css
+//  ^^^^^ keyword.control.directive
+//        ^^^^ keyword.operator.logic
 //             ^^^^^^ support.constant.media.css
-//                    ^^^ keyword.operator.logic.media.css
+//                    ^^^ keyword.operator.logic
 //                        ^ punctuation.section.group.begin.css
-//                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.type.property-name.media.css
+//                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ support.type
 //                                                       ^ punctuation.separator.key-value.css
 //                                                         ^^^^^^^^^^^^^ comment.block.css
 //                                                                       ^^^ constant.numeric
 //                                                                          ^ punctuation.section.group.end.css
-//                                                                           ^ punctuation.definition.arbitrary-repetition
+//                                                                           ^ punctuation.separator.sequence
     only screen and (-o-min-device-pixel-ratio: 13/10),
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
-//  ^^^^ keyword.operator.logic.media.css
+//  ^^^^ keyword.operator.logic
 //       ^^^^^^ support.constant.media.css
-//              ^^^ keyword.operator.logic.media.css
+//              ^^^ keyword.operator.logic
 //                  ^ punctuation.section.group.begin.css
-//                   ^^^^^^^^^^^^^^^^^^^^^^^^^ support.type.property-name.media.css
+//                   ^^^^^^^^^^^^^^^^^^^^^^^^^ support.type
 //                                            ^ punctuation.separator.key-value.css
 //                                              ^^ constant.numeric
 //                                                ^ keyword.operator
 //                                                 ^^ constant.numeric
 //                                                   ^ punctuation.section.group.end.css
-//                                                    ^ punctuation.definition.arbitrary-repetition
+//                                                    ^ punctuation.separator.sequence
     only screen and (min-resolution: 120dpi)
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.media.css
-//  ^^^^ keyword.operator.logic.media.css
+//  ^^^^ keyword.operator.logic
 //       ^^^^^^ support.constant.media.css
-//              ^^^ keyword.operator.logic.media.css
+//              ^^^ keyword.operator.logic
 //                  ^ punctuation.section.group.begin.css
-//                   ^^^^^^^^^^^^^^ support.type.property-name.media.css
+//                   ^^^^^^^^^^^^^^ support.type.property-name
 //                                 ^ punctuation.separator.key-value.css
 //                                   ^^^^^^ constant.numeric
 //                                         ^ punctuation.section.group.end.css
@@ -1090,22 +1090,22 @@ $gutter-width: 10px;
     @custom-media --a-b (width: 1px);
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.custom-media.css
 //  ^                          punctuation.definition.keyword.css
-//   ^^^^^^^^^^^^              keyword.control.at-rule.custom-media.css
-//                       ^^^^^ support.type.property-name.media.css
+//   ^^^^^^^^^^^^              keyword.control.directive
+//                       ^^^^^ support.type.property-name
 
     @keyframes beat, bounce {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.keyframe.css
 //  ^                       punctuation.definition.keyword.css
-//   ^^^^^^^^^              keyword.control.at-rule.keyframe.css
+//   ^^^^^^^^^              keyword.control.directive
 //             ^^^^         entity.other.animation-name.css
-//                 ^        punctuation.definition.arbitrary-repetition.css
+//                 ^        punctuation.separator.sequence
 //                   ^^^^^^ entity.other.animation-name.css
 
 @keyframes test-keyframes-keywords {
     from, to {}
-//  ^^^^ keyword.keyframe-selector.css
+//  ^^^^ keyword
 //      ^ punctuation.separator.sequence.css
-//        ^^ keyword.keyframe-selector.css
+//        ^^ keyword
 
     0%, 100% {}
 //  ^^ constant.numeric
@@ -1127,13 +1127,13 @@ $gutter-width: 10px;
 //  ^^ constant.numeric
 //   ^ constant.numeric.suffix
 //    ^ punctuation.separator.sequence.css
-//      ^^ keyword.keyframe-selector.css
+//      ^^ keyword
 }
 
     @document url(http://) { }
 //  ^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.document.css
 //  ^ punctuation.definition.keyword.css
-//  ^^^^^^^^^ keyword.control.at-rule.document.css
+//  ^^^^^^^^^ keyword.control.directive
 //                         ^ punctuation
 //                           ^ punctuation
 
@@ -1159,9 +1159,9 @@ $gutter-width: 10px;
 }
 
     @font-face {
-//  ^^^^^^^^^^^ meta.at-rule.css
+//  ^^^^^^^^^^^ meta.at-rule
 //  ^          punctuation.definition.keyword.css
-//   ^^^^^^^^^ keyword.control.at-rule.css
+//   ^^^^^^^^^ keyword.control.directive
 
     src: local(Font);
 //
@@ -1169,13 +1169,13 @@ $gutter-width: 10px;
 }
 
     @font-face
-//  ^^^^^^^^^^^ meta.at-rule.css
+//  ^^^^^^^^^^^ meta.at-rule
 //  ^          punctuation.definition.keyword.css
-//   ^^^^^^^^^ keyword.control.at-rule.css
+//   ^^^^^^^^^ keyword.control.directive
 {
     font-family: monospace,
 //  ^^^^^^^^^^^ support.type.property-name.css
-//               ^^^^^^^^^ support.constant.font-name.css
+//               ^^^^^^^^^ support.constant.property-value
         /* */
 //      ^^^^^ comment.block.css
 }
@@ -1183,20 +1183,20 @@ $gutter-width: 10px;
     @supports not ( and ( top: 2px ) ) {}
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.supports.css
 //  ^ punctuation.definition.keyword.css
-//   ^^^^^^^^ keyword.control.at-rule.supports.css
-//            ^^^ keyword.operator.logic.css
+//   ^^^^^^^^ keyword.control.directive
+//            ^^^ keyword.operator.logical.css
 //                ^ meta.group.css punctuation.section.group.begin.css
-//                  ^^^ keyword.operator.logic.css
+//                  ^^^ keyword.operator.logical.css
 //                      ^ meta.group.css punctuation.section.group.begin.css
 //                        ^^^ support.type.property-name.css
 //                           ^ punctuation.separator.key-value.css
 //                              ^^ constant.numeric
 //                                 ^ meta.group.css punctuation.section.group.end.css
 //                                     ^ punctuation
-//                                       ^ punctuation
+//                                      ^ punctuation
 
 @supports (--foo: green) {
-//         ^^^^^ support.type.custom-property.css
+//         ^^^^^ entity.other.custom-property.css
     .class {
 //  ^^^^^^ entity.other.attribute-name.class.css
         display: none;
@@ -1206,17 +1206,17 @@ $gutter-width: 10px;
 
     @counter-style {}
 //  ^          punctuation.definition.keyword.css
-//  ^^^^^^^^^^^^^^ keyword.control.at-rule.counter-style.css
+//  ^^^^^^^^^^^^^^ keyword.control.directive
 
 @counter-style none {}
-//             ^^^^ invalid.illegal.counter-style-name.css
+//             ^^^^ invalid.illegal
 
 @counter-style decimal {}
-//             ^^^^^^^ invalid.illegal.counter-style-name.css
+//             ^^^^^^^ invalid.illegal
 
     @counter-style name {
 //  ^          punctuation.definition.keyword.css
-//  ^^^^^^^^^^^^^^ keyword.control.at-rule.counter-style.css
+//  ^^^^^^^^^^^^^^ keyword.control.directive
 //                 ^^^^ entity.other.counter-style-name.css
     symbols: "‣";
 //  ^^^^^^^ support.type.property-name.css
@@ -1226,7 +1226,7 @@ $gutter-width: 10px;
 }
 
     @counter-style blacknwhite
-//  ^^^^^^^^^^^^^^ meta.at-rule.counter-style.css keyword.control.at-rule.counter-style.css
+//  ^^^^^^^^^^^^^^ meta.at-rule.counter-style.css keyword.control.directive
 //                 ^^^^^^^^^^^ entity.other.counter-style-name.css
 {
   system: cyclic;
@@ -1240,9 +1240,7 @@ $gutter-width: 10px;
 }
 
 .test-var { --test-var: arial; }
-//          ^^^^^^^^^^ support.type.custom-property.css
-//          ^^         punctuation.definition.custom-property
-//            ^^^^^^^^ support.type.custom-property.name.css
+//          ^^^^^^^^^^ entity.other.custom-property.css
 
 .test-types {
     top: 20;
@@ -1307,7 +1305,6 @@ $gutter-width: 10px;
 
           top: alpha(-1.5%);
 //             ^^^^^ support.function.color.css
-//                   ^ invalid.illegal.operator.css
 //                    ^^^ meta.number constant.numeric.value.css
 //                       ^ meta.number constant.numeric.suffix.css
 
@@ -1358,7 +1355,7 @@ $gutter-width: 10px;
 
 // Test Functional Pseudo Class Meta Scopes
 .test:nth-child(even) div .class {}
-//   ^^^^^^^^^^^^^^^^ meta.function-call
+//    ^^^^^^^^^^^^^^^ meta.function-call
 //             ^^^^^^ meta.group.css
 //             ^      punctuation.section.group.begin.css
 //                  ^ punctuation.section.group.end.css
@@ -1372,35 +1369,35 @@ $gutter-width: 10px;
 //                                ^^^^^ entity.other.pseudo-class.css
 
 .test-pseudo-class-numerics:last-of-type div .class {}
-//                         ^^^^^^^^^^^^^ entity.other.pseudo-class.css
+//                          ^^^^^^^^^^^^ entity.other.pseudo-class.css
 //                                       ^^^ entity.name.tag
 //                                           ^^^ entity.other.attribute-name.class.css
 
 .test-pseudo-class-keywords:nth-of-type(odd) {}
-//                         ^^^^^^^^^^^^ entity.other.pseudo-class.css
-//                                      ^^^ keyword.other.pseudo-class.css
+//                          ^^^^^^^^^^^ entity.other.pseudo-class.css
+//                                      ^^^ support.constant
 
 .test-pseudo-class-strings:dir(ltr) {}
-//                        ^^^^ entity.other.pseudo-class.css
-//                             ^^^ string.unquoted.css
+//                         ^^^ entity.other.pseudo-class.css
+//                             ^^^ support.constant
 
 .test-pseudo-class-tag:not(*) {}
-//                    ^^^^ entity.other.pseudo-class.css
-//                         ^ entity.name.tag.wildcard.css
+//                     ^^^ entity.other.pseudo-class.css
+//                         ^ variable.language.wildcard
 
 .test-pseudo-elements::before div .class {}
 //                   ^^ punctuation.definition
-//                   ^^^^^^^^ entity.other.pseudo-element.css
+//                     ^^^^^^ entity.other.pseudo-element.css
 //                            ^^^ entity.name.tag
 //                                ^^^ entity.other.attribute-name.class.css
 
 .test-pseudo-elements:after {}
 //                   ^ punctuation.definition
-//                   ^^^^^^ entity.other.pseudo-element.css
+//                    ^^^^^ entity.other.pseudo-element.css
 
 .test-pseudo-elements::-webkit-slider-runnable-track
 //                   ^^ punctuation.definition
-//                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ entity.other.pseudo-element.css
+//                             ^^^^^^^^^^^^^^^^^^^^^ entity.other.pseudo-element.css
 
 
 .test-unicode { top: "\2764 \273e"; }
@@ -1409,13 +1406,10 @@ $gutter-width: 10px;
 
 .test-unicode-range {
     unicode-range: U+0025-00FF, U+4??;
-//                 ^^^^^^^^^^^        support.unicode-range.css
-//                 ^^                 support.constant.unicode-range.prefix.css
-//                   ^^^^^^^^^        constant.codepoint-range.css
-//                       ^            punctuation.section.range.css
-//                              ^^^^^ support.unicode-range.css
-//                              ^^    support.constant.unicode-range.prefix.css
-//                                ^^^ constant.codepoint-range.css
+//                 ^^^^^^^^^^^        meta.number.unicode-range
+//                 ^^                 constant
+//                              ^^^^^ meta.number.unicode-range
+//                              ^^    constant.numeric.prefix
 }
 
 .test-escape-character { top: "\nstring\n"; }
@@ -1424,36 +1418,36 @@ $gutter-width: 10px;
 
 .test-attribute-selectors[disabled][type=button] {}
 //                       ^^^^^^^^^^ meta.attribute-selector.css
-//                       ^ punctuation.definition
+//                       ^ punctuation.section
 //                        ^^^^^^^^ entity.other.attribute-name.css
-//                                ^ punctuation.definition
+//                                ^ punctuation.section
 //                                  ^^^^ entity.other.attribute-name.css
 //                                       ^^^^^^ string.unquoted.css
 
 .test-attribute-selectors-namespaces[n|a=""][*|a=""][|att] {}
 //                                   ^ entity.other.namespace-prefix.css
 //                                    ^ punctuation.separator.namespace.css
-//                                           ^ entity.name.namespace.wildcard.css
+//                                           ^ variable.language.wildcard
 //                                            ^ punctuation.separator.namespace.css
 //                                                   ^ punctuation.separator.namespace.css
 
 .test-attribute-selectors-operators[a=""][a~=""][a|=""][a^=""][a$=""][a*=""] {}
-//                                   ^ keyword.operator.attribute-selector.css
-//                                         ^^ keyword.operator.attribute-selector.css
-//                                                ^^ keyword.operator.attribute-selector.css
-//                                                       ^^ keyword.operator.attribute-selector.css
-//                                                              ^^ keyword.operator.attribute-selector.css
-//                                                                     ^^ keyword.operator.attribute-selector.css
+//                                   ^ keyword.operator
+//                                         ^^ keyword.operator
+//                                                ^^ keyword.operator
+//                                                       ^^ keyword.operator
+//                                                              ^^ keyword.operator
+//                                                                     ^^ keyword.operator
 
 .test-attribute-selectors-whitespace[a = ""] {}
 //                                   ^   entity.other.attribute-name.css
-//                                     ^ keyword.operator.attribute-selector.css
+//                                     ^ keyword.operator
 
 .test-attribute-selectors-flags[a="" i] {}
-//                                   ^ keyword.other.css
+//                                   ^ keyword.other
 
    *.test-universal-selector {}
-// ^ entity.name.tag.wildcard.css
+// ^ variable.language.wildcard
 
 .test-combinators >>> a >> a > a + b ~ a {}
 //                ^^^                  keyword.operator.combinator.css
@@ -1464,15 +1458,15 @@ $gutter-width: 10px;
 
 .test-generic-font-families {
     font: serif;
-//        ^^^^^      support.constant.font-name.css
+//        ^^^^^      support.constant
     font: sans-serif;
-//        ^^^^^^^^^^ support.constant.font-name.css
+//        ^^^^^^^^^^ support.constant
     font: cursive;
-//        ^^^^^^^    support.constant.font-name.css
+//        ^^^^^^^    support.constant
     font: fantasy;
-//        ^^^^^^^    support.constant.font-name.css
+//        ^^^^^^^    support.constant
     font: monospace;
-//        ^^^^^^^^^  support.constant.font-name.css
+//        ^^^^^^^^^  support.constant
 }
 
 .test-unquoted-font-name {
@@ -1502,16 +1496,16 @@ $gutter-width: 10px;
 
 .test-color-values {
     color: aqua;
-//         ^^^^ support.constant.color.w3c-standard-color-name.css
+//         ^^^^ support.constant
 
     color: aliceblue;
-//         ^^^^^^^^^ support.constant.color.w3c-extended-color-keywords.css
+//         ^^^^^^^^^ support.constant
 
     color: currentColor;
-//         ^^^^^^^^^^^^ support.constant.color.w3c-special-color-keyword.css
+//         ^^^^^^^^^^^^ support.constant
 
     color: transparent;
-//         ^^^^^^^^^^^ support.constant.color.w3c-special-color-keyword.css
+//         ^^^^^^^^^^^ support.constant
 
     color: #b4da55;
 //         ^ punctuation.definition.constant.css
@@ -1571,14 +1565,14 @@ $gutter-width: 10px;
 //                   ^^^ constant.numeric
 //                      ^ punctuation.separator.sequence.css
 //                        ^^ constant.numeric
-//                            ^^^ support.function.color.css
+//                            ^^^ support.function
 
   top: color(w(var()) s(var()));
-//     ^^^^^       support.function.color.css
-//           ^     support.function.color.css
-//             ^^^ support.function.var.css
-//                    ^ support.function.color.css
-//                      ^^^ support.function.var.css
+//     ^^^^^       support.function
+//           ^     support.function
+//             ^^^ support.function
+//                    ^ support.function
+//                      ^^^ support.function
   top: rect(var());
 //     ^^^^ support.function.shape.css
 //          ^^^ support.function.var.css
@@ -1605,7 +1599,7 @@ $gutter-width: 10px;
 
     top: blenda(red 50% hsl);
 //       ^^^^^^ support.function.color.css
-//              ^^^ support.constant.color.w3c-standard-color-name.css
+//              ^^^ support.constant.color
 //                  ^^^ constant.numeric
 //                      ^^^ keyword.other.color-space.css
 
@@ -1616,13 +1610,13 @@ $gutter-width: 10px;
 //                         ^ punctuation.section.group.begin.css
 //                          ^^^ support.function.var.css
 //                             ^ punctuation.section.group.begin.css
-//                              ^^^^^^^^^^^^ support.type.custom-property
+//                              ^^^^^^^^^^^^ variable.other.custom-property
 //                                          ^ punctuation.section.group.end.css
-//                                            ^^^^^ support.function.color.css
+//                                            ^^^^^ support.function
 //                                                 ^ punctuation.section.group.begin.css
 //                                                  ^^^ support.function.var.css
 //                                                     ^ punctuation.section.group.begin.css
-//                                                      ^^^^^^^^^^^^ support.type.custom-property.css
+//                                                      ^^^^^^^^^^^^ variable.other.custom-property
 //                                                                  ^ punctuation.section.group.end.css
 //                                                                    ^^^ constant.numeric
 //                                                                       ^^ punctuation.section.group.end.css
@@ -1636,7 +1630,7 @@ $gutter-width: 10px;
 
     top: rotate(1)
 //       ^^^^^^ support.function.transform.css
-//              ^ - constant.numeric
+//               ^ - constant.numeric
 
     top: rotate3d(-1, 2deg);
 //       ^^^^^^^^ support.function.transform.css
@@ -1693,7 +1687,7 @@ $gutter-width: 10px;
     transform: translate(var(--center), 0) scale(var(--ripple-scale), 1);
 //             ^^^^^^^^^ support.function.transform
 //                       ^^^ support.function.var
-//                           ^^^^^^^^ support.type.custom-property
+//                           ^^^^^^^^ variable.other.custom-property
 //                                      ^ constant.numeric
 //                                               ^^^ support.function.var
 }
@@ -1706,25 +1700,25 @@ $gutter-width: 10px;
     top: steps(020, start);
 //       ^^^^^ support.function.timing.css
 //             ^^^ constant.numeric
-//                  ^^^^^ support.keyword.timing-direction.css
+//                  ^^^^^ keyword.other.timing.css
 
     top: steps(1, end);
-//                ^^^ support.keyword.timing-direction.css
+//                ^^^ keyword.other.timing
 
     top: steps(1, middle);
-//                ^^^^^^ support.keyword.timing-direction.css
+//                ^^^^^^ keyword.other.timing
 }
 
 .test-shape-functions {
     top: circle(at top 5.5e20em);
 //       ^^^^^^ support.function.shape.css
-//              ^^ keyword.other.css
+//              ^^ keyword.other
 //                 ^^^ support.constant.property-value.css
 //                     ^^^^^^^^ constant.numeric
 
     top: ellipse(at 0%);
 //       ^^^^^^^ support.function.shape.css
-//               ^^ keyword.other.css
+//               ^^ keyword.other
 //                  ^^ constant.numeric
 
     top: ellipse(closest-side);
@@ -1733,7 +1727,7 @@ $gutter-width: 10px;
     top: inset(1.1px round 50%);
 //       ^^^^^ support.function.shape.css
 //             ^^^^^ constant.numeric
-//                   ^^^^^ keyword.other.css
+//                   ^^^^^ keyword.other
 
     top: rect(auto);
 //       ^^^^ support.function.shape.css
@@ -1789,14 +1783,14 @@ $gutter-width: 10px;
     top: toggle(5px red preserve-3d);
 //       ^^^^^^ support.function.toggle.css
 //              ^^^ constant.numeric
-//                  ^^^ support.constant.color.w3c-standard-color-name.css
+//                  ^^^ support.constant.color
 //                      ^^^^^^^^^^^ support.constant.property-value.css
 }
 
 .test-attr-function {
     top: attr(*|c);
 //       ^^^^ support.function.attr.css
-//            ^ entity.name.namespace.wildcard.css
+//            ^ variable.language.wildcard
 //             ^ punctuation.separator.namespace.css
 //              ^ entity.other.attribute-name.css
 
@@ -1806,7 +1800,7 @@ $gutter-width: 10px;
 
     top: attr(size px, auto);
 //            ^^^^ entity.other.attribute-name.css
-//                 ^^ constant.numeric.suffix
+//                 ^^ keyword.other.unit
 //                   ^ punctuation.separator.sequence.css
 //                     ^^^^ support.constant.property-value.css
 
@@ -1828,19 +1822,13 @@ $gutter-width: 10px;
 //       ^^^^^ support.function.image.css
 //             ^^^ string.quoted.double.css
 
-    top: image(a);
-//             ^ string.unquoted.css
-
     top: image("a", rgb(0, 0, 0));
 //                ^ punctuation.separator.sequence.css
 //                      ^ constant.numeric
 
     top: image-set("a" 1x, a 4dpi);
 //                 ^^^ string.quoted.double.css
-//                     ^^ constant.numeric
-//                      ^ constant.numeric.suffix
 //                       ^ punctuation.separator.sequence.css
-//                         ^ string.unquoted.css
 //                           ^^^^ constant.numeric
 
     top: cross-fade(50% "a", b);
@@ -1848,7 +1836,6 @@ $gutter-width: 10px;
 //                  ^^^ constant.numeric
 //                      ^^^ string.quoted.double.css
 //                         ^ punctuation.separator.sequence.css
-//                           ^ string.unquoted.css
 }
 
 .test-gradient-functions {
@@ -1858,10 +1845,10 @@ $gutter-width: 10px;
     top: linear-gradient(45deg, white);
 //                       ^^^^^ constant.numeric
 //                            ^ punctuation.separator.sequence.css
-//                              ^^^^^ support.constant.color.w3c-standard-color-name.css
+//                              ^^^^^ support.constant.color
 
     top: linear-gradient(to top left);
-//                       ^^ keyword.other.css
+//                       ^^ keyword.other
 //                          ^^^ support.constant.property-value.css
 //                              ^^^^ support.constant.property-value.css
 
@@ -1876,13 +1863,13 @@ $gutter-width: 10px;
 //       ^^^^^^^^^^^^^^^ support.function.gradient.css
 
     top: radial-gradient(circle at top left);
-//                       ^^^^^^ keyword.other.css
-//                              ^^ keyword.other.css
+//                       ^^^^^^ keyword.other
+//                              ^^ keyword.other
 //                                 ^^^ support.constant.property-value.css
 //                                     ^^^^ support.constant.property-value.css
 
     top: radial-gradient(red, blue);
-//                       ^^^ support.constant.color.w3c-standard-color-name.css
+//                       ^^^ support.constant.color
 //                          ^ punctuation.separator.sequence.css
 
     top: repeating-radial-gradient();
@@ -1899,23 +1886,23 @@ $gutter-width: 10px;
 .test-counter-functions {
     top: counter(name, decimal-leading-zero);
 //       ^^^^^^^ support.function.counter.css
-//               ^^^^ entity.other.counter-name.css string.unquoted.css
+//               ^^^^ entity.other.counter-name.css
 //                   ^ punctuation.separator.sequence.css
-//                     ^^^^^^^^^^^^^^^^^^^^ support.constant.property-value.counter-style.css
+//                     ^^^^^^^^^^^^^^^^^^^^ support.constant.counter-style-name
 
     top: counters(name, "str", none);
 //       ^^^^^^^^ support.function.counter.css
-//                ^^^^ entity.other.counter-name.css string.unquoted.css
+//                ^^^^ entity.other.counter-name
 //                    ^ punctuation.separator.sequence.css
 //                      ^^^^^ string.quoted.double.css
 //                           ^ punctuation.separator.sequence.css
-//                             ^^^^ support.constant.property-value.counter-style.css
+//                             ^^^^ support.constant
 
     top: symbols(fixed "\2020" url());
 //       ^^^^^^^ support.function.counter.css
-//               ^^^^^ support.constant.symbol-type.css
+//               ^^^^^ support.constant
 //                     ^^^^^^^ string.quoted.double.css
-//                             ^^^ support.function.url.css
+//                             ^^^ support.function
 }
 
 .test-grid-functions {
@@ -1925,10 +1912,10 @@ $gutter-width: 10px;
 //                     ^^^^^^^^^ support.constant.property-value.css
 
     top: repeat(auto-fit, 2fr minmax(auto) 5%);
-//              ^^^^^^^^ support.keyword.repetitions.css
+//              ^^^^^^^^ keyword.other.grid
 //                      ^ punctuation.separator.sequence.css
 //                        ^^^ constant.numeric
-//                            ^^^^^^ support.function.grid.css
+//                            ^^^^^^ support.function
 //                                   ^^^^ support.constant.property-value.css
 //                                         ^^ constant.numeric
 
@@ -1971,24 +1958,24 @@ $gutter-width: 10px;
 
     grid-template: repeat(2, var(--size)) / repeat(2, 50%);
 //                           ^^^ support.function.var.css
-//                               ^^^^^^ support.type.custom-property.css
+//                               ^^^^^^ variable.other.custom-property
 //                                     ^^ punctuation.section.group.end.css
 //                                          ^^^^^^ support.function.grid.css
     grid-template-columns:
       [a-line-name] auto
-//    ^ punctuation.section.begin.css
+//    ^ punctuation.section
 //     ^^^^^^^^^^^ string.unquoted.line-name.css
-//                ^ punctuation.section.end.css
+//                ^ punctuation.section
       [b]     minmax(min-content, 1fr)
       [b c d] repeat(2, [e] 40px)
-//    ^ punctuation.section.begin.css
+//    ^ punctuation.section
 //     ^ string.unquoted.line-name.css
 //      ^ - string.unquoted.line-name.css
 //       ^ string.unquoted.line-name.css
-//          ^ punctuation.section.end.css
-//                      ^ punctuation.section.begin.css
+//          ^ punctuation.section
+//                      ^ punctuation.section
 //                       ^ string.unquoted.line-name.css
-//                        ^ punctuation.section.end.css
+//                        ^ punctuation.section
               repeat(5, auto);
 }
 
@@ -2049,8 +2036,7 @@ $gutter-width: 10px;
 .test-var-function {
     top: var(--name);
 //       ^^^         support.function.var.css
-//           ^^      punctuation.definition.custom-property.css
-//             ^^^^  support.type.custom-property.name.css
+//             ^^^^  variable.other.custom-property
 }
 
 .test-custom-tags > div > span + cust·m-tÀg > div-cøstom-tag ~ form-Çust😀m-tag.classname:last-child:hover {}
@@ -2105,14 +2091,14 @@ $gutter-width: 10px;
 .generic-font-family { font-family: my-serif, serif }
 //                                  ^^^^^^^^ string.unquoted
 //                                          ^ - string
-//                                            ^^^^^ support.constant.font-name
+//                                            ^^^^^ support.constant
 .generic-font-family2 { font-family: sans-serif , fantasy , system-ui; }
-//                                   ^^^^^^^^^^ support.constant.font-name
-//                                                ^^^^^^^ support.constant.font-name
-//                                                          ^^^^^^^^^ support.constant.font-name
+//                                   ^^^^^^^^^^ support.constant
+//                                                ^^^^^^^ support.constant
+//                                                          ^^^^^^^^^ support.constant
 .generic-font-family3 {
     font-family: cursive
-//               ^^^^^^^ support.constant.font-name
+//               ^^^^^^^ support.constant
 }
 .generic-font-family4 {
     font-family: droid serif;
@@ -2121,18 +2107,12 @@ $gutter-width: 10px;
 
 .variable-beginnings {
     --1x: url(data:image/png;base64,PNG);
-//  ^^^^ support.type.custom-property
-//  ^^ punctuation.definition.custom-property
-//    ^^ support.type.custom-property.name
+//  ^^^^ entity.other.custom-property
 //      ^ punctuation.separator.key-value
     background-image: var(--1x);
-//                        ^^^^ support.type.custom-property
-//                        ^^ punctuation.definition.custom-property
-//                          ^^ support.type.custom-property.name
+//                          ^^ variable.other.custom-property
     --\ff: 5px;
-//  ^^^^^ support.type.custom-property
-//  ^^ punctuation.definition.custom-property
-//    ^^^ support.type.custom-property.name
+//  ^^^^^ entity.other.custom-property
 //       ^ punctuation.separator.key-value
 }
 
@@ -2153,12 +2133,12 @@ $gutter-width: 10px;
 //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.css
 //  ^^^^ support.type.property-name.css
 //      ^ punctuation.separator.key-value.css
-//        ^ punctuation.section.begin.css
+//        ^ punctuation.section
 //         ^^^^^^^^^ string.unquoted.line-name.css
-//                  ^ punctuation.section.end.css
+//                  ^ punctuation.section
 //                    ^^^ string.quoted.double.css
 //                        ^^^^^ meta.number
-//                              ^ punctuation.section.begin.css
+//                              ^ punctuation.section
 //                               ^^^^^^^^^ string.unquoted.line-name.css
 //                                        ^ punctuation
  }

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -177,7 +177,7 @@ selector-ish::before[data-type="text"]:not(:first-child),
 //              ^^^^^ support.type.vendor-prefix.css
 
     -ms-text-size-adjust: 100%;
-//  ^^^^^^^^^^^^^^^^^^^^ meta.property-name.css
+//      ^^^^^^^^^^^^^^^^ meta.property-name.css
 //  ^^^^ support.type.vendor-prefix.css
   }
   span:hover { }

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -462,6 +462,8 @@ color: format(
     content: "I ate #{$value} pies!";
 //                    ^^^^^^ variable.other.sass
 //                    ^ punctuation.definition.variable.sass
+    padding: calc(#{spacer/2 - 5px});
+//                ^^^^^^^^^^^^^^^^^ meta.group.interpolation
     @include breathe(somestring);
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.sass
 //  ^^^^^^^^ keyword.control.directive.sass

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -644,10 +644,10 @@ $list: (top, bottom, right, position, height);
 .selector {
   color: nth(map.merge($map, $map2), 3);
 //       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.property-value.css meta.function-call.sass
-//       ^^^ support.function.sass
+//       ^^^ support.function
 //          ^ punctuation.section.group.begin
 //           ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function-call.arguments
-//           ^^^^^^^^^ support.function.sass
+//           ^^^^^^^^^ support.function
 //           ^^^ entity.name.namespace
 //              ^ punctuation
 //                    ^ punctuation.section.group.begin
@@ -687,19 +687,19 @@ $translucent-red: rgba(#E82C0C, 0.5);
 //                            ^ punctuation.separator.sequence.css
 $translucent-red: rgba(red, 0.5);
 //                ^^^^ support.function.color.css
-//                     ^^^ support.constant.color.w3c-standard-color-name.css
+//                     ^^^ support.constant.color
 //                        ^ punctuation.separator.sequence.css
 $translucent-red: hsla(240deg 100% 50% / 5%);
 //                ^^^^ support.function.color.css
 //                        ^^^ constant.numeric.suffix
 p {
   color: opacify($translucent-red, 0.3);
-//       ^^^^^^^ support.function.sass
+//       ^^^^^^^ support.function
 //              ^ punctuation.section.group.begin
 //                               ^ punctuation.separator.sequence.css
 //                                    ^ punctuation.section.group.end
   background-color: transparentize(#E82C0C, 0.25);
-//                  ^^^^^^^ support.function.sass
+//                  ^^^^^^^ support.function
 //                                 ^^^ constant.other.color.rgb-value.css
   background-color: color($mark, custom-function(unthemed));
 //                        ^ variable.other
@@ -714,14 +714,14 @@ p {
 $grid-width: 40px;
 $gutter-width: 10px;
 @function grid-width($n) {
-//<- meta.function.declaration.sass keyword.control.at-rule.sass
+//<- meta.function.declaration.sass keyword.control.directive
 // ^^^^^^^^^^^^^^^^^^^^^^ meta.function.declaration.sass
-// ^^^^^^ keyword.control.at-rule.sass
+// ^^^^^^ keyword.control.directive
 //        ^^^^^^^^^^ entity.name.function.sass
 //                  ^ meta.function.parameters.sass punctuation.section.group.begin.sass
   @return $n * $grid-width + ($n - 1) * $gutter-width;
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.sass
-// ^^^^^^ keyword.control.at-rule.return.sass
+// ^^^^^^ keyword.control.directive
 //        ^^ variable.other.sass
 //             ^^^^^^^^^^^ variable.other.sass
 //                            ^^ variable.other.sass
@@ -748,59 +748,59 @@ $gutter-width: 10px;
 */
 @use 'something else' as *;
 // <- punctuation.definition.keyword.sass
-// ^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^ keyword.control.at-rule.module.sass
+// ^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
+// ^ keyword.control.directive.module
 //    ^^^^^^^^^^^^^^ string.quoted
 //                    ^^ keyword.control
 //                       ^ constant.language.import-all
-//                        ^ punctuation.terminator.rule.sass
+//                        ^ punctuation.terminator.rule
 @use "src/corners";
 // <- punctuation.definition.keyword.sass
-// ^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^ keyword.control.at-rule.module.sass
+// ^^^^^^^^^^^^^^^ meta.at-rule.module
+// ^ keyword.control.directive.module
 //    ^^^^^^^^^^^^ string.quoted
-//                ^ punctuation.terminator.rule.sass
+//                ^ punctuation.terminator.rule
 @use /*import bootstrap*/ "bootstrap" as b;
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
 //                                    ^^ keyword.control
-// ^ keyword.control.at-rule.module.sass
+// ^ keyword.control.directive.module
 //                ^ comment
 @forward "functions";
 // <- punctuation.definition.keyword.sass
 // ^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^^^^^ keyword.control.at-rule.module.sass
+// ^^^^^ keyword.control.directive.module.sass
 //       ^^^^^^^^^^^ string.quoted
-//                  ^ punctuation.terminator.rule.sass
+//                  ^ punctuation.terminator.rule
 @forward "functions" show color-yiq;
 // <- punctuation.definition.keyword.sass
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^ keyword.control.at-rule.module.sass
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
+// ^ keyword.control.directive.module.sass
 //                   ^^^^ keyword.control
 //                        ^^^^^^^^^ meta.generic-name.sass
-//                                 ^ punctuation.terminator.rule.sass
+//                                 ^ punctuation.terminator.rule
 @forward "functions" hide assert-ascending, $some_variable;
 // <- punctuation.definition.keyword.sass
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
-// ^ keyword.control.at-rule.module.sass
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
+// ^ keyword.control.directive.module.sass
 //                   ^^^^ keyword.control
 //                        ^^^^^^^^^^^^^^^ meta.generic-name.sass
 //                                        ^ punctuation.separator.sequence.css
 //                                          ^ variable.other.sass
-//                                                        ^ punctuation.terminator.rule.sass
+//                                                        ^ punctuation.terminator.rule
 @forward "theme" as theme-*;
-// ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
+// ^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
 //                  ^^^^^^^ meta.generic-name.sass
 //                        ^ constant.language.import-all.sass
 @use 'opinionated' with ($black: #333);
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
 //                 ^^^^ keyword.control.with.sass
 //                       ^^^^ variable
 //                               ^^^^ constant
 //                             ^ punctuation
 //                      ^ punctuation.section.group.begin.sass
 //                                   ^ punctuation.section.group.end.sass
-//                                    ^ punctuation.terminator.rule.sass
+//                                    ^ punctuation.terminator.rule
 @forward "sass:meta" as meta with (
 // ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.module
 //                   ^^ keyword.control.as.sass
@@ -847,7 +847,7 @@ $gutter-width: 10px;
 //  ^ meta.at-rule constant.numeric
 //    ^ keyword.operator.arithmetic.sass
 //      ^ constant.numeric
-//             ^ punctuation.section.property-list.begin.css
+//             ^ punctuation.section.block.begin.css
 @if $scope == ie9 { border: 1px solid; }
 //              ^ - constant.numeric
 @if null       { border: 3px double; }
@@ -855,14 +855,16 @@ $gutter-width: 10px;
 @mixin adjust-location($x, $y) {
   @if unitless($x) {
 //    ^^^^^^^^^^^^ meta.function-call.sass
-//    ^^^^^^^^ support.function.sass
-//              ^ meta.group.css meta.function-call.arguments.css variable.other.sass
+//    ^^^^^^^^ support.function
+//              ^ meta.group.css
+//              ^ meta.function-call.arguments.css
+//              ^ variable.other.sass
     @debug 10em + 12em;
 //         ^^^^ constant.numeric
 //           ^ meta.at-rule constant.numeric
 //              ^ keyword.operator.arithmetic.sass
 //                ^^^^ constant.numeric
-//                    ^ punctuation.terminator.rule.sass
+//                    ^ punctuation.terminator.rule
     @warn "Assuming #{$x} to be in pixels";
 //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.quoted.double.css
 //                  ^^^^^ meta.group.interpolation.sass
@@ -905,15 +907,15 @@ $gutter-width: 10px;
 @for $i from 1 through 3 {
   .item-#{$i} { width: 2em * $i; }
 }
-@each $animal in puma, sea-slug, egret, salamander {}
-// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.each.sass
+@each $animal in puma, 'sea-slug', $egret, 10px {}
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.at-rule.each.sass
 //                                                 ^ - meta.at-rule.each.sass
-//                                                 ^ punctuation.section.property-list.begin.css
+//                                              ^ punctuation.section.block.begin.css
 //    ^^^^^^^ variable.other.sass
 //            ^^ keyword.operator
-//               ^^^^ string.unquoted
-//                     ^^^^^^ string.unquoted
+//               ^^^^ constant.other
 //                   ^ punctuation.separator
+//                     ^^^^^^ string
 @each $header, $size in (h1: 2em, h2: 1.5em, h3: 1.2em) {
 //    ^^^^^^^ variable.other.sass
 //           ^ punctuation.separator
@@ -953,7 +955,7 @@ $gutter-width: 10px;
 }
 
 .test-punctuation {
-//                ^ punctuation.section.property-list.begin.css
+//                ^ punctuation.section.block.begin.css
     top: 1px;
 //     ^      punctuation.separator.key-value.css
 //          ^ punctuation.terminator.rule.css

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -1,3 +1,5 @@
+/* SYNTAX TEST "Packages/Sass/Syntaxes/SCSS.sublime-syntax" */
+
 /*
 Correctly differentiate between properties and selectors,
 especially with pseudo-stuff because of the :

--- a/Tests/syntax_test_scss.scss
+++ b/Tests/syntax_test_scss.scss
@@ -3,8 +3,8 @@
 # this ensures Jekyll reads the file to be transformed into CSS later
 ---
 //^ frontmatter.jekyll punctuation.section.frontmatter.end.jekyll
-//
 
+/*
 Correctly differentiate between properties and selectors,
 especially with pseudo-stuff because of the :
 */

--- a/sass_completions.py
+++ b/sass_completions.py
@@ -824,8 +824,8 @@ class SassCompletions(sublime_plugin.EventListener):
 
         pt = locations[0]
 
-        # completions are for properties, not selectors, only inside sass/scss files
-        if not match_selector(view, pt, 'source.sass - meta.selector.css, source.scss - meta.selector.css'):
+        # completions only inside sass/scss files
+        if not match_selector(view, pt, 'source.sass, source.scss'):
             return None
 
         if not match_selector(view, pt, ''):

--- a/sass_completions.py
+++ b/sass_completions.py
@@ -1,595 +1,783 @@
 import re
 import sublime
 import sublime_plugin
+import timeit
+
+from functools import cached_property, wraps
+
+__all__ = ['CSSCompletions']
 
 KIND_CSS_PROPERTY = (sublime.KIND_ID_KEYWORD, "p", "property")
 KIND_CSS_FUNCTION = (sublime.KIND_ID_FUNCTION, "f", "function")
 KIND_CSS_CONSTANT = (sublime.KIND_ID_VARIABLE, "c", "constant")
 
-# Prepare some common property values for when there is more than one way to
-# specify a certain value type. The color value for example can be specified
-# by `rgb()` or `hsl()` and so on. Example where `|` denotes the caret:
-#
-#     color: rg|   -->   color: rgb(|);
-#
-# This is also helpful when multiple properties share the same value types.
-COMMON_VALUES = {
-    'animation_direction': [
-        'alternate', 'alternate-reverse', 'normal', 'reverse'
-    ],
-    'absolute_size': [
-        'xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large'
-    ],
-    'absolute_weight': [
-        '100', '200', '300', '400', '500', '600', '700', '800', '900'
-    ],
-    'basic_shape': ['inset($1)', 'circle($1)', 'ellipse($1)', 'polygon($1)'],
-    'blend_mode': [
-        'normal', 'multiply', 'screen', 'overlay', 'darken', 'lighten',
-        'color-dodge', 'color-burn', 'hard-light', 'soft-light', 'difference',
-        'exclusion', 'hue', 'saturation', 'color', 'luminosity'
-    ],
-    'border_style': [
-        'none', 'hidden', 'dotted', 'dashed', 'solid', 'double',
-        'groove', 'ridge', 'inset', 'outset'
-    ],
-    'border_width': ['thin', 'medium', 'thick'],
-    'break_before_after': [
-        'always', 'left', 'right', 'recto', 'verso', 'page', 'column', 'region'
-    ],
-    'break_inside': [
-        'auto', 'avoid', 'avoid-page', 'avoid-column', 'avoid-region'
-    ],
-    'color': [
-        'currentColor',
-        'transparent',
-        ['rgb()', 'rgb(${1:0}, ${2:0}, ${3:0})'],
-        ['rgba()', 'rgba(${1:0}, ${2:0}, ${3:0}, ${4:1.0})'],
-        ['hsl()', 'hsl(${1:0}, ${2:100%}, ${3:50%})'],
-        ['hsla()', 'hsla(${1:0}, ${2:100%}, ${3:50%}, ${4:1.0})'],
-        # Named colors
-        'aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige',
-        'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown',
-        'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral',
-        'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue',
-        'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgrey', 'darkgreen',
-        'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange',
-        'darkorchid', 'darkred', 'darksalmon', 'darkseagreen',
-        'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise',
-        'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey',
-        'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia',
-        'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'grey',
-        'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred', 'indigo',
-        'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen',
-        'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan',
-        'lightgoldenrodyellow', 'lightgray', 'lightgrey', 'lightgreen',
-        'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue',
-        'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow',
-        'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine',
-        'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen',
-        'mediumslateblue', 'mediumspringgreen', 'mediumturquoise',
-        'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose',
-        'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab',
-        'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen',
-        'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru',
-        'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red',
-        'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown',
-        'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue',
-        'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan',
-        'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white',
-        'whitesmoke', 'yellow', 'yellowgreen',
-        # Sass color functions
-        'adjust-color(${1:color}, ${2:component})',
-        'adjust-hue(${1:color}, ${2:degrees})',
-        'change-color(${1:color}, ${2:component})',
-        'complement(${1:color})',
-        'darken(${1:color}, ${2:amount})',
-        'desaturate(${1:color}, ${2:amount})',
-        'fade-in(${1:color}, ${1:amount})',
-        'fade-out(${1:color}, ${1:amount})',
-        'grayscale(${1:color})',
-        'ie-hex-str(${1:color})',
-        'invert(${1:color}, ${2:weight})',
-        'lighten(${1:color}, ${2:amount})',
-        'mix(${1:color}1, ${2:color}2, ${3:weight})',
-        'opacify(${1:color}, ${1:amount})',
-        'rgba(${1:color}, ${2:alpha})',
-        'saturate(${1:color}, ${2:amount})',
-        'scale-color(${1:color}, ${2:component})',
-        'transparentize(${1:color}, ${2:amount})'
-    ],
-    'font_variant_alternates': [
-        'normal', 'historical-forms', 'stylistic($1)', 'styleset($1)',
-        'character-variant($1)', 'swash($1)', 'ornaments($1)', 'annotation($1)'
-    ],
-    'generic_name': [
-        'serif', 'sans-serif', 'cursive', 'fantasy', 'monospace'
-    ],
-    'gradient': [
-        ['conic-gradient()', 'conic-gradient($1)'],
-        ['linear-gradient()', 'linear-gradient($1)'],
-        ['radial-gradient()', 'radial-gradient($1)'],
-        ['repeating-conic-gradient()', 'repeating-conic-gradient($1)'],
-        ['repeating-linear-gradient()', 'repeating-linear-gradient($1)'],
-        ['repeating-radial-gradient()', 'repeating-radial-gradient($1)']
-    ],
-    'grid': [
-        ['repeat()', 'repeat(${1:2}, ${2:1fr})'],
-        ['minmax()', 'minmax(${1:100px}, ${2:1fr})'],
-    ],
-    'list_style_type': [
-        'none', 'inline', 'disc', 'circle', 'square', 'decimal',
-        'decimal-leading-zero', 'arabic-indic', 'binary', 'bengali',
-        'cambodian', 'khmer', 'devanagari', 'gujarati', 'gurmukhi',
-        'kannada', 'lower-hexadecimal', 'lao', 'malayalam', 'mongolian',
-        'myanmar', 'octal', 'oriya', 'persian', 'urdu', 'telugu',
-        'tibetan', 'thai', 'upper-hexadecimal', 'lower-roman',
-        'upper-roman', 'lower-greek', 'lower-alpha', 'lower-latin',
-        'upper-alpha', 'upper-latin', 'afar', 'ethiopic-halehame-aa-et',
-        'ethiopic-halehame-aa-er', 'amharic', 'ethiopic-halehame-am-et',
-        'amharic-abegede', 'ethiopic-abegede-am-et', 'cjk-earthly-branch',
-        'cjk-heavenly-stem', 'ethiopic', 'ethiopic-halehame-gez',
-        'ethiopic-abegede', 'ethiopic-abegede-gez', 'hangul-consonant',
-        'hangul', 'lower-norwegian', 'oromo', 'ethiopic-halehame-om-et',
-        'sidama', 'ethiopic-halehame-sid-et', 'somali',
-        'ethiopic-halehame-so-et', 'tigre', 'ethiopic-halehame-tig',
-        'tigrinya-er', 'ethiopic-halehame-ti-er', 'tigrinya-er-abegede',
-        'ethiopic-abegede-ti-er', 'tigrinya-et', 'ethiopic-halehame-ti-et',
-        'tigrinya-et-abegede', 'ethiopic-abegede-ti-et', 'upper-greek',
-        'upper-norwegian', 'asterisks', 'footnotes', 'hebrew', 'armenian',
-        'lower-armenian', 'upper-armenian', 'georgian', 'cjk-ideographic',
-        'hiragana', 'katakana', 'hiragana-iroha', 'katakana-iroha'
-    ],
-    'number': [
-        'abs(${1:number})',
-        'ceil(${1:number})',
-        'floor(${1:number})',
-        'max(${1:numbers…})',
-        'min(${1:numbers…})',
-        'random()',
-        'round(${1:number})'
-    ],
-    'percentage': [
-        'percentage(${1:number})'
-    ],
-    'position': ['top', 'right', 'bottom', 'left', 'center'],
-    'relative_size': ['larger', 'smaller'],
-    'relative_weight': ['bolder', 'lighter'],
-    'repeat_style': [
-        'repeat', 'repeat-x', 'repeat-y', 'space', 'round', 'no-repeat'
-    ],
-    'string': [
-        '\"$1\"',
-        'quote(${1:string})',
-        'unquote(${1:string})',
-        'str-slice(${1:string}, ${2:start})',
-        'to-lower-case(${1:string})',
-        'to-upper-case(${1:string})'
-    ],
-    'timing_function': [
-        'ease',
-        'ease-in',
-        'ease-out',
-        'ease-in-out',
-        'linear',
-        ['cubic-bezier()', 'cubic-bezier(${1:0.0}, ${2:0.0}, ${3:1.0}, ${4:1.0})'],
-        'step-start',
-        'step-end',
-        ['steps()', 'steps(${1:2}, ${2:start})'],
-    ],
-    'uri': ['url($1)'],
-}
-
-PROPERTY_DICT = {
-    'align-content': [
-        'center', 'flex-end', 'flex-start', 'space-around', 'space-between',
-        'stretch'
-    ],
-    'align-items': ['baseline', 'center', 'flex-end', 'flex-start', 'stretch'],
-    'align-self': ['auto', 'baseline', 'center', 'flex-end', 'flex-start', 'stretch'],
-    'alignment-baseline': [
-        'baseline', 'middle', 'auto', 'before-edge', 'after-edge', 'central',
-        'text-before-edge', 'text-after-edge', 'ideographic', 'alphabetic',
-        'hanging', 'mathematical'
-    ],
-    'animation': [
-        'none', '<timing_function>', 'infinite', '<animation_direction>',
-        'forwards', 'backwards', 'both', 'running', 'paused'
-    ],
-    'animation-name': ['none', '<custom-ident>'],
-    'animation-duration': ['<time>'],
-    'animation-timing-function': ['<timing_function>'],
-    'animation-delay': ['<time>'],
-    'animation-iteration-count': ['infinite', '<number>'],
-    'animation-direction': ['<animation_direction>'],
-    'animation-fill-mode': ['none', 'forwards', 'backwards', 'both'],
-    'animation-play-state': ['running', 'paused'],
-    'backface-visibility': ['visible', 'hidden'],
-    'background': [
-        '<color>', '<gradient>', '<position>', '<uri>',
-        'repeat', 'repeat-x', 'repeat-y', 'no-repeat', 'scroll', 'fixed'
-    ],
-    'background-attachment': ['fixed', 'local', 'scroll'],
-    'background-blend-mode': ['<blend_mode>'],
-    'background-clip': ['border-box', 'padding-box', 'content-box'],
-    'background-color': ['<color>'],
-    'backdrop-filter': [
-        '<uri>', 'url($1)', 'blur($1)', 'brightness($1)', 'contrast($1)',
-        'drop-shadow($1)', 'grayscale($1)', 'hue-rotate($1)', 'invert($1)',
-        'opacity($1)', 'saturate($1)', 'sepia($1)'
-    ],
-    'background-image': ['<uri>', 'none'],
-    'background-origin': ['border-box', 'padding-box', 'content-box'],
-    'background-position': ['<position>'],
-    'background-repeat': ['<repeat_style>'],
-    'background-size': ['auto', 'cover', 'contain', '<length>', '<percentage>'],
-    'baseline-shift': ['baseline', 'sub', 'super'],
-    'border': ['<border_width>', '<border_style>', '<color>'],
-    'border-width': ['<border_width>'],
-    'border-style': ['<border_style>'],
-    'border-color': ['<color>'],
-    'border-collapse': ['collapse', 'separate'],
-    'border-radius': ['<length>', '<percentage>'],
-    'border-spacing': ['<length>'],
-    'border-image': [
-        '<border-image-source>', '<border-image-slice>', '<border-image-width>',
-        '<border-image-outset>', '<border-image-repeat>'
-    ],
-    'border-image-outset': ['<length>', '<number>'],
-    'border-image-repeat': ['stretch', 'repeat', 'round', 'space'],
-    'border-image-slice': ['fill', '<number>', '<percentage>'],
-    'border-image-source': ['none', '<image>'],
-    'border-image-width': ['<length>', '<percentage>', '<number>', 'auto'],
-    'border-top | border-right | border-bottom | border-left': [
-        '<border_width>', '<border_style>', '<color>'
-    ],
-    'border-top-color | border-right-color | border-bottom-color | border-left-color': ['<color>'],
-    'border-top-left-radius | border-top-right-radius | border-bottom-right-radius | border-bottom-left-radius': [
-        '<length>', '<percentage>'
-    ],
-    'border-top-style | border-right-style | border-bottom-style | border-left-style': ['<border_style>'],
-    'border-top-width | border-right-width | border-bottom-width | border-left-width': ['<border_width>'],
-    'bottom': ['<length>', '<percentage>', 'auto'],
-    'box-decoration-break': ['slice', 'clone'],
-    'box-shadow': ['none', 'inset', '<color>'],
-    'box-sizing': ['content-box', 'border-box'],
-    'break-after': ['<break_before_after>', '<break_inside>'],
-    'break-before': ['<break_before_after>', '<break_inside>'],
-    'break-inside': ['<break_inside>'],
-    'caption-side': ['top', 'bottom'],
-    'clear': ['none', 'left', 'right', 'both'],
-    'clip': [
-        ['rect()', 'rect(${1:0}, ${2:0}, ${3:0}, ${4:0})'],
-        'auto'
-    ],
-    'clip-path': ['none', '<uri>', '<basic_shape>'],
-    'clip-rule': ['nonzero', 'evenodd'],
-    'color': ['<color>'],
-    'color-interpolation': ['auto', 'sRGB', 'linearRGB'],
-    'color-interpolation-filters': ['auto', 'sRGB', 'linearRGB'],
-    'color-profile': ['auto', 'sRGB', '<uri>'],
-    'color-rendering': ['auto', 'optimizeSpeed', 'optimizeQuality'],
-    'columns': ['auto'],
-    'column-count': ['auto', '<number>'],
-    'column-fill': ['auto', 'balance'],
-    'column-gap': ['normal', '<length>'],
-    'column-rule': ['<border_width>', '<border_style>', '<color>'],
-    'column-rule-color': ['<color>'],
-    'column-rule-style': ['<border_style>'],
-    'column-rule-width': ['<border_width>'],
-    'column-span': ['none'],
-    'column-width': ['auto', '<length>'],
-    'content': [
-        'none', 'normal', '<string>', '<uri>', 'attr($1)',
-        'open-quote', 'close-quote', 'no-open-quote', 'no-close-quote',
-        'counter($1)'
-    ],
-    'counter-increment': ['none', '<custom_ident>', '<integer>'],
-    'counter-reset': ['none', '<custom_ident>', '<integer>'],
-    'cursor': [
-        '<uri>', 'auto', 'default', 'none', 'context-menu', 'help',
-        'pointer', 'progress', 'wait', 'cell', 'crosshair', 'text',
-        'vertical-text', 'alias', 'copy', 'move', 'no-drop', 'not-allowed',
-        'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize',
-        'se-resize', 'sw-resize', 'w-resize', 'ew-resize', 'ns-resize',
-        'nesw-resize', 'nwse-resize', 'col-resize', 'row-resize',
-        'all-scroll', 'zoom-in', 'zoom-out'
-    ],
-    'direction': ['ltr', 'rtl'],
-    'display': [
-        'none', 'inline', 'block', 'contents', 'list-item', 'inline-block',
-        'inline-table', 'table', 'table-cell', 'table-column',
-        'table-column-group', 'table-footer-group', 'table-header-group',
-        'table-row', 'table-row-group', 'table-caption', 'flex', 'inline-flex',
-        'grid', 'inline-grid', 'ruby', 'ruby-base', 'ruby-text',
-        'ruby-base-container', 'ruby-text-container', 'run-in'
-    ],
-    'dominant-baseline': [
-        'auto', 'middle', 'central', 'text-before-edge',
-        'text-after-edge', 'ideographic', 'alphabetic', 'hanging',
-        'mathematical', 'use-script', 'no-change', 'reset-size'
-    ],
-    'empty-cells': ['show', 'hide'],
-    'fill': ['<color>'],
-    'fill-rule': ['nonzero', 'evenodd'],
-    'filter': [
-        '<uri>',
-        'blur(${1:5px})',
-        'brightness(${1:1.0})',
-        'contrast(${1:100%})',
-        ['drop-shadow()', 'drop-shadow(${1:1px} ${2:1px})'],
-        'grayscale(${1:50%})',
-        'hue-rotate(${1:90deg})',
-        'invert(${1:50%})',
-        'opacity(${1:100%})',
-        'saturate(${1:50%})',
-        'sepia(${1:50%})'
-    ],
-    'flex': ['none'],
-    'flex-grow': ['<number>'],
-    'flex-shrink': ['<number>'],
-    'flex-basis': ['auto', '<width>'],
-    'flex-flow': [
-        'row', 'row-reverse', 'column', 'column-reverse', 'nowrap', 'wrap',
-        'wrap-reverse'
-    ],
-    'flex-direction': ['row', 'row-reverse', 'column', 'column-reverse'],
-    'flex-wrap': ['nowrap', 'wrap', 'wrap-reverse'],
-    'float': ['left', 'right', 'none'],
-    'flood-color': ['<color>'],
-    'font': [
-        'normal', 'italic', 'oblique', 'normal', 'small-caps', 'normal', 'bold',
-        '<absolute_weight>', '<relative_weight>', 'normal', '<generic_name>',
-        'caption', 'icon', 'menu', 'message-box', 'small-caption', 'status-bar'
-    ],
-    'font-family': ['<generic_name>'],
-    'font-feature-settings': ['normal', '<string>'],
-    'font-kerning': ['auto', 'normal', 'none'],
-    'font-language-override': ['normal', '<string>'],
-    'font-size': [
-        '<absolute_size>', '<relative_size>', '<length>', '<percentage>'
-    ],
-    'font-size-adjust': ['none', '<number>'],
-    'font-style': ['normal', 'italic', 'oblique'],
-    'font-stretch': [
-        'normal', 'semi-condensed', 'condensed', 'extra-condensed',
-        'ultra-condensed', 'semi-expanded', 'expanded', 'extra-expanded',
-        'ultra-expanded'
-    ],
-    'font-synthesis': ['none', 'weight', 'style'],
-    'font-variant': ['normal', 'small-caps'],
-    'font-variant-alternates': ['<font_variant_alternates>'],
-    'font-variant-caps': [
-        'normal', 'small-caps', 'all-small-caps', 'petite-caps',
-        'all-petite-caps', 'unicase', 'titling-case'
-    ],
-    'font-variant-east-asian': [
-        'normal', 'ruby', 'jis78', 'jis83', 'jis90', 'jis04', 'simplified',
-        'traditional'
-    ],
-    'font-variant-ligatures': [
-        'normal', 'none', 'common-ligatures', 'no-common-ligatures',
-        'discretionary-ligatures', 'no-discretionary-ligatures',
-        'historical-ligatures', 'no-historical-ligatures', 'contextual',
-        'no-contextual'
-    ],
-    'font-variant-numeric': [
-        'normal', 'ordinal', 'slashed-zero', 'lining-nums', 'oldstyle-nums',
-        'proportional-nums', 'tabular-nums', 'diagonal-fractions',
-        'stacked-fractions'
-    ],
-    'font-variant-position': ['normal', 'sub', 'super'],
-    'font-weight': ['normal', 'bold', '<absolute_weight>', '<relative_weight>'],
-    'grid': [],
-    'grid-area': [],
-    'grid-auto-columns': ['auto', '<percentage>', '<length>'],
-    'grid-auto-flow': ['row', 'column', 'dense'],
-    'grid-auto-rows': ['auto', '<percentage>', '<length>'],
-    'grid-column-gap': ['<length>', '<percentage>'],
-    'grid-gap': ['<length>', '<percentage>'],
-    'grid-row-gap': ['<length>', '<percentage>'],
-    'grid-template-areas': [],
-    'grid-template-columns': ['auto', '<grid>', '<percentage>', '<length>'],
-    'grid-template-rows': ['auto', '<grid>', '<percentage>', '<length>'],
-    'grid-column': ['<number>'],
-    'grid-column-end': ['<number>'],
-    'grid-column-start': ['<number>'],
-    'grid-row': ['<number>'],
-    'grid-row-end': ['<number>'],
-    'grid-row-start': ['<number>'],
-    'height': ['<length>', '<percentage>', 'auto', 'fit-content'],
-    'hyphens': ['none', 'manual', 'auto'],
-    'image-rendering': [
-        'auto', 'optimizeSpeed', 'optimizeQuality', 'pixelated'
-    ],
-    'ime-mode': ['auto', 'normal', 'active', 'inactive', 'disabled'],
-    'isolation': ['auto', 'isolation'],
-    'justify-content': [
-        'start', 'end', 'flex-start', 'flex-end', 'center', 'left', 'right',
-        'safe start', 'safe end', 'safe flex-start', 'safe flex-end',
-        'safe center', 'safe left', 'safe right', 'unsafe start',
-        'unsafe end', 'unsafe flex-start', 'unsafe flex-end', 'unsafe center',
-        'unsafe left', 'unsafe right', 'normal', 'baseline', 'first baseline',
-        'last baseline', 'space-between', 'space-around', 'space-evenly',
-        'stretch'
-    ],
-    'kerning': ['auto'],
-    'left': ['<length>', '<percentage>', 'auto'],
-    'letter-spacing': ['normal', '<length>'],
-    'lighting-color': ['<color>'],
-    'line-height': ['normal', '<number>', '<length>', '<percentage>'],
-    'list-style': ['<list_style_type>', 'inside', 'outside', '<uri>'],
-    'list-style-image': ['<uri>', 'none'],
-    'list-style-position': ['inside', 'outside'],
-    'list-style-type': ['<list_style_type>'],
-    'margin': ['auto', '<margin-width>'],
-    'margin-top | margin-right | margin-bottom | margin-left': [
-        'auto', '<margin-width>'
-    ],
-    'marker-end | marker-start | marker-mid': ['<uri>', 'none'],
-    'marks': ['crop', 'cross', 'none'],
-    'mask': ['<uri>', 'none'],
-    'mask-type': ['luminance', 'alpha'],
-    'max-height': ['<length>', '<percentage>', 'fit-content', 'none'],
-    'max-width': ['<length>', '<percentage>', 'fit-content', 'none'],
-    'min-height': ['<length>', '<percentage>', 'fit-content'],
-    'min-width': ['<length>', '<percentage>', 'fit-content'],
-    'mix-blend-mode': ['<blend_mode>'],
-    'object-fit': ['fill', 'contain', 'cover', 'none', 'scale-down'],
-    'object-position': ['<position>'],
-    'opacity': ['<number>'],
-    'order': ['<integer>'],
-    'orphans': ['<integer>'],
-    'outline': [
-        '<color>', '<border_style>', '<border_width>', '<length>'
-    ],
-    'outline-color': ['<color>', 'invert'],
-    'outline-offset': ['<length>'],
-    'outline-style': ['<border_style>'],
-    'outline-width': ['<border_width>', '<length>'],
-    'overflow | overflow-x | overflow-y': ['visible', 'hidden', 'scroll', 'auto'],
-    'overflow-wrap': ['normal', 'break-word'],
-    'padding': ['auto', '<padding-width>'],
-    'padding-top | padding-right | padding-bottom | padding-left': [
-        'auto', '<padding-width>'
-    ],
-    'page-break-after': ['auto', 'always', 'avoid', 'left', 'right'],
-    'page-break-before': ['auto', 'always', 'avoid', 'left', 'right'],
-    'page-break-inside': ['avoid', 'auto'],
-    'paint-order': ['normal', 'fill', 'stroke', 'markers'],
-    'perspective': ['none'],
-    'perspective-origin': ['<position>'],
-    'pointer-events': [
-        'auto', 'none', 'all', 'visiblePainted', 'visibleFill', 'visibleStroke',
-        'visible', 'painted', 'fill', 'stroke'
-    ],
-    'position': ['static', 'relative', 'absolute', 'fixed', 'sticky'],
-    'quotes': ['none', '<string>'],
-    'resize': ['none', 'both', 'horizontal', 'vertical'],
-    'right': ['<length>', '<percentage>', 'auto'],
-    'scroll-behavior': ['auto', 'smooth'],
-    'shape-image-threshold': ['<number>'],
-    'shape-margin': ['<length>', '<percentage>'],
-    'shape-outside': [
-        'none', 'margin-box', 'content-box', 'border-box', 'padding-box',
-        '<basic_shape>', '<uri>'
-    ],
-    'shape-rendering': ['auto', 'optimizeSpeed', 'crispEdges', 'geometricPrecision'],
-    'size': [
-        'a3', 'a4', 'a5', 'b4', 'b5', 'landscape', 'ledger', 'legal',
-        'letter', 'portrait'
-    ],
-    'stop-color': ['<color>'],
-    'stroke': ['<color>'],
-    'stroke-dasharray': ['none'],
-    'stroke-linecap': ['butt', 'round', 'square'],
-    'stroke-linejoin': ['round', 'miter', 'bevel'],
-    'table-layout': ['auto', 'fixed'],
-    'text-align': ['left', 'right', 'center', 'justify', 'justify-all'],
-    'text-align-last': ['start', 'end', 'left', 'right', 'center', 'justify'],
-    'text-anchor': ['start', 'middle', 'end'],
-    'text-decoration': [
-        'none', 'underline', 'overline', 'line-through', 'blink'
-    ],
-    'text-decoration-color': ['<color>'],
-    'text-decoration-line': ['none', 'underline', 'overline', 'line-through'],
-    'text-decoration-style': ['solid', 'double', 'dotted', 'dashed', 'wavy'],
-    'text-indent': ['<length>', '<percentage>'],
-    'text-orientation': ['mixed', 'upright', 'sideways', 'use-glyph-orientation'],
-    'text-overflow': ['clip', 'ellipsis'],
-    'text-rendering': [
-        'auto', 'optimizeSpeed', 'optimizeLegibility', 'geometricPrecision'
-    ],
-    'text-shadow': ['none', '<color>'],
-    'text-transform': ['capitalize', 'uppercase', 'lowercase', 'none'],
-    'text-underline-position': ['auto', 'under', 'left', 'right'],
-    'top': ['<length>', '<percentage>', 'auto'],
-    'transform': [
-        ['matrix()', 'matrix(${1:1}, ${2:1}, ${3:1}, ${4:1}, ${5:2}, ${6:2})'],
-        [
-            'matrix3d()',
-            'matrix3d('
-            '${1:1}, ${2:1}, ${3:0}, ${4:0}, '
-            '${5:1}, ${6:1}, ${7:0}, ${8:0}, '
-            '${9:0}, ${10:0}, ${11:1}, ${12:0}, '
-            '${13:2}, ${14:2}, ${15:0}, ${16:1}'
-            ')'
+def get_common_values():
+    common_values = {
+        'animation-direction': [
+            'alternate', 'alternate-reverse', 'normal', 'reverse'
         ],
-        'perspective(${1:0})',
-        'rotate(${1:45deg})',
-        ['rotate3d()', 'rotate3d(${1:0}, ${2:0}, ${3:1}, ${4:45deg})'],
-        'rotateX(${1:45deg})',
-        'rotateY(${1:45deg})',
-        'rotateZ(${1:45deg})',
-        'scale(${1:1.0})',
-        ['scale3d()', 'scale3d(${1:1.0}, ${2:1.0}, ${3:1.0})'],
-        'scaleX(${1:1.0})',
-        'scaleY(${1:1.0})',
-        'scaleZ(${1:1.0})',
-        'skew(${1:10deg})',
-        'skewX(${1:10deg})',
-        'skewY(${1:10deg})',
-        'translate(${1:10px})',
-        ['translate3d()', 'translate3d(${1:10px}, ${2:0px}, ${3:0px})'],
-        'translateX(${1:10px})',
-        'translateY(${1:10px})',
-        'translateZ(${1:10px})',
-        'none'
-    ],
-    'transform-origin': ['<position>'],
-    'transform-style': ['preserve-3d', 'flat'],
-    'transition': [],
-    'transition-delay': ['<time>'],
-    'transition-duration': ['<time>'],
-    'transition-property': ['none', '<custom-ident>'],
-    'transition-timing-function': ['<timing_function>'],
-    'unicode-bidi': ['normal', 'embed', 'bidi-override'],
-    'unicode-range': [],
-    'user-select': ['auto', 'text', 'none', 'contain'],
-    'vertical-align': [
-        'baseline', 'sub', 'super', 'text-top', 'text-bottom', 'middle', 'top',
-        'bottom', '<percentage>', '<length>'
-    ],
-    'visibility': ['visible', 'hidden', 'collapse'],
-    'white-space': ['normal', 'pre', 'nowrap', 'pre-wrap', 'pre-line'],
-    'widows': ['<integer>'],
-    'width': ['<length>', '<percentage>', 'auto', 'fit-content'],
-    'will-change': ['auto', 'contents', 'scroll-position', '<custom-ident>'],
-    'word-break': ['normal', 'break-all', 'keep-all'],
-    'word-spacing': ['normal', '<length>'],
-    'word-wrap': ['normal', 'break-word'],
-    'writing-mode': ['horizontal-tb', 'vertical-rl', 'vertical-lr', 'sideways-rl', 'sideways-lr'],
-    'z-index': ['auto', '<integer>'],
-}
+        'absolute-size': [
+            'xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large'
+        ],
+        'absolute-weight': [
+            '100', '200', '300', '400', '500', '600', '700', '800', '900',
+            'normal', 'bold'
+        ],
+        'basic-shape': [
+            ['circle()', 'circle($1)'],
+            ['ellipse()', 'ellipse($1)'],
+            ['inset()', 'inset($1)'],
+            ['polygon()', 'polygon($1)']
+        ],
+        'blend-mode': [
+            'normal', 'multiply', 'screen', 'overlay', 'darken', 'lighten',
+            'color-dodge', 'color-burn', 'hard-light', 'soft-light', 'difference',
+            'exclusion', 'hue', 'saturation', 'color', 'luminosity'
+        ],
+        'border-style': [
+            'none', 'hidden', 'dotted', 'dashed', 'solid', 'double',
+            'groove', 'ridge', 'inset', 'outset'
+        ],
+        'border-width': ['thin', 'medium', 'thick'],
+        'break-before-after': [
+            'always', 'left', 'right', 'recto', 'verso', 'page', 'column', 'region'
+        ],
+        'break-inside': [
+            'auto', 'avoid', 'avoid-page', 'avoid-column', 'avoid-region'
+        ],
+        'calc': [
+            ['calc()', 'calc($1)'],
+            ['clamp()', 'clamp(${1:0}, ${2:0}, ${3:0})'],
+            ['max()', 'max(${1:0}, ${2:0})'],
+            ['min()', 'min(${1:0}, ${2:0})']
+        ],
+        'color': [
+            'currentColor',
+            'transparent',
+            ['rgb()', 'rgb(${1:0}, ${2:0}, ${3:0})'],
+            ['rgba()', 'rgba(${1:0}, ${2:0}, ${3:0}, ${4:1.0})'],
+            ['hsl()', 'hsl(${1:0}, ${2:100%}, ${3:50%})'],
+            ['hsla()', 'hsla(${1:0}, ${2:100%}, ${3:50%}, ${4:1.0})'],
+            # Named colors
+            'aliceblue', 'antiquewhite', 'aqua', 'aquamarine', 'azure', 'beige',
+            'bisque', 'black', 'blanchedalmond', 'blue', 'blueviolet', 'brown',
+            'burlywood', 'cadetblue', 'chartreuse', 'chocolate', 'coral',
+            'cornflowerblue', 'cornsilk', 'crimson', 'cyan', 'darkblue',
+            'darkcyan', 'darkgoldenrod', 'darkgray', 'darkgrey', 'darkgreen',
+            'darkkhaki', 'darkmagenta', 'darkolivegreen', 'darkorange',
+            'darkorchid', 'darkred', 'darksalmon', 'darkseagreen',
+            'darkslateblue', 'darkslategray', 'darkslategrey', 'darkturquoise',
+            'darkviolet', 'deeppink', 'deepskyblue', 'dimgray', 'dimgrey',
+            'dodgerblue', 'firebrick', 'floralwhite', 'forestgreen', 'fuchsia',
+            'gainsboro', 'ghostwhite', 'gold', 'goldenrod', 'gray', 'grey',
+            'green', 'greenyellow', 'honeydew', 'hotpink', 'indianred', 'indigo',
+            'ivory', 'khaki', 'lavender', 'lavenderblush', 'lawngreen',
+            'lemonchiffon', 'lightblue', 'lightcoral', 'lightcyan',
+            'lightgoldenrodyellow', 'lightgray', 'lightgrey', 'lightgreen',
+            'lightpink', 'lightsalmon', 'lightseagreen', 'lightskyblue',
+            'lightslategray', 'lightslategrey', 'lightsteelblue', 'lightyellow',
+            'lime', 'limegreen', 'linen', 'magenta', 'maroon', 'mediumaquamarine',
+            'mediumblue', 'mediumorchid', 'mediumpurple', 'mediumseagreen',
+            'mediumslateblue', 'mediumspringgreen', 'mediumturquoise',
+            'mediumvioletred', 'midnightblue', 'mintcream', 'mistyrose',
+            'moccasin', 'navajowhite', 'navy', 'oldlace', 'olive', 'olivedrab',
+            'orange', 'orangered', 'orchid', 'palegoldenrod', 'palegreen',
+            'paleturquoise', 'palevioletred', 'papayawhip', 'peachpuff', 'peru',
+            'pink', 'plum', 'powderblue', 'purple', 'rebeccapurple', 'red',
+            'rosybrown', 'royalblue', 'saddlebrown', 'salmon', 'sandybrown',
+            'seagreen', 'seashell', 'sienna', 'silver', 'skyblue', 'slateblue',
+            'slategray', 'slategrey', 'snow', 'springgreen', 'steelblue', 'tan',
+            'teal', 'thistle', 'tomato', 'turquoise', 'violet', 'wheat', 'white',
+            'whitesmoke', 'yellow', 'yellowgreen'
+        ],
+        'counter-style': [
+            ['symbols()', 'symbols($1)']
+        ],
+        'counter-symbols': [
+            'cyclic', 'numeric', 'alphabetic', 'symbolic', 'additive', 'fixed'
+        ],
+        'ending-shape': ['circle', 'ellipse'],
+        'fill-rule': ['nonzero', 'evenodd'],
+        'filter-function': [
+            ['blur()', 'blur($1)'],
+            ['brightness()', 'brightness($1)'],
+            ['contrast()', 'contrast($1)'],
+            ['drop-shadow()', 'drop-shadow($1)'],
+            ['grayscale()', 'grayscale($1)'],
+            ['hue-rotate()', 'hue-rotate($1)'],
+            ['invert()', 'invert($1)'],
+            ['opacity()', 'opacity($1)'],
+            ['saturate()', 'saturate($1)'],
+            ['sepia()', 'sepia($1)']
+        ],
+        'font-variant-alternates': [
+            'normal', 'historical-forms',
+            ['stylistic()', 'stylistic($1)'],
+            ['styleset()', 'styleset($1)'],
+            ['character-variant()', 'character-variant($1)'],
+            ['swash()', 'swash($1)'],
+            ['ornaments()', 'ornaments($1)'],
+            ['annotation()', 'annotation($1)']
+        ],
+        'generic-font-name': [
+            'serif', 'sans-serif', 'cursive', 'fantasy', 'monospace'
+        ],
+        'gradient': [
+            ['conic-gradient()', 'conic-gradient($1)'],
+            ['linear-gradient()', 'linear-gradient($1)'],
+            ['radial-gradient()', 'radial-gradient($1)'],
+            ['repeating-conic-gradient()', 'repeating-conic-gradient($1)'],
+            ['repeating-linear-gradient()', 'repeating-linear-gradient($1)'],
+            ['repeating-radial-gradient()', 'repeating-radial-gradient($1)']
+        ],
+        'grid': [
+            ['repeat()', 'repeat(${1:2}, ${2:1fr})'],
+            ['minmax()', 'minmax(${1:100px}, ${2:1fr})'],
+        ],
+        'image': [
+            '<url>',
+            ['image()', 'image($1)'],
+            ['image-set()', 'image-set($1)'],
+            ['element()', 'element($1)'],
+            ['paint()', 'paint($1)'],
+            ['cross-fade()', 'cross-fade($1)'],
+            ['linear-gradient()', 'linear-gradient($1)'],
+            ['repeating-linear-gradient()', 'repeating-linear-gradient($1)'],
+            ['radial-gradient()', 'radial-gradient($1)'],
+            ['repeating-radial-gradient()', 'repeating-radial-gradient($1)'],
+            ['conic-gradient()', 'conic-gradient($1)'],
+        ],
+        'image-tags': ['ltr', 'rtl'],
+        'line-style': [
+            'none', 'hidden', 'dotted', 'dashed', 'solid', 'double', 'groove',
+            'ridge', 'inset', 'outset'
+        ],
+        'leader-type': [
+            'dotted', 'solid', 'space'
+        ],
+        'list-style-type': [
+            'none', 'inline', 'disc', 'circle', 'square', 'decimal',
+            'decimal-leading-zero', 'arabic-indic', 'binary', 'bengali',
+            'cambodian', 'khmer', 'devanagari', 'gujarati', 'gurmukhi',
+            'kannada', 'lower-hexadecimal', 'lao', 'malayalam', 'mongolian',
+            'myanmar', 'octal', 'oriya', 'persian', 'urdu', 'telugu',
+            'tibetan', 'thai', 'upper-hexadecimal', 'lower-roman',
+            'upper-roman', 'lower-greek', 'lower-alpha', 'lower-latin',
+            'upper-alpha', 'upper-latin', 'afar', 'ethiopic-halehame-aa-et',
+            'ethiopic-halehame-aa-er', 'amharic', 'ethiopic-halehame-am-et',
+            'amharic-abegede', 'ethiopic-abegede-am-et', 'cjk-earthly-branch',
+            'cjk-heavenly-stem', 'ethiopic', 'ethiopic-halehame-gez',
+            'ethiopic-abegede', 'ethiopic-abegede-gez', 'hangul-consonant',
+            'hangul', 'lower-norwegian', 'oromo', 'ethiopic-halehame-om-et',
+            'sidama', 'ethiopic-halehame-sid-et', 'somali',
+            'ethiopic-halehame-so-et', 'tigre', 'ethiopic-halehame-tig',
+            'tigrinya-er', 'ethiopic-halehame-ti-er', 'tigrinya-er-abegede',
+            'ethiopic-abegede-ti-er', 'tigrinya-et', 'ethiopic-halehame-ti-et',
+            'tigrinya-et-abegede', 'ethiopic-abegede-ti-et', 'upper-greek',
+            'upper-norwegian', 'asterisks', 'footnotes', 'hebrew', 'armenian',
+            'lower-armenian', 'upper-armenian', 'georgian', 'cjk-ideographic',
+            'hiragana', 'katakana', 'hiragana-iroha', 'katakana-iroha'
+        ],
+        'position': ['<side-or-corner>', 'center'],
+        'relative-size': ['larger', 'smaller'],
+        'relative-weight': ['bolder', 'lighter'],
+        'repeat-style': [
+            'repeat', 'repeat-x', 'repeat-y', 'space', 'round', 'no-repeat'
+        ],
+        'self-position': [
+            'center', 'start', 'end', 'self-start', 'self-end', 'flex-start',
+            'flex-end'
+        ],
+        'shape-radius': [
+            'closest-side', 'farthest-side'
+        ],
+        'side-or-corner': [
+            'left', 'right', 'top', 'bottom'
+        ],
+        'timing-function': [
+            'linear',
+            'ease', 'ease-in', 'ease-out', 'ease-in-out', 'step-start', 'step-end',
+            ['cubic-bezier()', 'cubic-bezier(${1:0.0}, ${2:0.0}, ${3:1.0}, ${4:1.0})'],
+            ['steps()', 'steps(${1:2}, ${2:start})'],
+        ],
+        'type-or-unit': [
+            'string', 'color', 'url', 'integer', 'number', 'length', 'angle',
+            'time', 'frequency', 'cap', 'ch', 'em', 'ex', 'ic', 'lh', 'rlh',
+            'rem', 'vb', 'vi', 'vw', 'vh', 'vmin', 'vmax', 'mm', 'Q', 'cm',
+            'in', 'pt', 'pc', 'px', 'deg', 'grad', 'rad', 'turn', 'ms', 's',
+            'Hz', 'kHz', '%'
+        ],
+        'url': [['url()', 'url($1)']],
+    }
+
+    resolved_values = {}
+
+    def resolve(vals):
+        vals_resolved = []
+        for val in vals:
+            if val[0] == '<' and val[-1] == '>':
+                key = val[1:-1]
+                resolved = resolved_values.get(key)
+                if resolved:
+                    vals_resolved += resolved
+                    continue
+                resolved = common_values.get(key)
+                if resolved:
+                    vals_resolved += resolve(resolved)
+                    continue
+
+            vals_resolved.append(val)
+        return vals_resolved
+
+    for val_key, val_vals in common_values.items():
+        resolved_values[val_key] = resolve(val_vals)
+
+    return resolved_values
 
 
-def completion_sort_key(v):
-    if isinstance(v, str):
-        return v
-    return v[0]
+def get_func_args():
+
+    common_values = get_common_values()
+
+    func_args = {
+        'attr': ['<color>', '<type-or-unit>'],
+        'blur': ['<calc>'],
+        'brightness': ['<calc>'],
+        'calc': [
+            ['attr()', 'attr($1)'],
+            '<calc>'
+        ],
+        'circle': ['<calc>', '<shape-radius>', 'at', '<position>'],
+        'clamp': [
+            ['attr()', 'attr($1)'],
+            '<calc>'
+        ],
+        'conic-gradient': ['from', 'at', '<position>', '<color>'],
+        'contrast': [],
+        'counter': ['<counter-style>'],
+        'counters': ['<counter-style>'],
+        'cross-fade': ['<image>', '<color>'],
+        'cubic-bezier': ['<calc>'],
+        'drop-shadow': ['<calc>', '<color>'],
+        'element': [],
+        'ellipse': ['<calc>', '<shape-radius>', 'at',  '<position>'],
+        'env': [],
+        'filter': ['<filter-function>', '<image>'],
+        'fit-content': [],
+        'grayscale': ['<calc>'],
+        'hsl': ['<calc>'],
+        'hsla': ['<calc>'],
+        'hue-rotate': ['<calc>'],
+        'image': ['<image-tags>', '<url>', '<color>'],
+        'image-set': [
+            ['type()', 'type($)'],
+            '<url>', '<color>'
+        ],
+        'inset': ['<calc>', 'round'],
+        'invert': ['<calc>'],
+        'leader': ['<leader-type>'],
+        'linear-gradient': ['<side-or-corner>', '<color>', 'to'],
+        'matrix': ['<calc>'],
+        'matrix3d': ['<calc>'],
+        'max': [
+            ['attr()', 'attr($1)'],
+            '<calc>'
+        ],
+        'min': [
+            ['attr()', 'attr($1)'],
+            '<calc>'
+        ],
+        'minmax': ['min-content', 'max-content', 'auto'],
+        'opacity': ['<calc>'],
+        'path': ['<fill-rule>'],
+        'paint': [],
+        'perspective': ['<calc>'],
+        'polygon': ['<calc>', '<fill-rule>'],
+        'radial-gradient': [
+            '<ending-shape>', '<size>', 'at',  '<position>', '<color>'
+        ],
+        'rect': ['<calc>', 'auto'],
+        'repeat': ['<calc>', 'auto-fill', 'auto-fit'],
+        'repeating-conic-gradient': ['from', 'at', '<position>', '<color>'],
+        'repeating-linear-gradient': ['<side-or-corner>', '<color>', 'to'],
+        'repeating-radial-gradient': [
+            '<ending-shape>', '<size>', 'at',  '<position>', '<color>'
+        ],
+        'rgb': ['<calc>'],
+        'rgba': ['<calc>'],
+        'rotate': ['<calc>'],
+        'rotate3d': ['<calc>'],
+        'rotateX': ['<calc>'],
+        'rotateY': ['<calc>'],
+        'rotateZ': ['<calc>'],
+        'saturate': ['<calc>'],
+        'scale': ['<calc>'],
+        'scale3d': ['<calc>'],
+        'scaleX': ['<calc>'],
+        'scaleY': ['<calc>'],
+        'scaleZ': ['<calc>'],
+        'skew': ['<calc>'],
+        'skewX': ['<calc>'],
+        'skewY': ['<calc>'],
+        'sepia': ['<calc>'],
+        'steps': ['<calc>', 'end', 'middle', 'start'],
+        'target-counter': ['<url>', '<counter-style>'],
+        'target-counters': ['<url>', '<counter-style>'],
+        'target-text': ['<url>', 'content', 'before', 'after', 'first-letter'],
+        'toggle': ['<calc>', '<color>'],
+        'translate': ['<calc>'],
+        'translate3d': ['<calc>'],
+        'translateX': ['<calc>'],
+        'translateY': ['<calc>'],
+        'translateZ': ['<calc>'],
+        'var': [],
+    }
+
+    completions = {}
+
+    for func, args in func_args.items():
+        # args that are allowed for all properties
+        expanded_args = [['var()', 'var($1)']]
+
+        # Determine which args are available for the current property name
+        for arg in args:
+            if arg[0] == '<' and arg[-1] == '>':
+                key = arg[1:-1]
+                if key in common_values:
+                    expanded_args += common_values[key]
+            else:
+                expanded_args.append(arg)
+
+        completions[func] = expanded_args
+
+    return completions
 
 
-def parse_css_data():
-    """
-    Returns a dictionary containing values associated to their property names
-    """
+def get_properties():
+    '''
+    Gets the properties.
+
+    Prepare some common property values for when there is more than one way to
+    specify a certain value type. The color value for example can be specified
+    by `rgb()` or `hsl()` and so on. Example where `|` denotes the caret:
+
+        color: rg|   -->   color: rgb(|);
+
+    This is also helpful when multiple properties share the same value types.
+    '''
+    common_values = get_common_values()
+
+    properties_dict = {
+        'align-content': [
+            'center', 'flex-end', 'flex-start', 'space-around', 'space-between',
+            'stretch'
+        ],
+        'align-items': [
+            'baseline', 'center', 'flex-end', 'flex-start', 'stretch'
+        ],
+        'align-self': [
+            'auto', 'baseline', 'center', 'flex-end', 'flex-start', 'stretch'
+        ],
+        'alignment-baseline': [
+            'baseline', 'middle', 'auto', 'before-edge', 'after-edge', 'central',
+            'text-before-edge', 'text-after-edge', 'ideographic', 'alphabetic',
+            'hanging', 'mathematical'
+        ],
+        'animation': [
+            'none', '<timing-function>', 'infinite', '<animation-direction>',
+            'forwards', 'backwards', 'both', 'running', 'paused'
+        ],
+        'animation-name': ['none', '<custom-ident>'],
+        'animation-duration': ['<time>'],
+        'animation-timing-function': ['<timing-function>'],
+        'animation-delay': ['<time>'],
+        'animation-iteration-count': ['infinite', '<number>'],
+        'animation-direction': ['<animation-direction>'],
+        'animation-fill-mode': ['none', 'forwards', 'backwards', 'both'],
+        'animation-play-state': ['running', 'paused'],
+        'backface-visibility': ['visible', 'hidden'],
+        'background': [
+            '<color>', '<gradient>', '<position>', '<url>',
+            'repeat', 'repeat-x', 'repeat-y', 'no-repeat', 'scroll', 'fixed'
+        ],
+        'background-attachment': ['fixed', 'local', 'scroll'],
+        'background-blend-mode': ['<blend-mode>'],
+        'background-clip': ['border-box', 'padding-box', 'content-box'],
+        'background-color': ['<color>'],
+        'background-image': ['<url>', 'none'],
+        'background-origin': ['border-box', 'padding-box', 'content-box'],
+        'background-position': ['<position>'],
+        'background-repeat': ['<repeat-style>'],
+        'background-size': [
+            'auto', 'cover', 'contain', '<length>', '<percentage>'
+        ],
+        'baseline-shift': ['baseline', 'sub', 'super'],
+        'border': ['<border-width>', '<border-style>', '<color>'],
+        'border-width': ['<border-width>'],
+        'border-style': ['<border-style>'],
+        'border-color': ['<color>'],
+        'border-collapse': ['collapse', 'separate'],
+        'border-radius': ['<length>', '<percentage>'],
+        'border-spacing': ['<length>'],
+        'border-image': [
+            '<border-image-source>', '<border-image-slice>',
+            '<border-image-width>', '<border-image-outset>',
+            '<border-image-repeat>'
+        ],
+        'border-image-outset': ['<length>', '<number>'],
+        'border-image-repeat': ['stretch', 'repeat', 'round', 'space'],
+        'border-image-slice': ['fill', '<number>', '<percentage>'],
+        'border-image-source': ['none', '<image>'],
+        'border-image-width': ['<length>', '<percentage>', '<number>', 'auto'],
+        'border-top | border-right | border-bottom | border-left': [
+            '<border-width>', '<border-style>', '<color>'
+        ],
+        'border-top-color | border-right-color | border-bottom-color | border-left-color': ['<color>'],
+        'border-top-left-radius | border-top-right-radius | border-bottom-right-radius | border-bottom-left-radius': [
+            '<length>', '<percentage>'
+        ],
+        'border-top-style | border-right-style | border-bottom-style | border-left-style': ['<border-style>'],
+        'border-top-width | border-right-width | border-bottom-width | border-left-width': ['<border-width>'],
+        'bottom': ['<length>', '<percentage>', 'auto'],
+        'box-decoration-break': ['slice', 'clone'],
+        'box-shadow': ['none', 'inset', '<color>'],
+        'box-sizing': ['content-box', 'border-box'],
+        'break-after': ['<break-before-after>', '<break-inside>'],
+        'break-before': ['<break-before-after>', '<break-inside>'],
+        'break-inside': ['<break-inside>'],
+        'caption-side': ['top', 'bottom'],
+        'clear': ['none', 'left', 'right', 'both'],
+        'clip': [
+            ['rect()', 'rect(${1:0}, ${2:0}, ${3:0}, ${4:0})'],
+            'auto'
+        ],
+        'clip-path': ['none', '<url>', '<basic-shape>'],
+        'clip-rule': ['nonzero', 'evenodd'],
+        'color': ['<color>'],
+        'color-interpolation': ['auto', 'sRGB', 'linearRGB'],
+        'color-interpolation-filters': ['auto', 'sRGB', 'linearRGB'],
+        'color-profile': ['auto', 'sRGB', '<url>'],
+        'color-rendering': ['auto', 'optimizeSpeed', 'optimizeQuality'],
+        'columns': ['auto'],
+        'column-count': ['auto', '<number>'],
+        'column-fill': ['auto', 'balance'],
+        'column-gap': ['normal', '<length>'],
+        'column-rule': ['<border-width>', '<border-style>', '<color>'],
+        'column-rule-color': ['<color>'],
+        'column-rule-style': ['<border-style>'],
+        'column-rule-width': ['<border-width>'],
+        'column-span': ['none'],
+        'column-width': ['auto', '<length>'],
+        'content': [
+            'none', 'normal', '<url>',
+            'open-quote', 'close-quote', 'no-open-quote', 'no-close-quote',
+            ['attr()', 'attr($1)'],
+            ['counter()', 'counter($1)']
+        ],
+        'counter-increment': ['none', '<custom_ident>', '<integer>'],
+        'counter-reset': ['none', '<custom_ident>', '<integer>'],
+        'cursor': [
+            '<url>', 'auto', 'default', 'none', 'context-menu', 'help',
+            'pointer', 'progress', 'wait', 'cell', 'crosshair', 'text',
+            'vertical-text', 'alias', 'copy', 'move', 'no-drop', 'not-allowed',
+            'e-resize', 'n-resize', 'ne-resize', 'nw-resize', 's-resize',
+            'se-resize', 'sw-resize', 'w-resize', 'ew-resize', 'ns-resize',
+            'nesw-resize', 'nwse-resize', 'col-resize', 'row-resize',
+            'all-scroll', 'zoom-in', 'zoom-out'
+        ],
+        'direction': ['<image-tags>'],
+        'display': [
+            'none', 'inline', 'block', 'contents', 'list-item', 'inline-block',
+            'inline-table', 'table', 'table-cell', 'table-column',
+            'table-column-group', 'table-footer-group', 'table-header-group',
+            'table-row', 'table-row-group', 'table-caption', 'flex',
+            'inline-flex', 'grid', 'inline-grid', 'ruby', 'ruby-base',
+            'ruby-text', 'ruby-base-container', 'ruby-text-container', 'run-in'
+        ],
+        'dominant-baseline': [
+            'auto', 'middle', 'central', 'text-before-edge',
+            'text-after-edge', 'ideographic', 'alphabetic', 'hanging',
+            'mathematical', 'use-script', 'no-change', 'reset-size'
+        ],
+        'empty-cells': ['show', 'hide'],
+        'fill': ['<color>'],
+        'fill-rule': ['nonzero', 'evenodd'],
+        'filter': [
+            '<url>',
+            ['blur()', 'blur(${1:5px})'],
+            ['brightness()', 'brightness(${1:1.0})'],
+            ['contrast()', 'contrast(${1:100%})'],
+            ['drop-shadow()', 'drop-shadow(${1:1px} ${2:1px})'],
+            ['grayscale()', 'grayscale(${1:50%})'],
+            ['hue-rotate()', 'hue-rotate(${1:90deg})'],
+            ['invert()', 'invert(${1:50%})'],
+            ['opacity()', 'opacity(${1:100%})'],
+            ['saturate()', 'saturate(${1:50%})'],
+            ['sepia()', 'sepia(${1:50%})']
+        ],
+        'flex': ['none'],
+        'flex-grow': ['<number>'],
+        'flex-shrink': ['<number>'],
+        'flex-basis': ['auto', '<width>'],
+        'flex-flow': [
+            'row', 'row-reverse', 'column', 'column-reverse', 'nowrap', 'wrap',
+            'wrap-reverse'
+        ],
+        'flex-direction': ['row', 'row-reverse', 'column', 'column-reverse'],
+        'flex-wrap': ['nowrap', 'wrap', 'wrap-reverse'],
+        'float': ['left', 'right', 'none'],
+        'flood-color': ['<color>'],
+        'font': [
+            '<absolute-weight>', '<generic-font-name>', '<relative-weight>',
+            'caption', 'icon', 'italic', 'menu', 'message-box', 'oblique',
+            'small-caps', 'small-caption', 'status-bar'
+        ],
+        'font-display': ['auto', 'block', 'swap', 'fallback', 'optional'],
+        'font-family': ['<generic-font-name>'],
+        'font-feature-settings': ['normal', '<string>'],
+        'font-kerning': ['auto', 'normal', 'none'],
+        'font-language-override': ['normal', '<string>'],
+        'font-size': [
+            '<absolute-size>', '<relative-size>', '<length>', '<percentage>'
+        ],
+        'font-size-adjust': ['none', '<number>'],
+        'font-style': ['normal', 'italic', 'oblique'],
+        'font-stretch': [
+            'normal', 'semi-condensed', 'condensed', 'extra-condensed',
+            'ultra-condensed', 'semi-expanded', 'expanded', 'extra-expanded',
+            'ultra-expanded'
+        ],
+        'font-synthesis': ['none', 'weight', 'style'],
+        'font-variant': ['normal', 'small-caps'],
+        'font-variant-alternates': ['<font-variant-alternates>'],
+        'font-variant-caps': [
+            'normal', 'small-caps', 'all-small-caps', 'petite-caps',
+            'all-petite-caps', 'unicase', 'titling-case'
+        ],
+        'font-variant-east-asian': [
+            'normal', 'ruby', 'jis78', 'jis83', 'jis90', 'jis04', 'simplified',
+            'traditional'
+        ],
+        'font-variant-ligatures': [
+            'normal', 'none', 'common-ligatures', 'no-common-ligatures',
+            'discretionary-ligatures', 'no-discretionary-ligatures',
+            'historical-ligatures', 'no-historical-ligatures', 'contextual',
+            'no-contextual'
+        ],
+        'font-variant-numeric': [
+            'normal', 'ordinal', 'slashed-zero', 'lining-nums', 'oldstyle-nums',
+            'proportional-nums', 'tabular-nums', 'diagonal-fractions',
+            'stacked-fractions'
+        ],
+        'font-variant-position': ['normal', 'sub', 'super'],
+        'font-weight': ['<absolute-weight>', '<relative-weight>'],
+        'grid': [],
+        'grid-area': [],
+        'grid-auto-columns': ['auto', '<percentage>', '<length>'],
+        'grid-auto-flow': ['row', 'column', 'dense'],
+        'grid-auto-rows': ['auto', '<percentage>', '<length>'],
+        'grid-column-gap': ['<length>', '<percentage>'],
+        'grid-gap': ['<length>', '<percentage>'],
+        'grid-row-gap': ['<length>', '<percentage>'],
+        'grid-template-areas': [],
+        'grid-template-columns': ['auto', '<grid>', '<percentage>', '<length>'],
+        'grid-template-rows': ['auto', '<grid>', '<percentage>', '<length>'],
+        'grid-column': ['<number>'],
+        'grid-column-end': ['<number>'],
+        'grid-column-start': ['<number>'],
+        'grid-row': ['<number>'],
+        'grid-row-end': ['<number>'],
+        'grid-row-start': ['<number>'],
+        'height': ['<length>', '<percentage>', 'auto', 'fit-content'],
+        'hyphens': ['none', 'manual', 'auto'],
+        'image-rendering': [
+            'auto', 'optimizeSpeed', 'optimizeQuality', 'pixelated'
+        ],
+        'ime-mode': ['auto', 'normal', 'active', 'inactive', 'disabled'],
+        'isolation': ['auto', 'isolation'],
+        'justify-content | justify-items | justify-self': [
+            'start', 'end', 'flex-start', 'flex-end', 'center', 'left', 'right',
+            'safe start', 'safe end', 'safe flex-start', 'safe flex-end',
+            'safe center', 'safe left', 'safe right', 'unsafe start',
+            'unsafe end', 'unsafe flex-start', 'unsafe flex-end', 'unsafe center',
+            'unsafe left', 'unsafe right', 'normal', 'baseline', 'first baseline',
+            'last baseline', 'space-between', 'space-around', 'space-evenly',
+            'stretch', 'legacy', 'lecacy center', 'legacy left', 'legacy right'
+        ],
+        'kerning': ['auto'],
+        'left': ['<length>', '<percentage>', 'auto'],
+        'letter-spacing': ['normal', '<length>'],
+        'lighting-color': ['<color>'],
+        'line-height': ['normal', '<number>', '<length>', '<percentage>'],
+        'list-style': ['<list-style-type>', 'inside', 'outside', '<url>'],
+        'list-style-image': ['<url>', 'none'],
+        'list-style-position': ['inside', 'outside'],
+        'list-style-type': ['<list-style-type>'],
+        'margin': ['auto', '<margin-width>'],
+        'margin-top | margin-right | margin-bottom | margin-left': [
+            'auto', '<margin-width>'
+        ],
+        'marker-end | marker-start | marker-mid': ['<url>', 'none'],
+        'marks': ['crop', 'cross', 'none'],
+        'mask': ['<url>', 'none'],
+        'mask-type': ['luminance', 'alpha'],
+        'max-height': ['<length>', '<percentage>', 'fit-content', 'none'],
+        'max-width': ['<length>', '<percentage>', 'fit-content', 'none'],
+        'min-height': ['<length>', '<percentage>', 'fit-content'],
+        'min-width': ['<length>', '<percentage>', 'fit-content'],
+        'mix-blend-mode': ['<blend-mode>'],
+        'object-fit': ['fill', 'contain', 'cover', 'none', 'scale-down'],
+        'object-position': ['<position>'],
+        'opacity': ['<number>'],
+        'order': ['<integer>'],
+        'orphans': ['<integer>'],
+        'outline': [
+            '<color>', '<border-style>', '<border-width>', '<length>'
+        ],
+        'outline-color': ['<color>', 'invert'],
+        'outline-offset': ['<length>'],
+        'outline-style': ['<border-style>'],
+        'outline-width': ['<border-width>', '<length>'],
+        'overflow | overflow-x | overflow-y': [
+            'visible', 'hidden', 'scroll', 'auto'
+        ],
+        'overflow-wrap': ['normal', 'break-word'],
+        'padding': ['auto', '<padding-width>'],
+        'padding-top | padding-right | padding-bottom | padding-left': [
+            'auto', '<padding-width>'
+        ],
+        'page-break-after': ['auto', 'always', 'avoid', 'left', 'right'],
+        'page-break-before': ['auto', 'always', 'avoid', 'left', 'right'],
+        'page-break-inside': ['avoid', 'auto'],
+        'paint-order': ['normal', 'fill', 'stroke', 'markers'],
+        'perspective': ['none'],
+        'perspective-origin': ['<position>'],
+        'pointer-events': [
+            'auto', 'none', 'all', 'visiblePainted', 'visibleFill',
+            'visibleStroke', 'visible', 'painted', 'fill', 'stroke'
+        ],
+        'position': ['static', 'relative', 'absolute', 'fixed', 'sticky'],
+        'quotes': ['none', '<string>'],
+        'resize': ['none', 'both', 'horizontal', 'vertical'],
+        'right': ['<length>', '<percentage>', 'auto'],
+        'scroll-behavior': ['auto', 'smooth'],
+        'shape-image-threshold': ['<number>'],
+        'shape-margin': ['<length>', '<percentage>'],
+        'shape-outside': [
+            'none', 'margin-box', 'content-box', 'border-box', 'padding-box',
+            '<basic-shape>', '<url>'
+        ],
+        'shape-rendering': [
+            'auto', 'optimizeSpeed', 'crispEdges', 'geometricPrecision'
+        ],
+        'size': [
+            'a3', 'a4', 'a5', 'b4', 'b5', 'jis-b4', 'jis-b5', 'landscape',
+            'ledger', 'legal', 'letter', 'portrait'
+        ],
+        'stop-color': ['<color>'],
+        'stroke': ['<color>'],
+        'stroke-dasharray': ['none'],
+        'stroke-linecap': ['butt', 'round', 'square'],
+        'stroke-linejoin': ['round', 'miter', 'bevel'],
+        'system': ['<counter-symbols>'],
+        'table-layout': ['auto', 'fixed'],
+        'text-align': ['left', 'right', 'center', 'justify', 'justify-all'],
+        'text-align-last': ['start', 'end', 'left', 'right', 'center', 'justify'],
+        'text-anchor': ['start', 'middle', 'end'],
+        'text-decoration': [
+            'none', 'underline', 'overline', 'line-through', 'blink'
+        ],
+        'text-decoration-color': ['<color>'],
+        'text-decoration-line': ['none', 'underline', 'overline', 'line-through'],
+        'text-decoration-style': ['solid', 'double', 'dotted', 'dashed', 'wavy'],
+        'text-indent': ['<length>', '<percentage>'],
+        'text-orientation': ['mixed', 'upright', 'sideways', 'use-glyph-orientation'],
+        'text-overflow': ['clip', 'ellipsis'],
+        'text-rendering': [
+            'auto', 'optimizeSpeed', 'optimizeLegibility', 'geometricPrecision'
+        ],
+        'text-shadow': ['none', '<color>'],
+        'text-transform': ['capitalize', 'uppercase', 'lowercase', 'none'],
+        'text-underline-position': ['auto', 'under', 'left', 'right'],
+        'top': ['<length>', '<percentage>', 'auto'],
+        'transform': [
+            'none',
+            ['matrix()', 'matrix(${1:1}, ${2:1}, ${3:1}, ${4:1}, ${5:2}, ${6:2})'],
+            [
+                'matrix3d()',
+                'matrix3d('
+                '${1:1}, ${2:1}, ${3:0}, ${4:0}, '
+                '${5:1}, ${6:1}, ${7:0}, ${8:0}, '
+                '${9:0}, ${10:0}, ${11:1}, ${12:0}, '
+                '${13:2}, ${14:2}, ${15:0}, ${16:1}'
+                ')'
+            ],
+            ['perspective()', 'perspective(${1:0})'],
+            ['rotate()', 'rotate(${1:45deg})'],
+            ['rotate3d()', 'rotate3d(${1:0}, ${2:0}, ${3:1}, ${4:45deg})'],
+            ['rotateX()', 'rotateX(${1:45deg})'],
+            ['rotateY()', 'rotateY(${1:45deg})'],
+            ['rotateZ()', 'rotateZ(${1:45deg})'],
+            ['scale()', 'scale(${1:1.0})'],
+            ['scale3d()', 'scale3d(${1:1.0}, ${2:1.0}, ${3:1.0})'],
+            ['scaleX()', 'scaleX(${1:1.0})'],
+            ['scaleY()', 'scaleY(${1:1.0})'],
+            ['scaleZ()', 'scaleZ(${1:1.0})'],
+            ['skew()', 'skew(${1:10deg})'],
+            ['skewX()', 'skewX(${1:10deg})'],
+            ['skewY()', 'skewY(${1:10deg})'],
+            ['translate()', 'translate(${1:10px})'],
+            ['translate3d()', 'translate3d(${1:10px}, ${2:0px}, ${3:0px})'],
+            ['translateX()', 'translateX(${1:10px})'],
+            ['translateY()', 'translateY(${1:10px})'],
+            ['translateZ()', 'translateZ(${1:10px})']
+        ],
+        'transform-origin': ['<position>'],
+        'transform-style': ['preserve-3d', 'flat'],
+        'transition': [],
+        'transition-delay': ['<time>'],
+        'transition-duration': ['<time>'],
+        'transition-property': ['none', '<custom-ident>'],
+        'transition-timing-function': ['<timing-function>'],
+        'unicode-bidi': ['normal', 'embed', 'bidi-override'],
+        'unicode-range': [],
+        'user-select': ['auto', 'text', 'none', 'contain'],
+        'vertical-align': [
+            'baseline', 'sub', 'super', 'text-top', 'text-bottom', 'middle',
+            'top', 'bottom', '<percentage>', '<length>'
+        ],
+        'visibility': ['visible', 'hidden', 'collapse'],
+        'white-space': ['normal', 'pre', 'nowrap', 'pre-wrap', 'pre-line'],
+        'widows': ['<integer>'],
+        'width': ['<length>', '<percentage>', 'auto', 'fit-content'],
+        'will-change': ['auto', 'contents', 'scroll-position', '<custom-ident>'],
+        'word-break': ['normal', 'break-all', 'keep-all'],
+        'word-spacing': ['normal', '<length>'],
+        'word-wrap': ['normal', 'break-word'],
+        'writing-mode': [
+            'horizontal-tb', 'vertical-rl', 'vertical-lr', 'sideways-rl',
+            'sideways-lr'
+        ],
+        'z-index': ['auto', '<integer>'],
+    }
+
     props = {}
-    for names, values in PROPERTY_DICT.items():
+
+    for names, values in properties_dict.items():
+        # Values that are allowed for all properties
+        allowed_values = ['inherit', 'initial', 'unset', ['var()', 'var($1)']]
+
         # Determine which values are available for the current property name
-        allowed_values = []
         for value in values:
             if value[0] == '<' and value[-1] == '>':
                 key = value[1:-1]
-                if key in COMMON_VALUES:
-                    allowed_values += COMMON_VALUES[key]
+                if key in common_values:
+                    allowed_values += common_values[key]
             else:
                 allowed_values.append(value)
 
-        # Append values that are allowed for all properties
-        allowed_values += ['all', 'inherit', 'initial', 'unset']
-
         for name in names.split(' | '):
-            props[name] = sorted(allowed_values, key=completion_sort_key)
+            props[name] = allowed_values
 
     return props
 
@@ -609,39 +797,36 @@ def next_none_whitespace(view, pt):
 
 
 class CSSCompletions(sublime_plugin.EventListener):
-    selector_scope = (
-        # completions are for properties, not selectors, only inside sass/scss files
-        "source.sass - meta.selector.css, source.scss - meta.selector.css"
-    )
-    props = None
-    re_name = None
-    re_value = None
-    re_trigger = None
+
+    @cached_property
+    def func_args(self):
+        return get_func_args()
+
+    @cached_property
+    def props(self):
+        return get_properties()
+
+    @cached_property
+    def re_name(self):
+        return re.compile(r"([a-zA-Z-]+)\s*:[^:;{}]*$")
+
+    @cached_property
+    def re_value(self):
+        return re.compile(r"^(?:\s*(:)|([ \t]*))([^:]*)([;}])")
 
     def on_query_completions(self, view, prefix, locations):
 
-        pt = locations[0]
-        loc = locations[0]
-        is_scss = view.match_selector(loc, "source.scss")
-
+        is_scss = view.match_selector(locations[0], "source.scss")
         if is_scss and sublime.load_settings('SCSS.sublime-settings').get('disable_default_completions'):
             return None
         elif sublime.load_settings('Sass.sublime-settings').get('disable_default_completions'):
             return None
 
-        if not match_selector(view, pt, self.selector_scope):
+        pt = locations[0]
+        if not match_selector(view, pt, ''):
             return None
 
-        if not self.props:
-            self.props = parse_css_data()
-            self.re_value = re.compile(r"^(?:\s*(:)|([ \t]*))([^:]*)([;}])")
-            self.re_trigger = re.compile(r"\$(?:\d+|\{\d+\:([^}]+)\})")
-            if is_scss:
-                self.re_name = re.compile(r"([a-zA-Z-]+)\s*:[^:;{}]*$")
-            else:
-                self.re_name = re.compile(r":?([a-zA-Z-]+)\s*:?[^:;{}]*$")
-
-        if match_selector(view, pt, "meta.property-value.css meta.function-call"):
+        if match_selector(view, pt, "meta.property-value.css meta.function-call.arguments"):
             items = self.complete_function_argument(view, prefix, pt)
         elif match_selector(view, pt, "meta.property-value.css"):
             items = self.complete_property_value(view, prefix, pt, is_scss)
@@ -653,15 +838,13 @@ class CSSCompletions(sublime_plugin.EventListener):
         return None
 
     def complete_property_name(self, view, prefix, pt, is_scss):
-        if is_scss:
+        if match_selector(view, pt, "meta.group"):
+            # don't append semicolon in groups e.g.: `@media screen (prop: |)`
+            suffix = ": $0"
+        elif is_scss:
             suffix = ": $0;"
         else:
-            line = view.substr(sublime.Region(view.line(pt).begin(), view.line(pt).end()))
-            regex = re.compile(r"^\s+:")
-            if regex.match(line):
-                suffix = " $0"
-            else:
-                suffix = ": $0"
+            suffix = ": $0"
         text = view.substr(sublime.Region(pt, view.line(pt).end()))
         matches = self.re_value.search(text)
         if matches:
@@ -686,7 +869,14 @@ class CSSCompletions(sublime_plugin.EventListener):
         )
 
     def complete_property_value(self, view, prefix, pt, is_scss):
-        completions = []
+        completions = [
+            sublime.CompletionItem(
+                trigger="!important",
+                completion_format=sublime.COMPLETION_FORMAT_TEXT,
+                kind=sublime.KIND_KEYWORD,
+                details="override any other declaration"
+            )
+        ]
         text = view.substr(sublime.Region(view.line(pt).begin(), pt - len(prefix)))
         matches = self.re_name.search(text)
         if matches:
@@ -695,21 +885,23 @@ class CSSCompletions(sublime_plugin.EventListener):
             if values:
                 details = f"<code>{prop}</code> property-value"
 
-                if next_none_whitespace(view, pt) == ";" or not is_scss:
+                if match_selector(view, pt, "meta.group"):
+                    # don't append semicolon in groups e.g.: `@media screen (prop: val)`
+                    suffix = ""
+                elif not is_scss:
+                    suffix = ""
+                elif next_none_whitespace(view, pt) == ";":
                     suffix = ""
                 else:
                     suffix = "$0;"
 
                 for value in values:
-                    if isinstance(value, str):
-                        desc = self.re_trigger.sub(r"\1", value)
-                        snippet = value
-                    else:
+                    if isinstance(value, list):
                         desc, snippet = value
-
-                    if "(" in snippet:
                         kind = KIND_CSS_FUNCTION
                     else:
+                        desc = value
+                        snippet = value
                         kind = KIND_CSS_CONSTANT
 
                     completions.append(sublime.CompletionItem(
@@ -722,5 +914,63 @@ class CSSCompletions(sublime_plugin.EventListener):
 
         return completions
 
-    def complete_function_argument(self, view, prefix, pt):
-        return None
+    def complete_function_argument(self, view: sublime.View, prefix, pt):
+        func_name = ""
+        nest_level = 1
+        # Look for the beginning of the current function call's arguments list,
+        # while ignoring any nested function call or group.
+        for i in range(pt - 1, pt - 32 * 1024, -1):
+            ch = view.substr(i)
+            # end of nested arguments list or group before caret
+            if ch == ")" and not view.match_selector(i, "string, comment"):
+                nest_level += 1
+                continue
+            # begin of maybe nested arguments list or group before caret
+            if ch == "(" and not view.match_selector(i, "string, comment"):
+                nest_level -= 1
+                # Stop, if nesting level drops below start value as this indicates the
+                # beginning of the arguments list the function name is of interest for.
+                if nest_level <= 0:
+                    func_name = view.substr(view.expand_by_class(
+                        i - 1, sublime.CLASS_WORD_START | sublime.CLASS_WORD_END))
+                    break
+
+        if func_name == "var":
+            return [
+                sublime.CompletionItem(
+                    trigger=symbol,
+                    completion_format=sublime.COMPLETION_FORMAT_TEXT,
+                    kind=sublime.KIND_VARIABLE,
+                    details="var() argument"
+                )
+                for symbol in set(
+                    view.substr(symbol_region)
+                    for symbol_region in view.find_by_selector("entity.other.custom-property")
+                )
+                if not prefix or symbol.startswith(prefix)
+            ]
+
+        args = self.func_args.get(func_name)
+        if not args:
+            return None
+
+        completions = []
+        details = f"{func_name}() argument"
+        for arg in args:
+            if isinstance(arg, list):
+                completions.append(sublime.CompletionItem(
+                    trigger=arg[0],
+                    completion=arg[1],
+                    completion_format=sublime.COMPLETION_FORMAT_SNIPPET,
+                    kind=KIND_CSS_FUNCTION,
+                    details=details
+                ))
+            else:
+                completions.append(sublime.CompletionItem(
+                    trigger=arg,
+                    completion_format=sublime.COMPLETION_FORMAT_TEXT,
+                    kind=KIND_CSS_CONSTANT,
+                    details=details
+                ))
+
+        return completions

--- a/sass_completions.py
+++ b/sass_completions.py
@@ -5,7 +5,7 @@ import timeit
 
 from functools import cached_property, wraps
 
-__all__ = ['CSSCompletions']
+__all__ = ['SassCompletions']
 
 KIND_CSS_PROPERTY = (sublime.KIND_ID_KEYWORD, "p", "property")
 KIND_CSS_FUNCTION = (sublime.KIND_ID_FUNCTION, "f", "function")
@@ -796,7 +796,7 @@ def next_none_whitespace(view, pt):
             return ch
 
 
-class CSSCompletions(sublime_plugin.EventListener):
+class SassCompletions(sublime_plugin.EventListener):
 
     @cached_property
     def func_args(self):
@@ -823,6 +823,11 @@ class CSSCompletions(sublime_plugin.EventListener):
             return None
 
         pt = locations[0]
+
+        # completions are for properties, not selectors, only inside sass/scss files
+        if not match_selector(view, pt, 'source.sass - meta.selector.css, source.scss - meta.selector.css'):
+            return None
+
         if not match_selector(view, pt, ''):
             return None
 


### PR DESCRIPTION
The default CSS package was rewritten to solve various issues and align more closely with the newest scope naming guidelines. The changes are too big to "cherry pick", so we need to start over again as well. This PR tracks the process of starting from a fresh copy of the CSS package and then re-implementing the Sass language features on top of it. In the process we also simplify it around the `sass-value-expression`. 

----

Fixes #85 #82 #72 #69 #81